### PR TITLE
Improve install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -399,6 +399,9 @@ if(WITH_IIOD)
 	option(WITH_SYSTEMD "Enable installation of systemd service file for iiod" OFF)
 	set(SYSTEMD_UNIT_INSTALL_DIR /lib/systemd/system CACHE PATH "default install path for systemd unit files")
 
+	option(WITH_SYSVINIT "Enable installation of SysVinit script for iiod" OFF)
+	set(SYSVINIT_INSTALL_DIR /etc/init.d CACHE PATH "default install path for SysVinit scripts")
+
 	if (NOT PTHREAD_LIBRARIES)
 		message(WARNING "IIOD requires threads support; disabling")
 		set(WITH_IIOD OFF CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,6 +402,9 @@ if(WITH_IIOD)
 	option(WITH_SYSVINIT "Enable installation of SysVinit script for iiod" OFF)
 	set(SYSVINIT_INSTALL_DIR /etc/init.d CACHE PATH "default install path for SysVinit scripts")
 
+	option(WITH_UPSTART "Enable installation of upstart config file for iiod" OFF)
+	set(UPSTART_CONF_INSTALL_DIR /etc/init CACHE PATH "default install path for upstart conf files")
+
 	if (NOT PTHREAD_LIBRARIES)
 		message(WARNING "IIOD requires threads support; disabling")
 		set(WITH_IIOD OFF CACHE BOOL "" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,6 +396,9 @@ if(OSX_PACKAGE)
 endif()
 
 if(WITH_IIOD)
+	option(WITH_SYSTEMD "Enable installation of systemd service file for iiod" OFF)
+	set(SYSTEMD_UNIT_INSTALL_DIR /lib/systemd/system CACHE PATH "default install path for systemd unit files")
+
 	if (NOT PTHREAD_LIBRARIES)
 		message(WARNING "IIOD requires threads support; disabling")
 		set(WITH_IIOD OFF CACHE BOOL "" FORCE)

--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -62,3 +62,8 @@ add_definitions(-D_GNU_SOURCE=1)
 if(NOT SKIP_INSTALL_ALL)
 	install(TARGETS iiod RUNTIME DESTINATION ${CMAKE_INSTALL_SBINDIR})
 endif()
+
+if (WITH_SYSTEMD)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/init/iiod.service.cmakein ${PROJECT_BINARY_DIR}/init/iiod.service)
+	install(FILES ${PROJECT_BINARY_DIR}/init/iiod.service DESTINATION ${SYSTEMD_UNIT_INSTALL_DIR})
+endif()

--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -74,3 +74,8 @@ if (WITH_SYSVINIT)
 	        PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
 	        DESTINATION ${SYSVINIT_INSTALL_DIR})
 endif()
+
+if (WITH_UPSTART)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/init/iiod.conf.cmakein ${PROJECT_BINARY_DIR}/init/iiod.conf)
+	install(FILES ${PROJECT_BINARY_DIR}/init/iiod.conf DESTINATION ${UPSTART_CONF_INSTALL_DIR})
+endif()

--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -67,3 +67,10 @@ if (WITH_SYSTEMD)
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/init/iiod.service.cmakein ${PROJECT_BINARY_DIR}/init/iiod.service)
 	install(FILES ${PROJECT_BINARY_DIR}/init/iiod.service DESTINATION ${SYSTEMD_UNIT_INSTALL_DIR})
 endif()
+
+if (WITH_SYSVINIT)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/init/iiod.init.cmakein ${PROJECT_BINARY_DIR}/init/iiod)
+	install(FILES ${PROJECT_BINARY_DIR}/init/iiod
+	        PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
+	        DESTINATION ${SYSVINIT_INSTALL_DIR})
+endif()

--- a/iiod/init/iiod.conf.cmakein
+++ b/iiod/init/iiod.conf.cmakein
@@ -10,4 +10,4 @@ stop on runlevel [!2345]
 
 respawn
 
-exec /usr/sbin/iiod -D
+exec @CMAKE_INSTALL_FULL_SBINDIR@/iiod -D

--- a/iiod/init/iiod.init.cmakein
+++ b/iiod/init/iiod.init.cmakein
@@ -23,7 +23,7 @@ fi
 case "$1" in
 	start)
 		log_daemon_msg "Starting IIO Daemon" "iiod" || true
-		if start-stop-daemon -S -b -q -m -p /var/run/iiod.pid -x /usr/sbin/iiod -- $IIOD_OPTS; then
+		if start-stop-daemon -S -b -q -m -p /var/run/iiod.pid -x @CMAKE_INSTALL_FULL_SBINDIR@/iiod -- $IIOD_OPTS; then
 			log_end_msg 0 || true
 		else
 			log_end_msg 1 || true
@@ -46,9 +46,9 @@ case "$1" in
 
 	status)
 		if [ -f /var/run/iiod.pid ] ; then
-			status_of_proc -p /var/run/iiod.pid /usr/sbin/iiod iiod && exit 0 || exit $?
+			status_of_proc -p /var/run/iiod.pid @CMAKE_INSTALL_FULL_SBINDIR@/iiod iiod && exit 0 || exit $?
 		else
-			status_of_proc /usr/sbin/iiod iiod && exit 0 || exit $?
+			status_of_proc @CMAKE_INSTALL_FULL_SBINDIR@/iiod iiod && exit 0 || exit $?
 		fi
 		;;
 

--- a/iiod/init/iiod.service.cmakein
+++ b/iiod/init/iiod.service.cmakein
@@ -8,7 +8,7 @@ After=network.target
 ConditionPathExists=/sys/bus/iio
 
 [Service]
-ExecStart=/usr/sbin/iiod
+ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/iiod
 KillMode=process
 Restart=on-failure
 


### PR DESCRIPTION
My goal is to update the openembedded/Yocto recipe for libiio. I'm using current Yocto with usrmerge flag enabled. This requires these two patches to build.
Installing udev rules to /usr/lib/udev/rules.d instead of /lib/udev/rules.d is common for systemd based Linux distributions.