### PR TITLE
Initialize block in local_get_buffer() to 0s before dequeuing to prev…

### DIFF
--- a/local.c
+++ b/local.c
@@ -341,6 +341,7 @@ static ssize_t local_get_buffer(const struct iio_device *dev,
 		}
 	}
 
+	memset(&block, 0, sizeof(block));
 	ret = (ssize_t) ioctl(fileno(f), BLOCK_DEQUEUE_IOCTL, &block);
 	if (ret) {
 		ret = (ssize_t) -errno;


### PR DESCRIPTION
…ent "Syscall param ioctl(generic) points to uninitialized byte(s)" Valgrind error.

Signed-off-by: Nicholas Pillitteri <njpillitteri@gmail.com>