### PR TITLE
RFC: Fix channel identifier heuristics

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -98,27 +98,59 @@ static const char * const modifier_names[] = {
 };
 
 /*
- * Looks for a IIO channel modifier at the beginning of the string s. If a
- * modifier was found the symbolic constant (IIO_MOD_*) is returned, otherwise
- * IIO_NO_MOD is returned. If a modifier was found len_p will be updated with
- * the length of the modifier.
+ * Looks for a IIO channel modifier in the second to last underscore (_)
+ * separated section of string s, after the channel-name extension, or at the
+ * beginning of s if no underscore is found.
+ *
+ * If a modifier was found the symbolic constant (IIO_MOD_*) is
+ * returned, otherwise IIO_NO_MOD is returned. If a modifier was found len_p
+ * will be updated with the length of the modifier. If an extension was found
+ * len_ex is set to its length, otherwise to zero. An extension can also exist
+ * when IIO_NO_MOD is returned.
  */
-unsigned int find_channel_modifier(const char *s, size_t *len_p)
+unsigned int find_channel_modifier(const char *s, size_t *offs_p, size_t *len_p)
 {
 	unsigned int i;
 	size_t len;
+	const char *fwd, *ptr;
+
+	if (offs_p)
+		*offs_p = 0;
+
+	/* find modifier location: fast forward to the last underscore,
+	 * then rewind to the previous one */
+	fwd = strrchr(s, '_');
+	ptr = fwd;
+	if (!fwd) {
+		fwd = s;
+	} else {
+		++ptr;
+		while (--fwd > s) {
+			if (*fwd == '_') {
+				++fwd;
+				if (offs_p)
+					*offs_p = fwd - s;
+				break;
+			}
+		}
+	}
 
 	for (i = 0; i < ARRAY_SIZE(modifier_names); i++) {
 		if (!modifier_names[i])
 			continue;
 		len = strlen(modifier_names[i]);
-		if (strncmp(s, modifier_names[i], len) == 0 &&
-				(s[len] == '\0' || s[len] == '_')) {
+		if (strncmp(fwd, modifier_names[i], len) == 0 &&
+				(fwd[len] == '\0' || fwd[len] == '_')) {
 			if (len_p)
 				*len_p = len;
 			return i;
 		}
 	}
+
+	/* no modifier found, set offset to where it would otherwise be, after
+	 * the extension */
+	if (offs_p && ptr)
+		*offs_p = ptr - s;
 
 	return IIO_NO_MOD;
 }

--- a/iio-private.h
+++ b/iio-private.h
@@ -266,7 +266,8 @@ __api ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 		const uint32_t *mask, size_t words);
 
 void iio_channel_init_finalize(struct iio_channel *chn);
-unsigned int find_channel_modifier(const char *s, size_t *len_p);
+unsigned int find_channel_modifier(const char *s, size_t *offs_p,
+		size_t *len_p);
 
 char *iio_strdup(const char *str);
 


### PR DESCRIPTION
libiio currently has issues identifying the channel identifier (channel_id)
when a driver reports multiple attributes of the same type (e.g.
IIO_CONCENTRATION) with a name extension (.extend_name field in
struct iio_chan_spec) as it tries to resolve the name extension as the
modifier (e.g. IIO_MOD_VOC). In this case the startup routine
(local_create_context) fails to establish a valid context and aborts.

This patch defuses the situation by resolving the second-to-last underscore
(_) separated segment as the modifier, leaving room for a name extension
that itself potentially contains underscores.

* Modify find_channel_modifier to find the modifier in the second-to-last
  underscore separated segment.
  Also, report the offset from the beginning of the string until the
  position of the modifier, or the expected position of the modifier in
  case of IIO_NO_MOD.
* In is_global_attr, check the string prefix until the last underscore for
  a match