### PR TITLE
Local backend: Avoid double free when create_device is aborted.

### DIFF
--- a/local.c
+++ b/local.c
@@ -1223,6 +1223,7 @@ static void free_protected_attrs(struct iio_channel *chn)
 
 	free(pdata->protected_attrs);
 	pdata->nb_protected_attrs = 0;
+	pdata->protected_attrs = NULL;
 }
 
 static int add_attr_to_channel(struct iio_channel *chn,


### PR DESCRIPTION
After freeing protected_attrs array, set it to NULL. Otherwise, it
could be freed a second time. It can happen in create_device() when
handle_scan_elements() returns a failure, forcing create_device() to
abort.

Signed-off-by: Gwendal Grignou <gwendal@chromium.org>