### PR TITLE
InnoSetup: install matlab bindings via the windows installer

### DIFF
--- a/libiio.iss.cmakein
+++ b/libiio.iss.cmakein
@@ -63,3 +63,5 @@ Source: "C:\libs\32\libserialport-0.dll"; DestDir: "{sys}"; Flags: onlyifdoesnte
 Source: "C:\libs\64\libserialport-0.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Flags: onlyifdoesntexist
 
 Source: "C:\projects\libiio\build-win32\bindings\csharp\libiio-sharp.dll"; DestDir: "{cf}\libiio"
+
+Source: "C:\projects\libiio\bindings\matlab\*"; Excludes: "CMakeLists.txt"; Destdir: "{cf}\libiio\matlab"


### PR DESCRIPTION
Places the matlab bindings alongside the C# bindings dll in "Common Files\libiio".

The last piece of the puzzle in order for people to install libiio and start using the bindings seamlessly would be to have the installer also run the iio_installer_script.m to add the installed binding directory to the system path. Obviously we'd either want to make that an install option or done automatically if matlab is installed.

For now people will have to run it themselves or manually add the install dir to their syspath for matlab.