### PR TITLE
Python: Fix bug in buffer read()/write() -- add missing "self".

### DIFF
--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -338,8 +338,8 @@ class Buffer(object):
 		_buffer_push(self._buffer)
 
 	def read(self):
-		start = _buffer_start(_buffer)
-		end = _buffer_end(_buffer)
+		start = _buffer_start(self._buffer)
+		end = _buffer_end(self._buffer)
 		array = bytearray(end - start)
 		mytype = c_char * len(array)
 		c_array = mytype.from_buffer(array)
@@ -347,8 +347,8 @@ class Buffer(object):
 		return array
 
 	def write(self, array):
-		start = _buffer_start(_buffer)
-		end = _buffer_end(_buffer)
+		start = _buffer_start(self._buffer)
+		end = _buffer_end(self._buffer)
 		length = end - start
 		if length > len(array):
 			length = len(array)


### PR DESCRIPTION
Thanks for creating libiio and the Python bindings!

I found this small bug while trying to collect data from an AD9361 in Python.  After fixing this, everything worked as expected.