### PR TITLE
Local backend: return negative errno code on local_read/write() error

### DIFF
--- a/iio.h
+++ b/iio.h
@@ -1102,7 +1102,7 @@ __api int iio_buffer_get_poll_fd(struct iio_buffer *buf);
 
 /** @brief Make iio_buffer_refill() and iio_buffer_push() blocking or not
  *
- * After this function has been called with blocking == true,
+ * After this function has been called with blocking == false,
  * iio_buffer_refill() and iio_buffer_push() will return -EAGAIN if no data is
  * ready.
  * A device is blocking by default.

--- a/local.c
+++ b/local.c
@@ -325,7 +325,7 @@ static ssize_t local_read(const struct iio_device *dev,
 		if (ret == -1) {
 			if (pdata->blocking && errno == EAGAIN)
 				continue;
-			ret = -EIO;
+			ret = -errno;
 			break;
 		} else if (ret == 0) {
 			ret = -EIO;
@@ -373,7 +373,7 @@ static ssize_t local_write(const struct iio_device *dev,
 			if (pdata->blocking && errno == EAGAIN)
 				continue;
 
-			ret = -EIO;
+			ret = -errno;
 			break;
 		} else if (ret == 0) {
 			ret = -EIO;


### PR DESCRIPTION
Since commit 4ebd0743, returned negative errno code is always `-EIO`
on `read()` error instead of using `-errno`.

For example, `-EAGAIN` was not returned anymore in blocking mode when
no data was available.

Also fix documentation regarding `-EAGAIN` from `iio_buffer_refill()` and
`iio_buffer_push()`.