### PR TITLE
Dev plugins support upstream submit 01 branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ find_library(AVAHI_COMMON_LIBRARIES avahi-common)
 find_library(PTHREAD_LIBRARIES pthread)
 include(FindLibXml2)
 
-set(LIBIIO_CFILES channel.c device.c context.c buffer.c utilities.c)
+set(LIBIIO_CFILES channel.c device.c context.c buffer.c utilities.c plugins.c)
 set(LIBIIO_HEADERS iio.h)
 
 add_definitions(-D_POSIX_C_SOURCE=200809L -DLIBIIO_EXPORTS=1)

--- a/context.c
+++ b/context.c
@@ -424,12 +424,21 @@ struct iio_context * iio_create_local_context(void)
 
 struct iio_context * iio_create_network_context(const char *hostname)
 {
-#if NETWORK_BACKEND
-	return network_create_context(hostname);
-#else
-	errno = ENOSYS;
-	return NULL;
-#endif
+	int ret;
+	struct iio_context_factory *factory;
+
+	factory = get_context_factory("network");
+	if (!factory)
+		return NULL;
+
+	ret = factory_set_property(factory, "hostname", hostname);
+	if (ret < 0) {
+		errno = -ret;
+
+		return 0;
+	}
+
+	return factory->create_context();
 }
 
 struct iio_context * iio_create_xml_context_mem(const char *xml, size_t len)

--- a/iio-private.h
+++ b/iio-private.h
@@ -29,6 +29,8 @@
 #define strerror_r(err, buf, len) strerror_s(buf, len, err)
 #endif
 
+#define MAX_FACTORY_PROPERTIES 10
+
 #define BIT_MASK(bit) (1 << ((bit) % 32))
 #define BIT_WORD(bit) ((bit) / 32)
 #define TEST_BIT(addr, bit) (!!(*(((uint32_t *) addr) + BIT_WORD(bit)) \
@@ -164,6 +166,7 @@ struct iio_buffer {
 struct iio_context_factory {
 	const char *name;
 	struct iio_context * (*create_context)(void);
+	struct iio_property properties[MAX_FACTORY_PROPERTIES];
 };
 
 void free_channel(struct iio_channel *chn);
@@ -197,6 +200,8 @@ __api ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 
 int iio_context_factory_register(struct iio_context_factory *factory);
 int iio_context_factory_unregister(const char *name);
+const char * iio_context_factory_get_property(
+		struct iio_context_factory *factory, const char *key);
 void iio_context_dump_factories(void);
 
 #endif /* __IIO_PRIVATE_H__ */

--- a/iio-private.h
+++ b/iio-private.h
@@ -161,6 +161,11 @@ struct iio_buffer {
 	bool is_output, dev_is_high_speed;
 };
 
+struct iio_context_factory {
+	const char *name;
+	struct iio_context * (*create_context)(void);
+};
+
 void free_channel(struct iio_channel *chn);
 void free_device(struct iio_device *dev);
 
@@ -190,5 +195,9 @@ struct iio_context * xml_create_context(const char *xml_file);
 /* This function is not part of the API, but is used by the IIO daemon */
 __api ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 		uint32_t *mask, size_t words);
+
+int iio_context_factory_register(struct iio_context_factory *factory);
+int iio_context_factory_unregister(const char *name);
+void iio_context_dump_factories(void);
 
 #endif /* __IIO_PRIVATE_H__ */

--- a/iio-private.h
+++ b/iio-private.h
@@ -190,7 +190,6 @@ ssize_t iio_device_write_raw(const struct iio_device *dev,
 int read_double(const char *str, double *val);
 int write_double(char *buf, size_t len, double val);
 
-struct iio_context * network_create_context(const char *hostname);
 struct iio_context * xml_create_context_mem(const char *xml, size_t len);
 struct iio_context * xml_create_context(const char *xml_file);
 

--- a/iio-private.h
+++ b/iio-private.h
@@ -187,7 +187,6 @@ ssize_t iio_device_write_raw(const struct iio_device *dev,
 int read_double(const char *str, double *val);
 int write_double(char *buf, size_t len, double val);
 
-struct iio_context * local_create_context(void);
 struct iio_context * network_create_context(const char *hostname);
 struct iio_context * xml_create_context_mem(const char *xml, size_t len);
 struct iio_context * xml_create_context(const char *xml_file);

--- a/iio-private.h
+++ b/iio-private.h
@@ -169,14 +169,14 @@ struct iio_context_factory {
 	struct iio_property properties[MAX_FACTORY_PROPERTIES];
 };
 
-void free_channel(struct iio_channel *chn);
-void free_device(struct iio_device *dev);
+__api void free_channel(struct iio_channel *chn);
+__api void free_device(struct iio_device *dev);
 
 char *iio_channel_get_xml(const struct iio_channel *chn, size_t *len);
 char *iio_device_get_xml(const struct iio_device *dev, size_t *len);
 
-char *iio_context_create_xml(const struct iio_context *ctx);
-void iio_context_init(struct iio_context *ctx);
+__api char *iio_context_create_xml(const struct iio_context *ctx);
+__api void iio_context_init(struct iio_context *ctx);
 
 bool iio_device_is_tx(const struct iio_device *dev);
 int iio_device_open(const struct iio_device *dev,
@@ -197,10 +197,10 @@ struct iio_context * xml_create_context(const char *xml_file);
 __api ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 		uint32_t *mask, size_t words);
 
-int iio_context_factory_register(struct iio_context_factory *factory);
-int iio_context_factory_unregister(const char *name);
-const char * iio_context_factory_get_property(
+__api int iio_context_factory_register(struct iio_context_factory *factory);
+__api int iio_context_factory_unregister(const char *name);
+__api const char * iio_context_factory_get_property(
 		struct iio_context_factory *factory, const char *key);
-void iio_context_dump_factories(void);
+__api void iio_context_dump_factories(void);
 
 #endif /* __IIO_PRIVATE_H__ */

--- a/iio.h
+++ b/iio.h
@@ -78,6 +78,22 @@ struct iio_buffer;
 __api void iio_library_get_version(unsigned int *major,
 		unsigned int *minor, char git_tag[8]);
 
+/** @} *//* ------------------------------------------------------------------*/
+/* ------------------------- Plugins functions -------------------------------*/
+/** @defgroup Plugins Plugins
+ * @{ */
+
+/** @brief Finds and initializes the libiio plugins.
+ *
+ * Each shared object in the PLUGINS_DEFAULT_DIR (defaulting to
+ * /usr/lib/libiio-plugins/), will be loaded, provided it's path matches the
+ * PLUGINS_MATCHING_PATTERN (defaulting to libiio-*.so).
+ */
+__api void iio_init_plugins(void);
+
+/** @brief Cleans up what has been performed in iio_init_plugins()
+ */
+__api void iio_cleanup_plugins(void);
 
 /** @} *//* ------------------------------------------------------------------*/
 /* ------------------------- Context functions -------------------------------*/

--- a/iio.h
+++ b/iio.h
@@ -86,6 +86,15 @@ __api void iio_library_get_version(unsigned int *major,
  * @struct iio_context
  * @brief Contains the representation of an IIO context */
 
+/**
+ * @struct iio_property
+ * @brief Simple key / value pair of strings
+ */
+struct iio_property {
+	char *key;	/**< key (index) of the property */
+	char *value;	/**< value of the property */
+};
+
 
 /** @brief Create a context from local or remote IIO devices
  * @return On success, A pointer to an iio_context structure

--- a/iio.h
+++ b/iio.h
@@ -111,6 +111,21 @@ struct iio_property {
 	char *value;	/**< value of the property */
 };
 
+/** @brief Create a context knowing it's name
+ * @param name Name of the context to create
+ * @param properties Properties for configuring the creation of the context.
+ * Depends on the properties of influence for the given context. For example,
+ * the network context supports the "hostname" property, while the local context
+ * supports none. The array must be NULL-terminated, that is, the last property
+ * must have a NULL name. NULL must be passed if there are no properties.
+ * @return On success, A pointer to an iio_context structure
+ * @return On failure, NULL is returned and errno is set appropriately
+ *
+ * If an additional libiio backends has been registered by a plugin, one will be
+ * able to create a corresponding context with this function, by passing the
+ * plugin's name. */
+__api struct iio_context * iio_create_context(const char *name,
+		const struct iio_property *properties);
 
 /** @brief Create a context from local or remote IIO devices
  * @return On success, A pointer to an iio_context structure
@@ -126,7 +141,9 @@ __api struct iio_context * iio_create_default_context(void);
 
 /** @brief Create a context from local IIO devices (Linux only)
  * @return On success, A pointer to an iio_context structure
- * @return On failure, NULL is returned and errno is set appropriately */
+ * @return On failure, NULL is returned and errno is set appropriately
+ *
+ * @note this function is a shortcut for iio_create_context("local", NULL); */
 __api struct iio_context * iio_create_local_context(void);
 
 

--- a/plugins.c
+++ b/plugins.c
@@ -1,0 +1,93 @@
+/*
+ * libiio - Library for interfacing industrial I/O (IIO) devices
+ *
+ * Copyright (C) 2015 Parrot SA
+ * Author: Nicolas Carrier <nicolas.carrier@parrot.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * */
+#include <dirent.h>
+
+#include <dlfcn.h>
+
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "iio.h"
+
+#include "debug.h"
+
+#ifndef PLUGINS_DEFAULT_DIR
+#define PLUGINS_DEFAULT_DIR "/usr/lib/libiio-plugins/"
+#endif
+
+#ifndef PLUGINS_MAX
+#define PLUGINS_MAX 4
+#endif
+
+#ifndef PLUGINS_MATCHING_PATTERN
+#define PLUGINS_MATCHING_PATTERN "libiio-*.so"
+#endif
+
+static int pattern_filter(const struct dirent *d)
+{
+	return fnmatch(PLUGINS_MATCHING_PATTERN, d->d_name, 0) == 0;
+}
+
+static void *plugins[PLUGINS_MAX];
+
+void iio_init_plugins(void)
+{
+	int ret;
+	int n;
+	struct dirent **namelist;
+	char *path;
+	void **current_plugin;
+
+	n = scandir(PLUGINS_DEFAULT_DIR, &namelist, pattern_filter, NULL);
+	if (n == -1) {
+		ERROR("%s scandir: %s\n", __func__, strerror(errno));
+		return;
+	}
+
+	current_plugin = plugins;
+	while (n--) {
+		ret = asprintf(&path, PLUGINS_DEFAULT_DIR "%s",
+				namelist[n]->d_name);
+		if (ret == -1) {
+			ERROR("%s asprintf error\n", __func__);
+			return;
+		}
+		DEBUG("loading plugin %s\n", path);
+		*current_plugin = dlopen(path, RTLD_NOW);
+		free(path);
+		if (!*current_plugin)
+			WARNING("%s dlopen: %s\n", __func__, dlerror());
+		else
+			current_plugin++;
+		free(namelist[n]);
+	}
+	free(namelist);
+
+	iio_context_dump_factories();
+}
+
+void iio_cleanup_plugins(void)
+{
+	int i = PLUGINS_MAX;
+
+	while (i--)
+		if (plugins[i])
+			dlclose(plugins[i]);
+}
+


### PR DESCRIPTION
Hello,
Here is a patch set which implements plugins support for libiio.

The main goal is to allow implementing libiio backends outside of libiio, in plugin form.

The base idea is that a given directory is scanned for .so files, whose name match a given pattern.
These .so are dlopened and have access to some functions from the internal libiio API (from iio-private.h and debug.h).
For the particular case of backend implementation, two functions are provided, allowing plugins to register context factories, iio_context_factory_register() and iio_context_factory_unregister().
A factory allows the creation of an iio_context, parametrized with key/value string properties.
The local and network plugins are modified to register factories and their context creation function wrappers in context.c are modified to use these factories.

A public API function is added, to allow the access to an arbitrary backend implementation: iio_create_context().

The main drawback I see of this patch set is that it may break libiio on windows. Since I have absolutely no knowledge of this platform, I'm not competent for fixing that issue. I hope some more knowledgeable people will be able to do it. Maybe a conditional compilation approach, disabling the feature in non-dlopen capable platform would be a correct first attempt.

Having the possibility to create custom backends would allow a lot of possibilities, for example :
- record sensors/actuators accesses at runtime without altering the normal functioning of the upper software (and without using a network daemon)
- inject fake data from either a record file or a simulated environment
- access via libiio, sensors not using the kernel iio framework, i.e. add iio support in userland.
- enable any of the previous possibility, at runtime, with no recompilation

I am open to any suggestion or remark.
