### PR TITLE
Allow iio.Buffer to be aware of the Context, to avoid a segmentation violation

### DIFF
--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -519,6 +519,10 @@ class Buffer(object):
 		self._length = samples_count * device.sample_size
 		self._samples_count = samples_count
 
+		self._ctx = device.ctx() 
+		# Holds a reference to the corresponding IIO Context. This ensures that
+		# every iio.Buffer object is destroyed before its corresponding IIO Context.
+
 	def __del__(self):
 		if self._buffer is not None:
 			_buffer_destroy(self._buffer)


### PR DESCRIPTION
Added a new parameter (ctx = None) for the iio.Buffer class constructor. This parameter is stored in self._ctx as a reference to a Context variable. This reference ensures that the Context outlives the buffer, if this is not the case a segmentation violation will occur when destroying the buffer.