### PR TITLE
initilize block to 0s before dequeuing to prevent "Syscall param ioct…

### DIFF
--- a/local.c
+++ b/local.c
@@ -341,7 +341,6 @@ static ssize_t local_get_buffer(const struct iio_device *dev,
 		}
 	}
 
-	memset(&block, 0, sizeof(block));
 	ret = (ssize_t) ioctl(fileno(f), BLOCK_DEQUEUE_IOCTL, &block);
 	if (ret) {
 		ret = (ssize_t) -errno;

--- a/local.c
+++ b/local.c
@@ -341,6 +341,7 @@ static ssize_t local_get_buffer(const struct iio_device *dev,
 		}
 	}
 
+	memset(&block, 0, sizeof(block));
 	ret = (ssize_t) ioctl(fileno(f), BLOCK_DEQUEUE_IOCTL, &block);
 	if (ret) {
 		ret = (ssize_t) -errno;


### PR DESCRIPTION
…l(generic) points to uninitialised byte(s)" Valgrind error