### PR TITLE
matlab: Add scan_block helper API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,7 +294,14 @@ set(CPACK_PACKAGE_CONTACT "Engineerzone <https://ez.analog.com/community/linux-d
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "libaio-dev (>= 0.3.109-4), libavahi-client-dev (>= 0.6.31-4), libavahi-common-dev (>= 0.6.31-4), libc6-dev (>= 2.19-0), libusb-1.0-0-dev (>= 2:1.0.17-1), libxml2-dev (>= 2.9.1+dfsg1-3)")
 include(CPack)
 
-add_library(iio ${LIBIIO_CFILES} ${LIBIIO_HEADERS})
+add_subdirectory(bindings)
+
+if (WITH_MATLAB_BINDINGS_API)
+	set(LIBIIO_EXTRA_HEADERS ${LIBIIO_EXTRA_HEADERS} bindings/matlab/iio-wrapper.h)
+	add_definitions(-DMATLAB_BINDINGS_API=1)
+endif()
+
+add_library(iio ${LIBIIO_CFILES} ${LIBIIO_HEADERS} ${LIBIIO_EXTRA_HEADERS})
 set_target_properties(iio PROPERTIES
 	VERSION ${VERSION}
 	SOVERSION ${LIBIIO_VERSION_MAJOR}
@@ -391,7 +398,5 @@ endif()
 if(WITH_TESTS)
 	add_subdirectory(tests)
 endif()
-
-add_subdirectory(bindings)
 
 configure_file(iio-config.h.cmakein ${CMAKE_CURRENT_BINARY_DIR}/iio-config.h @ONLY)

--- a/bindings/matlab/CMakeLists.txt
+++ b/bindings/matlab/CMakeLists.txt
@@ -5,6 +5,8 @@ find_program(
 )
 mark_as_advanced(MATLAB_EXECUTABLE)
 
+option(WITH_MATLAB_BINDINGS_API "Enable MATLAB bindings API" ON)
+
 if (MATLAB_EXECUTABLE AND NOT SKIP_INSTALL_ALL)
 	option(MATLAB_BINDINGS "Install MATLAB bindings" ON)
 
@@ -19,5 +21,6 @@ if (MATLAB_EXECUTABLE AND NOT SKIP_INSTALL_ALL)
 				COMMAND ${MATLAB_EXECUTABLE} -nodesktop
 					-nodisplay -r \"cd('${CMAKE_INSTALL_PREFIX}/share/libiio/matlab');iio_installer_script;exit;\"
 				OUTPUT_QUIET)")
+		set(WITH_MATLAB_BINDINGS_API ON CACHE BOOL "" FORCE)
 	endif()
 endif()

--- a/bindings/matlab/iio-wrapper.h
+++ b/bindings/matlab/iio-wrapper.h
@@ -1,4 +1,46 @@
 #ifndef MATLAB_LOADLIBRARY
 #define MATLAB_LOADLIBRARY
 #include <iio.h>
+
+#ifndef __api
+#define __api
+#endif
+
+struct iio_scan_block;
+
+/** @brief Create a scan block
+* @param backend A NULL-terminated string containing the backend to use for
+* scanning. If NULL, all the available backends are used.
+* @param flags Unused for now. Set to 0.
+* @return on success, a pointer to a iio_scan_block structure
+* @return On failure, NULL is returned and errno is set appropriately */
+__api struct iio_scan_block * iio_create_scan_block(
+		const char *backend, unsigned int flags);
+
+
+/** @brief Destroy the given scan block
+* @param ctx A pointer to an iio_scan_block structure
+*
+* <b>NOTE:</b> After that function, the iio_scan_block pointer shall be invalid. */
+__api void iio_scan_block_destroy(struct iio_scan_block *blk);
+
+
+/** @brief Enumerate available contexts via scan block
+* @param blk A pointer to a iio_scan_block structure.
+* @returns On success, the number of contexts found.
+* @returns On failure, a negative error number.
+*/
+__api ssize_t iio_scan_block_scan(struct iio_scan_block *blk);
+
+
+/** @brief Get the iio_context_info for a particular context
+* @param blk A pointer to an iio_scan_block structure
+* @param index The index corresponding to the context.
+* @return A pointer to the iio_context_info for the context
+* @returns On success, a pointer to the specified iio_context_info
+* @returns On failure, NULL is returned and errno is set appropriately
+*/
+__api struct iio_context_info *iio_scan_block_get_info(
+		struct iio_scan_block *blk, unsigned int index);
+
 #endif

--- a/iio-config.h.cmakein
+++ b/iio-config.h.cmakein
@@ -12,6 +12,7 @@
 #cmakedefine WITH_NETWORK_BACKEND
 #cmakedefine WITH_USB_BACKEND
 #cmakedefine WITH_SERIAL_BACKEND
+#cmakedefine WITH_MATLAB_BINDINGS_API
 
 #cmakedefine WITH_NETWORK_GET_BUFFER
 #cmakedefine WITH_NETWORK_EVENTFD

--- a/iio-private.h
+++ b/iio-private.h
@@ -44,6 +44,10 @@
 #   define __api
 #endif
 
+#ifdef WITH_MATLAB_BINDINGS_API
+#include "bindings/matlab/iio-wrapper.h"
+#endif
+
 #define ARRAY_SIZE(x) (sizeof(x) ? sizeof(x) / sizeof((x)[0]) : 0)
 #define BIT(x) (1 << (x))
 #define BIT_MASK(bit) BIT((bit) % 32)

--- a/scan.c
+++ b/scan.c
@@ -158,3 +158,57 @@ void iio_scan_context_destroy(struct iio_scan_context *ctx)
 #endif
 	free(ctx);
 }
+
+#ifdef WITH_MATLAB_BINDINGS_API
+
+struct iio_scan_block {
+	struct iio_scan_context *ctx;
+	struct iio_context_info **info;
+	ssize_t ctx_cnt;
+};
+
+ssize_t iio_scan_block_scan(struct iio_scan_block *blk)
+{
+	iio_context_info_list_free(blk->info);
+	blk->info = NULL;
+	blk->ctx_cnt = iio_scan_context_get_info_list(blk->ctx, &blk->info);
+	return blk->ctx_cnt;
+}
+
+struct iio_context_info *iio_scan_block_get_info(
+		struct iio_scan_block *blk, unsigned int index)
+{
+	if (!blk->info || (ssize_t)index >= blk->ctx_cnt) {
+		errno = EINVAL;
+		return NULL;
+	}
+	return blk->info[index];
+}
+
+struct iio_scan_block *iio_create_scan_block(
+		const char *backend, unsigned int flags)
+{
+	struct iio_scan_block *blk;
+
+	blk = calloc(1, sizeof(*blk));
+	if (!blk) {
+		errno = ENOMEM;
+		return NULL;
+	}
+
+	blk->ctx = iio_create_scan_context(backend, flags);
+	if (!blk->ctx) {
+		free(blk);
+		return NULL;
+	}
+
+	return blk;
+}
+
+void iio_scan_block_destroy(struct iio_scan_block *blk)
+{
+	iio_context_info_list_free(blk->info);
+	iio_scan_context_destroy(blk->ctx);
+	free(blk);
+}
+#endif


### PR DESCRIPTION
Add scan_block helper functions for use in languages (e.g. MATLAB) that
cannot easily iterate over a list of pointers.

The scan_block functions enable the creation / scanning of a scan context
and the retrival of context_info via an index value.

Signed-off-by: Matt Fornero <matt.fornero@mathworks.com>