### PR TITLE
Updated OSX tar deploy to be friendly with MathWorks HSP.

### DIFF
--- a/CI/travis/before_deploy
+++ b/CI/travis/before_deploy
@@ -55,9 +55,26 @@ if [  -n "${temp}"  ] ; then
 		cp ${TRAVIS_BUILD_DIR}/bindings/matlab/*.m usr/lib/matlab/iio/
 
 		if [ "$TRAVIS_OS_NAME" = "osx" ] ; then
-			ln -s /Library/Frameworks/iio.framework/iio usr/lib/libiio.dylib
-			ln -s /Library/Frameworks/iio.framework/Headers/iio.h usr/include/iio.h
+			cd usr/lib
+			ln -fs ../../Library/Frameworks/iio.framework/iio libiio.dylib
+			install_name_tool -change /usr/local/opt/libusb/lib/libusb-1.0.0.dylib @rpath/libusb-1.0.dylib libiio.dylib
+			install_name_tool -add_rpath @loader_path/../../../../../usr/lib libiio.dylib
+			install_name_tool -add_rpath /usr/local/opt/libusb/lib libiio.dylib
+
+			cd ../include
+			ln -s ../../Library/Frameworks/iio.framework/Headers/iio.h iio.h
+
+			# Update references for tools
+			cd ../..
+			TOOLS=Library/Frameworks/iio.framework/Tools/*
+			for tool in $TOOLS
+			do
+				install_name_tool -add_rpath @loader_path/../../ $tool
+			done
 			cp /usr/local/lib/libusb-1.0.dylib usr/lib/
+			chmod +w usr/lib/libusb-1.0.dylib
+			install_name_tool -id @rpath/libusb-1.0.dylib usr/lib/libusb-1.0.dylib
+
 			tar -czf ${TRAVIS_BUILD_DIR}/${RELEASE_PKG_FILE_TGZ} usr Library
 		else
 			tar -czf ${TRAVIS_BUILD_DIR}/${RELEASE_PKG_FILE_TGZ} usr lib


### PR DESCRIPTION
These additions were requested by MathWorks to make their installation easier.  It will remove the requirement for a compiler for their HSP.

Signed-off-by: Travis Collins <travis.collins@analog.com>