### PR TITLE
Python 3 support

### DIFF
--- a/bindings/python/examples/iio_info.py
+++ b/bindings/python/examples/iio_info.py
@@ -18,42 +18,42 @@ import iio
 def main():
 	ctx = iio.Context()
 
-	print 'Library version: %u.%u (git tag: %s)' % iio.version
+	print ('Library version: %u.%u (git tag: %s)' % iio.version)
 
-	print 'IIO context created: ' + ctx.name
-	print 'Backend version: %u.%u (git tag: %s)' % ctx.version
-	print 'Backend description string: ' + ctx.description
+	print ('IIO context created: ' + ctx.name)
+	print ('Backend version: %u.%u (git tag: %s)' % ctx.version)
+	print ('Backend description string: ' + ctx.description)
 
-	print 'IIO context has %u devices:' % len(ctx.devices)
+	print ('IIO context has %u devices:' % len(ctx.devices))
 
 	for dev in ctx.devices:
-		print '\t' + dev.id + ': ' + dev.name
+		print ('\t' + dev.id + ': ' + dev.name)
 
 		if dev is iio.Trigger:
-			print 'Found trigger! Rate: %u Hz' % dev.frequency
+			print ('Found trigger! Rate: %u Hz' % dev.frequency)
 
-		print '\t\t%u channels found:' % len(dev.channels)
+		print ('\t\t%u channels found:' % len(dev.channels))
 
 		for chn in dev.channels:
-			print '\t\t\t%s: %s (%s)' % (chn.id, chn.name or "", 'output' if chn.output else 'input')
+			print ('\t\t\t%s: %s (%s)' % (chn.id, chn.name or "", 'output' if chn.output else 'input'))
 
 			if len(chn.attrs) != 0:
-				print '\t\t\t%u channel-specific attributes found:' % len(chn.attrs)
+				print ('\t\t\t%u channel-specific attributes found:' % len(chn.attrs))
 
 			for attr in chn.attrs:
-				print '\t\t\t\t' + attr + ', value: ' + chn.attrs[attr].value
+				print ('\t\t\t\t' + attr + ', value: ' + chn.attrs[attr].value)
 
 		if len(dev.attrs) != 0:
-			print '\t\t%u device-specific attributes found:' % len(dev.attrs)
+			print ('\t\t%u device-specific attributes found:' % len(dev.attrs))
 
 		for attr in dev.attrs:
-			print '\t\t\t' + attr + ', value: ' + dev.attrs[attr].value
+			print ('\t\t\t' + attr + ', value: ' + dev.attrs[attr].value)
 
 		if len(dev.debug_attrs) != 0:
-			print '\t\t%u debug attributes found:' % len(dev.debug_attrs)
+			print ('\t\t%u debug attributes found:' % len(dev.debug_attrs))
 
 		for attr in dev.debug_attrs:
-			print '\t\t\t' + attr + ', value: ' + dev.debug_attrs[attr].value
+			print ('\t\t\t' + attr + ', value: ' + dev.debug_attrs[attr].value)
 
 if __name__ == '__main__':
 	main()

--- a/bindings/python/examples/iio_info.py
+++ b/bindings/python/examples/iio_info.py
@@ -18,42 +18,42 @@ import iio
 def main():
 	ctx = iio.Context()
 
-	print ('Library version: %u.%u (git tag: %s)' % iio.version)
+	print ('Library version: {}.{} (git tag: {})'.format(iio.version[0], iio.version[1], iio.version[2].decode()))
 
 	print ('IIO context created: %s' % ctx.name)
-	print ('Backend version: %u.%u (git tag: %s)' % ctx.version)
-	print ('Backend description string: %s' % ctx.description)
+	print ('Backend version: {}.{} (git tag: {})'.format(ctx.version[0], ctx.version[1], ctx.version[2].decode()))
+	print ('Backend description string: {}'.format(ctx.description.decode()))
 
 	print ('IIO context has %u devices:' % len(ctx.devices))
 
 	for dev in ctx.devices:
-		print ('\t' + dev.id.decode() + ': ' + dev.name.decode())
+		print ('\t{}: {}'.format(dev.id.decode(), dev.name.decode()))
 
 		if dev is iio.Trigger:
-			print ('Found trigger! Rate: %u Hz' % dev.frequency)
+			print ('Found trigger! Rate: {} Hz'.format(dev.frequency))
 
-		print ('\t\t%u channels found:' % len(dev.channels))
+		print ('\t\t{} channels found:'.format(len(dev.channels)))
 
 		for chn in dev.channels:
-			print ('\t\t\t%s: %s (%s)' % (chn.id, chn.name or "", 'output' if chn.output else 'input'))
+			print ('\t\t\t{}: {} ({})'.format(chn.id.decode(), chn.name.decode() if chn.name else "", 'output' if chn.output else 'input'))
 
 			if len(chn.attrs) != 0:
-				print ('\t\t\t%u channel-specific attributes found:' % len(chn.attrs))
+				print ('\t\t\t{} channel-specific attributes found:'.format(len(chn.attrs)))
 
 			for attr in chn.attrs:
-				print ('\t\t\t\t' + attr.decode() + ', value: ' + chn.attrs[attr].value.decode())
+				print ('\t\t\t\t{}, value: {}'.format(attr.decode(), chn.attrs[attr].value.decode()))
 
 		if len(dev.attrs) != 0:
-			print ('\t\t%u device-specific attributes found:' % len(dev.attrs))
+			print ('\t\t{} device-specific attributes found:'.format(len(dev.attrs)))
 
 		for attr in dev.attrs:
-			print ('\t\t\t' + attr.decode() + ', value: ' + dev.attrs[attr].value.decode())
+			print ('\t\t\t{}, value: '.format(attr.decode(), dev.attrs[attr].value.decode()))
 
 		if len(dev.debug_attrs) != 0:
-			print ('\t\t%u debug attributes found:' % len(dev.debug_attrs))
+			print ('\t\t{} debug attributes found:'.format(len(dev.debug_attrs)))
 
 		for attr in dev.debug_attrs:
-			print ('\t\t\t' + attr.decode() + ', value: ' + dev.debug_attrs[attr].value.decode())
+			print ('\t\t\t{}, value: '.format(attr.decode(), dev.debug_attrs[attr].value.decode()))
 
 if __name__ == '__main__':
 	main()

--- a/bindings/python/examples/iio_info.py
+++ b/bindings/python/examples/iio_info.py
@@ -27,7 +27,7 @@ def main():
 	print ('IIO context has %u devices:' % len(ctx.devices))
 
 	for dev in ctx.devices:
-		print ('\t' + dev.id.decode('utf-8') + ': ' + dev.name.decode('utf-8'))
+		print ('\t' + dev.id.decode() + ': ' + dev.name.decode())
 
 		if dev is iio.Trigger:
 			print ('Found trigger! Rate: %u Hz' % dev.frequency)
@@ -41,19 +41,19 @@ def main():
 				print ('\t\t\t%u channel-specific attributes found:' % len(chn.attrs))
 
 			for attr in chn.attrs:
-				print ('\t\t\t\t' + attr.decode('utf-8') + ', value: ' + chn.attrs[attr].value.decode('utf-8'))
+				print ('\t\t\t\t' + attr.decode() + ', value: ' + chn.attrs[attr].value.decode())
 
 		if len(dev.attrs) != 0:
 			print ('\t\t%u device-specific attributes found:' % len(dev.attrs))
 
 		for attr in dev.attrs:
-			print ('\t\t\t' + attr.decode('utf-8') + ', value: ' + dev.attrs[attr].value.decode('utf-8'))
+			print ('\t\t\t' + attr.decode() + ', value: ' + dev.attrs[attr].value.decode())
 
 		if len(dev.debug_attrs) != 0:
 			print ('\t\t%u debug attributes found:' % len(dev.debug_attrs))
 
 		for attr in dev.debug_attrs:
-			print ('\t\t\t' + attr.decode('utf-8') + ', value: ' + dev.debug_attrs[attr].value.decode('utf-8'))
+			print ('\t\t\t' + attr.decode() + ', value: ' + dev.debug_attrs[attr].value.decode())
 
 if __name__ == '__main__':
 	main()

--- a/bindings/python/examples/iio_info.py
+++ b/bindings/python/examples/iio_info.py
@@ -20,14 +20,14 @@ def main():
 
 	print ('Library version: %u.%u (git tag: %s)' % iio.version)
 
-	print ('IIO context created: ' + ctx.name)
+	print ('IIO context created: %s' % ctx.name)
 	print ('Backend version: %u.%u (git tag: %s)' % ctx.version)
-	print ('Backend description string: ' + ctx.description)
+	print ('Backend description string: %s' % ctx.description)
 
 	print ('IIO context has %u devices:' % len(ctx.devices))
 
 	for dev in ctx.devices:
-		print ('\t' + dev.id + ': ' + dev.name)
+		print ('\t' + dev.id.decode('utf-8') + ': ' + dev.name.decode('utf-8'))
 
 		if dev is iio.Trigger:
 			print ('Found trigger! Rate: %u Hz' % dev.frequency)
@@ -41,19 +41,19 @@ def main():
 				print ('\t\t\t%u channel-specific attributes found:' % len(chn.attrs))
 
 			for attr in chn.attrs:
-				print ('\t\t\t\t' + attr + ', value: ' + chn.attrs[attr].value)
+				print ('\t\t\t\t' + attr.decode('utf-8') + ', value: ' + chn.attrs[attr].value.decode('utf-8'))
 
 		if len(dev.attrs) != 0:
 			print ('\t\t%u device-specific attributes found:' % len(dev.attrs))
 
 		for attr in dev.attrs:
-			print ('\t\t\t' + attr + ', value: ' + dev.attrs[attr].value)
+			print ('\t\t\t' + attr.decode('utf-8') + ', value: ' + dev.attrs[attr].value.decode('utf-8'))
 
 		if len(dev.debug_attrs) != 0:
 			print ('\t\t%u debug attributes found:' % len(dev.debug_attrs))
 
 		for attr in dev.debug_attrs:
-			print ('\t\t\t' + attr + ', value: ' + dev.debug_attrs[attr].value)
+			print ('\t\t\t' + attr.decode('utf-8') + ', value: ' + dev.debug_attrs[attr].value.decode('utf-8'))
 
 if __name__ == '__main__':
 	main()

--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -484,7 +484,7 @@ class Buffer(object):
 				operations will be performed
 			samples_count: type=int
 				The size of the buffer, in samples
-			circular: type=bool
+			cyclic: type=bool
 				If set to True, the buffer is circular
 
 		returns: type=iio.Buffer

--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -405,7 +405,7 @@ class Channel(object):
 	def __init__(self, _channel):
 		self._channel = _channel
 		self._attrs = { name : ChannelAttr(_channel, name) for name in \
-				[_c_get_attr(_channel, x) for x in xrange(0, _c_attr_count(_channel))] }
+				[_c_get_attr(_channel, x) for x in range(0, _c_attr_count(_channel))] }
 		self._id = _c_get_id(self._channel)
 		self._name = _c_get_name(self._channel)
 		self._output = _c_is_output(self._channel)
@@ -561,13 +561,13 @@ class _DeviceOrTrigger(object):
 	def __init__(self, _device):
 		self._device = _device
 		self._attrs = { name : DeviceAttr(_device, name) for name in \
-				[_d_get_attr(_device, x) for x in xrange(0, _d_attr_count(_device))] }
+				[_d_get_attr(_device, x) for x in range(0, _d_attr_count(_device))] }
 		self._debug_attrs = { name: DeviceDebugAttr(_device, name) for name in \
-				[_d_get_debug_attr(_device, x) for x in xrange(0, _d_debug_attr_count(_device))] }
+				[_d_get_debug_attr(_device, x) for x in range(0, _d_debug_attr_count(_device))] }
 
 		# TODO(pcercuei): Use a dictionary for the channels.
 		chans = [ Channel(_get_channel(self._device, x))
-			for x in xrange(0, _channels_count(self._device)) ]
+			for x in range(0, _channels_count(self._device)) ]
 		self._channels = sorted(chans, key=lambda c: c.id)
 		self._id = _d_get_id(self._device)
 		self._name = _d_get_name(self._device)
@@ -711,7 +711,7 @@ class Context(object):
 
 		# TODO(pcercuei): Use a dictionary for the devices.
 		self._devices = [ Trigger(dev) if _d_is_trigger(dev) else Device(self, dev) for dev in \
-				[ _get_device(self._context, x) for x in xrange(0, _devices_count(self._context)) ]]
+				[ _get_device(self._context, x) for x in range(0, _devices_count(self._context)) ]]
 		self._name = _get_name(self._context)
 		self._description = _get_description(self._context)
 		self._xml = _get_xml(self._context)
@@ -818,7 +818,7 @@ def scan_contexts():
 	ctx = _create_scan_context(None, 0)
 	nb = _get_context_info_list(ctx, _byref(ptr));
 
-	for i in xrange(0, nb):
+	for i in range(0, nb):
 		d[_context_info_get_uri(ptr[i])] = _context_info_get_description(ptr[i])
 
 	_context_info_list_free(ptr)


### PR DESCRIPTION
I installed libiio from debian including Python bindings, but import only worked in Python 2.7 while Python 3 did not see the package.

So I tried to use the bindings locally, now the issue was with compatibility. After the given patches the example/iio_info.py works properly again. I am sure the example code is correct.

Regarding the wrapper itself, I do not know if how the 'xrange' to 'range' change will affect Python 2.7.
And I do not know if the change is actually tested by the example.

Also this change does not affect install for Python 3, so this is something to look into.