### PR TITLE
Avoid to increment ptr in iio_buffer_first() for disabled channels

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -220,6 +220,10 @@ void * iio_buffer_first(const struct iio_buffer *buffer,
 		if (cur->index < 0 || cur->index == chn->index)
 			break;
 
+		/* Test if the buffer has samples for this channel */
+		if (!TEST_BIT(buffer->mask, cur->index))
+			continue;
+
 		if (ptr % len)
 			ptr += len - (ptr % len);
 		ptr += len;


### PR DESCRIPTION
Previous implementation of iio_buffer_first() considered that a
struct iio_buffer always contains samples for all the channels of the
device, for disabled channels. This is actually wrong, and disabled
channels should be ignored during offset calculation of a given enabled
channel.

It implements the same strategy as iio_buffer_foreach_sample().

Change-Id: I6df5a3ec766d0490d94d72cf67db2e6c1d3b76c2