### PR TITLE
Fix: local buffer tries to re-enqueue block after an error, breaking all future get buffer ops

### DIFF
--- a/local.c
+++ b/local.c
@@ -482,6 +482,8 @@ static ssize_t local_get_buffer(const struct iio_device *dev,
 			*addr_ptr = pdata->addrs[pdata->last_dequeued];
 			return (ssize_t) last_block->bytes_used;
 		}
+
+		pdata->last_dequeued = -1;
 	}
 
 	clock_gettime(CLOCK_MONOTONIC, &start);


### PR DESCRIPTION
Hi,
I'm using a setup where I stream data to and from an FPGA via the libiio buffer (using dmaengine)

While using the non-blocking buffer `iio_buffer_set_blocking_mode()` with `iio_buffer_refill()`
 I stumbled upon some weird error:
After an initially successful received buffer and a subsequent timeout, it would always give
> "Unable to enqueue block"

I looked into the code and think I spotted the error, at least the patch fixes the behaviour for me.
I think this is an error, which brakes the behaviour for all non-blocking cases as soon as a timeout occurs.

The underlying problem is, that upon returning from a buffer operation with EAGAIN the `pdata->last_dequeued` block id is not invalidated, and also there is no block being dequeued in the current run. On the next refill(s) libiio tries to enqueue the previously received buffer (already re-enqueued), which inherently returns an error for all future calls... 

 ~~I've added the "else if", because I'm not quite sure which errors can be returned apart from the two  timeout cases. But from looking at the kernel code, I think that the ETIMEDOUT is not even a valid case in the current code?
cf. https://github.com/analogdevicesinc/linux/blob/xcomm_zynq/drivers/iio/industrialio-buffer.c#L1562~~