### PR TITLE
Add to API to make runtime query of built library backends possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ if (ENABLE_IPV6)
 	endif()
 endif()
 
-set(LIBIIO_CFILES channel.c device.c context.c buffer.c utilities.c scan.c)
+set(LIBIIO_CFILES channel.c device.c context.c buffer.c utilities.c scan.c iio-config.c)
 set(LIBIIO_HEADERS iio.h)
 
 add_definitions(-D_POSIX_C_SOURCE=200809L -D__XSI_VISIBLE=500 -DLIBIIO_EXPORTS=1)

--- a/iio-config.c
+++ b/iio-config.c
@@ -1,0 +1,66 @@
+
+/*
+ * libiio - Library for interfacing industrial I/O (IIO) devices
+ *
+ * Copyright (C) 2014-2015 Analog Devices, Inc.
+ * Author: Paul Cercueil <paul.cercueil@analog.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * */
+
+#include "iio-config.h"
+#include <stdbool.h>
+
+bool iio_backend_has_local() 
+{
+#ifdef WITH_LOCAL_BACKEND
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool iio_backend_has_xml() 
+{
+#ifdef WITH_XML_BACKEND
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool iio_backend_has_network() 
+{
+#ifdef WITH_NETWORK_BACKEND
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool iio_backend_has_usb() 
+{
+#ifdef WITH_USB_BACKEND
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool iio_backend_has_serial() 
+{
+#ifdef WITH_SERIAL_BACKEND
+	return true;
+#else
+	return false;
+#endif
+}

--- a/iio.h
+++ b/iio.h
@@ -243,6 +243,31 @@ __api void iio_library_get_version(unsigned int *major,
 __api void iio_strerror(int err, char *dst, size_t len);
 
 
+/** @brief Query if library was built with local backend
+ * @return True if built with local backend */
+__api __pure bool iio_backend_has_local();
+
+
+/** @brief Query if library was built with xml backend
+ * @return True if built with xml backend */
+__api __pure bool iio_backend_has_xml();
+
+
+/** @brief Query if library was built with network backend
+ * @return True if built with network backend */
+__api __pure bool iio_backend_has_network();
+
+
+/** @brief Query if library was built with usb backend
+ * @return True if built with usb backend */
+__api __pure bool iio_backend_has_usb();
+
+
+/** @brief Query if library was built with serial backend
+ * @return True if built with serial backend */
+__api __pure bool iio_backend_has_serial();
+
+
 /** @} *//* ------------------------------------------------------------------*/
 /* ------------------------- Context functions -------------------------------*/
 /** @defgroup Context Context


### PR DESCRIPTION
Currently applications cannot query at runtime which backends are available. I've added some functions to the top level section of the API to query the built configuration at runtime.

If you'd prefer, it'd also be possible to do the same with a single function returning flags: a matter of taste.