### PR TITLE
[RFC PATCH] local: don't move shared "en" attribute

### DIFF
--- a/local.c
+++ b/local.c
@@ -1214,6 +1214,15 @@ static unsigned int is_global_attr(struct iio_channel *chn, const char *attr)
 	if (strncmp(chn->id, attr, len))
 		return 0;
 
+	/*
+	 * Don't move device level channel enable attribute to channel even though it
+	 * it is a shared attribute. For example, iio:device0/in_accel_en. "en" is a
+	 * special case because scan channels also use "en" but libiio does not
+	 * distinguish between the two "en"'s when searching by name.
+	 */
+	if (!strcmp(ptr + 1, "en"))
+		return 0;
+
 	DEBUG("Found match: %s and %s\n", chn->id, attr);
 	if (chn->id[len] >= '0' && chn->id[len] <= '9') {
 		if (chn->name) {


### PR DESCRIPTION
the shared channel enable attribute should not be moved because it conflicts
with the scan channel "en". if the shared attribute is moved, libiio cannot
distinguish between the shared and specific "en" because the attributes are
accessed by name (e.g. `iio_device_attr_write`).

Signed-off-by: Lucas Magasweran <lucas.magasweran@daqri.com>

---
I know that few drivers currently uses the shared channel enable info flag. However, this is a feature that my sensor needs to support. The workaround is to use `sysfs` to avoid the "en" ambiguity in `libiio`. Unfortunately, this makes userspace less portable.

To see the effect of this change using the IIO dummy driver apply the following patch and then run `iio_info`.

https://gist.github.com/lucasrangit/90a9960c23cc8e771d3d2abcf2f9d391

Before: "en" is repeated twice (attribute 5 and 6)
```
			accel_x:  (input)
			7 channel-specific attributes found:
				attr 0: calibbias value: -7
				attr 1: raw value: 34
				attr 2: calibscale value: 0.000100
				attr 3: index value: 3
				attr 4: type value: le:s16/16>>0
				attr 5: en value: 0
				attr 6: en value: 0
			accel_y:  (input)
			7 channel-specific attributes found:
				attr 0: raw value: 34
				attr 1: calibbias value: -7
				attr 2: calibscale value: 0.000100
				attr 3: type value: le:s16/16>>0
				attr 4: index value: 4
				attr 5: en value: 0
				attr 6: en value: 0
```

After: there is an "accel" channel with the shared "en" attribute and "accel_x" has a single "en" attribute
```
			accel_x:  (input)
			6 channel-specific attributes found:
				attr 0: calibbias value: -7
				attr 1: raw value: 34
				attr 2: calibscale value: 0.000100
				attr 3: index value: 3
				attr 4: type value: le:s16/16>>0
				attr 5: en value: 0
			accel_y:  (input)
			6 channel-specific attributes found:
				attr 0: raw value: 34
				attr 1: calibbias value: -7
				attr 2: calibscale value: 0.000100
				attr 3: type value: le:s16/16>>0
				attr 4: index value: 4
				attr 5: en value: 0
			accel:  (input)
			1 channel-specific attributes found:
				attr 0: en value: 1	
```