### PR TITLE
appveyor: include matlab bindings in the zip file artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,8 @@ build_script:
     - copy c:\libs\32\libxml2.dll c:\libiio-win32\
     - copy c:\libs\32\libusb-1.0.dll c:\libiio-win32\
     - copy c:\libs\32\libserialport-0.dll c:\libiio-win32\
+    - xcopy /S bindings\matlab c:\libiio-win32\matlab\
+    - del c:\libiio-win32\matlab\CMakeLists.txt
     - 7z a "c:\libiio-win32.zip" c:\libiio-win32
     - appveyor PushArtifact c:\libiio-win32.zip
 
@@ -62,5 +64,7 @@ build_script:
     - copy c:\libs\64\libxml2.dll c:\libiio-win64\
     - copy c:\libs\64\libusb-1.0.dll c:\libiio-win64\
     - copy c:\libs\64\libserialport-0.dll c:\libiio-win64\
+    - xcopy /S bindings\matlab c:\libiio-win64\matlab\
+    - del c:\libiio-win64\matlab\CMakeLists.txt
     - 7z a "c:\libiio-win64.zip" c:\libiio-win64
     - appveyor PushArtifact c:\libiio-win64.zip


### PR DESCRIPTION
Precursor to adding support to the installer to properly install the matlab bindings on windows.