### PR TITLE
iio_buffer: add iio_buffer_get_blocking_mode() function

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -123,6 +123,11 @@ int iio_buffer_get_poll_fd(struct iio_buffer *buffer)
 	return iio_device_get_poll_fd(buffer->dev);
 }
 
+bool iio_buffer_get_blocking_mode(struct iio_buffer *buffer)
+{
+	return iio_device_get_blocking_mode(buffer->dev);
+}
+
 int iio_buffer_set_blocking_mode(struct iio_buffer *buffer, bool blocking)
 {
 	return iio_device_set_blocking_mode(buffer->dev, blocking);

--- a/device.c
+++ b/device.c
@@ -291,6 +291,14 @@ int iio_device_get_poll_fd(const struct iio_device *dev)
 		return -ENOSYS;
 }
 
+bool iio_device_get_blocking_mode(const struct iio_device *dev)
+{
+	if (dev->ctx->ops->get_blocking_mode)
+		return dev->ctx->ops->get_blocking_mode(dev);
+	else
+		return true;
+}
+
 int iio_device_set_blocking_mode(const struct iio_device *dev, bool blocking)
 {
 	if (dev->ctx->ops->set_blocking_mode)

--- a/iio-private.h
+++ b/iio-private.h
@@ -99,6 +99,7 @@ struct iio_backend_ops {
 			size_t samples_count, bool cyclic);
 	int (*close)(const struct iio_device *dev);
 	int (*get_fd)(const struct iio_device *dev);
+	bool (*get_blocking_mode)(const struct iio_device *dev);
 	int (*set_blocking_mode)(const struct iio_device *dev, bool blocking);
 
 	void (*cancel)(const struct iio_device *dev);
@@ -232,6 +233,7 @@ bool iio_device_is_tx(const struct iio_device *dev);
 int iio_device_open(const struct iio_device *dev,
 		size_t samples_count, bool cyclic);
 int iio_device_close(const struct iio_device *dev);
+bool iio_device_get_blocking_mode(const struct iio_device *dev);
 int iio_device_set_blocking_mode(const struct iio_device *dev, bool blocking);
 ssize_t iio_device_read_raw(const struct iio_device *dev,
 		void *dst, size_t len, uint32_t *mask, size_t words);

--- a/iio.h
+++ b/iio.h
@@ -1134,6 +1134,15 @@ __api void iio_buffer_destroy(struct iio_buffer *buf);
  */
 __api int iio_buffer_get_poll_fd(struct iio_buffer *buf);
 
+/** @brief Retrieve the blocking mode of an iio_buffer structure
+ *
+ * A device is blocking by default.
+ * @param buf A pointer to an iio_buffer structure
+ * @return True if buffer API is blocking, false else
+ */
+__api bool iio_buffer_get_blocking_mode(struct iio_buffer *buf);
+
+
 /** @brief Make iio_buffer_refill() and iio_buffer_push() blocking or not
  *
  * After this function has been called with blocking == false,

--- a/local.c
+++ b/local.c
@@ -958,6 +958,11 @@ static int local_get_fd(const struct iio_device *dev)
 		return dev->pdata->fd;
 }
 
+static bool local_get_blocking_mode(const struct iio_device *dev)
+{
+	return dev->pdata->blocking;
+}
+
 static int local_set_blocking_mode(const struct iio_device *dev, bool blocking)
 {
 	if (dev->pdata->fd == -1)
@@ -1712,6 +1717,7 @@ static const struct iio_backend_ops local_ops = {
 	.open = local_open,
 	.close = local_close,
 	.get_fd = local_get_fd,
+	.get_blocking_mode = local_get_blocking_mode,
 	.set_blocking_mode = local_set_blocking_mode,
 	.read = local_read,
 	.write = local_write,

--- a/network.c
+++ b/network.c
@@ -170,6 +170,15 @@ static bool network_is_interrupted(int err)
 
 #else
 
+static bool get_blocking_mode(int fd)
+{
+	int ret = fcntl(fd, F_GETFL, 0);
+	if (ret < 0)
+		return true;
+
+	return !(ret & O_NONBLOCK);
+}
+
 static int set_blocking_mode(int fd, bool blocking)
 {
 	int ret = fcntl(fd, F_GETFL, 0);


### PR DESCRIPTION
Hi,

I'm using this new function to implement an `iio_buffer_flush()` function that does not require to pass again the blocking mode as an argument. 

The `iio_buffer_flush()` implementation is there: https://github.com/rlefevre/libiio/commit/bbac4cdc4b89566b42a2d61cd77d95f4d3be89b5 but I'm not sure if it makes sense to submit it as a PR as it can also be implemented outside of libiio.

What do you think?

Thank you