### PR TITLE
Fix return values attribute writes

### DIFF
--- a/device.c
+++ b/device.c
@@ -696,9 +696,13 @@ int iio_device_identify_filename(const struct iio_device *dev,
 int iio_device_reg_write(struct iio_device *dev,
 		uint32_t address, uint32_t value)
 {
+	ssize_t ret;
+
 	char buf[1024];
 	snprintf(buf, sizeof(buf), "0x%x 0x%x", address, value);
-	return iio_device_debug_attr_write(dev, "direct_reg_access", buf);
+	ret = iio_device_debug_attr_write(dev, "direct_reg_access", buf);
+
+	return ret < 0 ? ret : 0;
 }
 
 int iio_device_reg_read(struct iio_device *dev,


### PR DESCRIPTION
This patchset makes a bunch of functions compliant with their interface as defined in iio.h. Those functions are supposed to return 0 on success, while their current implementation returns the number of bytes written instead.

The patch was verified against a previously failing scenario which uses iio_device_attr_write_longlong() only, but the same resolution should apply cleanly to all other affected functions.

Patches to different families of functions has been kept separate for clarity. Feel free to squash them down if this is more convenient for the repository commit policy.
