### PR TITLE
iio_buffer: fix samples alignment computation

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -201,6 +201,7 @@ ssize_t iio_buffer_foreach_sample(struct iio_buffer *buffer,
 			void *, size_t, void *), void *d)
 {
 	uintptr_t ptr = (uintptr_t) buffer->buffer,
+		  start = ptr,
 		  end = ptr + buffer->data_length;
 	const struct iio_device *dev = buffer->dev;
 	ssize_t processed = 0;
@@ -225,8 +226,8 @@ ssize_t iio_buffer_foreach_sample(struct iio_buffer *buffer,
 			if (!TEST_BIT(buffer->mask, chn->index))
 				continue;
 
-			if (ptr % length)
-				ptr += length - (ptr % length);
+			if ((ptr - start) % length)
+				ptr += length - ((ptr - start) % length);
 
 			/* Test if the client wants samples from this channel */
 			if (TEST_BIT(dev->mask, chn->index)) {
@@ -256,7 +257,8 @@ void * iio_buffer_first(const struct iio_buffer *buffer,
 {
 	size_t len;
 	unsigned int i;
-	uintptr_t ptr = (uintptr_t) buffer->buffer;
+	uintptr_t ptr = (uintptr_t) buffer->buffer,
+		  start = ptr;
 
 	if (!iio_channel_is_enabled(chn))
 		return iio_buffer_end(buffer);
@@ -277,14 +279,14 @@ void * iio_buffer_first(const struct iio_buffer *buffer,
 		if (i > 0 && cur->index == buffer->dev->channels[i - 1]->index)
 			continue;
 
-		if (ptr % len)
-			ptr += len - (ptr % len);
+		if ((ptr - start) % len)
+			ptr += len - ((ptr - start) % len);
 		ptr += len;
 	}
 
 	len = chn->format.length / 8;
-	if (ptr % len)
-		ptr += len - (ptr % len);
+	if ((ptr - start) % len)
+		ptr += len - ((ptr - start) % len);
 	return (void *) ptr;
 }
 


### PR DESCRIPTION
Samples are aligned to their own size, but the alignment is
from the buffer start, not an absolute (virtual) memory alignment.

For example, timestamps are added like this in the kernel:

    size_t ts_offset = indio_dev->scan_bytes / sizeof(int64_t) - 1;
    ((int64_t *)data)[ts_offset] = timestamp;

Also:

```
  static int iio_compute_scan_bytes(struct iio_dev *indio_dev,
                                const unsigned long *mask, bool timestamp)
  {
        const struct iio_chan_spec *ch;
        unsigned bytes = 0;
        int length, i;

        /* How much space will the demuxed element take? */
        for_each_set_bit(i, mask, indio_dev->masklength) {
                ...
                bytes = ALIGN(bytes, length);
                        ^^^^^^^^^^^^^^^^^^^^
                bytes += length;
  }
```