### PR TITLE
Fix optarg() handling

### DIFF
--- a/tests/iio_adi_xflow_check.c
+++ b/tests/iio_adi_xflow_check.c
@@ -200,7 +200,9 @@ static struct iio_context *scan(void)
 int main(int argc, char **argv)
 {
 	unsigned int buffer_size = 1024 * 1024;
-	int c, option_index = 0, arg_index = 0, ip_index = 0, uri_index = 0;
+	int c, option_index = 0;
+	const char *arg_uri = NULL;
+	const char *arg_ip = NULL;
 	unsigned int n_tx = 0, n_rx = 0;
 	static struct iio_context *ctx;
 	static struct xflow_pthread_data xflow_pthread_data;
@@ -220,8 +222,7 @@ int main(int argc, char **argv)
 			usage(argv);
 			return EXIT_SUCCESS;
 		case 's':
-			arg_index += 2;
-			ret = sscanf(argv[arg_index], "%u%c", &buffer_size, &unit);
+			ret = sscanf(optarg, "%u%c", &buffer_size, &unit);
 			if (ret == 0)
 				return EXIT_FAILURE;
 			if (ret == 2) {
@@ -232,15 +233,12 @@ int main(int argc, char **argv)
 			}
 			break;
 		case 'n':
-			arg_index += 2;
-			ip_index = arg_index;
+			arg_ip = optarg;
 			break;
 		case 'u':
-			arg_index += 2;
-			uri_index = arg_index;
+			arg_uri = optarg;
 			break;
 		case 'a':
-			arg_index += 1;
 			scan_for_context = true;
 			break;
 		case '?':
@@ -248,7 +246,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (arg_index + 1 >= argc) {
+	if (optind + 1 != argc) {
 		fprintf(stderr, "Incorrect number of arguments.\n\n");
 		usage(argv);
 		return EXIT_FAILURE;
@@ -264,10 +262,10 @@ int main(int argc, char **argv)
 
 	if (scan_for_context)
 		ctx = scan();
-	else if (uri_index)
-		ctx = iio_create_context_from_uri(argv[uri_index]);
-	else if (ip_index)
-		ctx = iio_create_network_context(argv[ip_index]);
+	else if (arg_uri)
+		ctx = iio_create_context_from_uri(arg_uri);
+	else if (arg_ip)
+		ctx = iio_create_network_context(arg_ip);
 	else
 		ctx = iio_create_default_context();
 
@@ -276,7 +274,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	device_name = argv[arg_index + 1];
+	device_name = argv[optind];
 
 	dev = get_device(ctx, device_name);
 	if (!dev) {

--- a/tests/iio_attr.c
+++ b/tests/iio_attr.c
@@ -375,8 +375,9 @@ static void usage(void)
 int main(int argc, char **argv)
 {
 	struct iio_context *ctx;
-	int c, option_index = 0, arg_index = 0, uri_index = 0,
-	    device_index = 0, channel_index = 0, attr_index = 0;
+	int c, option_index = 0;
+	int device_index = 0, channel_index = 0, attr_index = 0;
+	const char *arg_uri = NULL;
 	enum backend backend = LOCAL;
 	bool detect_context = false, search_device = false, ignore_case = false,
 		search_channel = false, search_buffer = false, search_debug = false,
@@ -394,57 +395,45 @@ int main(int argc, char **argv)
 			return EXIT_SUCCESS;
 		/* context connection */
 		case 'a':
-			arg_index += 1;
 			detect_context = true;
 			break;
 		case 'u':
 			backend = AUTO;
-			arg_index += 2;
-			uri_index = arg_index;
+			arg_uri = optarg;
 			break;
 		/* Attribute type
 		 * 'd'evice, 'c'hannel, 'C'ontext, 'B'uffer or 'D'ebug
 		 */
 		case 'd':
-			arg_index += 1;
 			search_device = true;
 			break;
 		case 'c':
-			arg_index += 1;
 			search_channel = true;
 			break;
 		case 'B':
-			arg_index +=1;
 			search_buffer = true;
 			break;
 		case 'D':
-			arg_index +=1;
 			search_debug = true;
 			break;
 		case 'C':
-			arg_index +=1;
 			search_context = true;
 			break;
 		/* Channel qualifiers */
 		case 'i':
-			arg_index += 1;
 			input_only = true;
 			break;
 		case 'o':
-			arg_index += 1;
 			output_only = true;
 			break;
 		case 's':
-			arg_index += 1;
 			scan_only = true;
 			break;
 		/* options */
 		case 'I':
-			arg_index += 1;
 			ignore_case = true;
 			break;
 		case 'q':
-			arg_index += 1;
 			quiet = true;
 			break;
 		case '?':
@@ -470,59 +459,59 @@ int main(int argc, char **argv)
 
 	if (search_context) {
 		/* -C [IIO_attribute] */
-		if (argc >= arg_index + 2)
-			attr_index = arg_index + 1;
-		if (argc >= arg_index + 3) {
+		if (argc >= optind + 1)
+			attr_index = optind;
+		if (argc >= optind + 2) {
 			fprintf(stderr, "Too many options for searching for context attributes\n");
 			return EXIT_FAILURE;
 		}
 	} else if (search_device) {
 		/* -d [device] [attr] [value] */
-		if (argc >= arg_index + 2)
-			device_index = arg_index + 1;
-		if (argc >= arg_index + 3)
-			attr_index = arg_index + 2;
-		if (argc >= arg_index + 4)
-			wbuf = argv[arg_index + 3];
-		if (argc >= arg_index + 5) {
+		if (argc >= optind + 1)
+			device_index = optind;
+		if (argc >= optind + 2)
+			attr_index = optind + 1;
+		if (argc >= optind + 3)
+			wbuf = argv[optind + 2];
+		if (argc >= optind + 4) {
 			fprintf(stderr, "Too many options for searching for device attributes\n");
 			return EXIT_FAILURE;
 		}
 	} else if (search_channel) {
 		/* -c [device] [channel] [attr] [value] */
-		if (argc >= arg_index + 2)
-			device_index = arg_index + 1;
-		if (argc >= arg_index + 3)
-			channel_index = arg_index + 2;
-		if (argc >= arg_index + 4)
-			attr_index = arg_index + 3;
-		if (argc >= arg_index + 5)
-			wbuf = argv[arg_index + 4];
-		if (argc >= arg_index + 6) {
+		if (argc >= optind + 1)
+			device_index = optind;
+		if (argc >= optind + 2)
+			channel_index = optind + 1;
+		if (argc >= optind + 3)
+			attr_index = optind + 2;
+		if (argc >= optind + 4)
+			wbuf = argv[optind + 3];
+		if (argc >= optind + 5) {
 			fprintf(stderr, "Too many options for searching for channel attributes\n");
 			return EXIT_FAILURE;
 		}
 	} else if (search_buffer) {
 		/* -B [device] [attribute] [value] */
-		if (argc >= arg_index + 2)
-			device_index = arg_index + 1;
-		if (argc >= arg_index + 3)
-			attr_index = arg_index + 2;
-		if (argc >= arg_index + 4)
-			wbuf = argv[arg_index + 3];
-		if (argc >= arg_index + 5) {
+		if (argc >= optind + 1)
+			device_index = optind;
+		if (argc >= optind + 2)
+			attr_index = optind + 1;
+		if (argc >= optind + 3)
+			wbuf = argv[optind + 2];
+		if (argc >= optind + 4) {
 			fprintf(stderr, "Too many options for searching for buffer attributes\n");
 			return EXIT_FAILURE;
 		}
 	} else if (search_debug) {
 		/* -D [device] [attribute] [value] */
-		if (argc >= arg_index + 2)
-			device_index = arg_index + 1;
-		if (argc >= arg_index + 3)
-			attr_index = arg_index + 2;
-		if (argc >= arg_index + 4)
-			wbuf = argv[arg_index + 3];
-		if (argc >= arg_index + 5) {
+		if (argc >= optind + 1)
+			device_index = optind;
+		if (argc >= optind + 2)
+			attr_index = optind + 1;
+		if (argc >= optind + 3)
+			wbuf = argv[optind + 2];
+		if (argc >= optind + 4) {
 			fprintf(stderr, "Too many options for searching for device attributes\n");
 			return EXIT_FAILURE;
 		}
@@ -552,7 +541,7 @@ int main(int argc, char **argv)
 	if (detect_context)
 		ctx = autodetect_context();
 	else if (backend == AUTO)
-		ctx = iio_create_context_from_uri(argv[uri_index]);
+		ctx = iio_create_context_from_uri(arg_uri);
 	else
 		ctx = iio_create_default_context();
 

--- a/tests/iio_genxml.c
+++ b/tests/iio_genxml.c
@@ -66,8 +66,10 @@ int main(int argc, char **argv)
 {
 	char *xml;
 	struct iio_context *ctx;
-	int c, option_index = 0, arg_index = 0, xml_index = 0, ip_index = 0;
-	int uri_index = 0;
+	int c, option_index = 0;
+	const char *arg_uri = NULL;
+	const char *arg_xml = NULL;
+	const char *arg_ip = NULL;
 	enum backend backend = LOCAL;
 
 	while ((c = getopt_long(argc, argv, "+hn:x:u:",
@@ -82,8 +84,7 @@ int main(int argc, char **argv)
 				return EXIT_FAILURE;
 			}
 			backend = NETWORK;
-			arg_index += 2;
-			ip_index = arg_index;
+			arg_ip = optarg;
 			break;
 		case 'x':
 			if (backend != LOCAL) {
@@ -91,12 +92,10 @@ int main(int argc, char **argv)
 				return EXIT_FAILURE;
 			}
 			backend = XML;
-			arg_index += 2;
-			xml_index = arg_index;
+			arg_xml = optarg;
 			break;
 		case 'u':
-			arg_index += 2;
-			uri_index = arg_index;
+			arg_uri = optarg;
 			backend = AUTO;
 			break;
 		case '?':
@@ -104,18 +103,18 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (arg_index >= argc) {
+	if (optind != argc) {
 		fprintf(stderr, "Incorrect number of arguments.\n\n");
 		usage();
 		return EXIT_FAILURE;
 	}
 
 	if (backend == AUTO) 
-		ctx = iio_create_context_from_uri(argv[uri_index]);
+		ctx = iio_create_context_from_uri(arg_uri);
 	else if (backend == XML)
-		ctx = iio_create_xml_context(argv[xml_index]);
+		ctx = iio_create_xml_context(arg_xml);
 	else if (backend == NETWORK)
-		ctx = iio_create_network_context(argv[ip_index]);
+		ctx = iio_create_network_context(arg_ip);
 	else
 		ctx = iio_create_default_context();
 

--- a/tests/iio_info.c
+++ b/tests/iio_info.c
@@ -172,8 +172,10 @@ static int dev_is_buffer_capable(const struct iio_device *dev)
 int main(int argc, char **argv)
 {
 	struct iio_context *ctx;
-	int c, option_index = 0, arg_index = 0, xml_index = 0, ip_index = 0,
-	    uri_index = 0;
+	int c, option_index = 0;
+	const char *arg_uri = NULL;
+	const char *arg_ip = NULL;
+	const char *arg_xml = NULL;
 	enum backend backend = LOCAL;
 	bool do_scan = false, detect_context = false;
 	unsigned int i, major, minor;
@@ -192,8 +194,7 @@ int main(int argc, char **argv)
 				return EXIT_FAILURE;
 			}
 			backend = NETWORK;
-			arg_index += 2;
-			ip_index = arg_index;
+			arg_ip = optarg;
 			break;
 		case 'x':
 			if (backend != LOCAL) {
@@ -201,11 +202,9 @@ int main(int argc, char **argv)
 				return EXIT_FAILURE;
 			}
 			backend = XML;
-			arg_index += 2;
-			xml_index = arg_index;
+			arg_xml = optarg;
 			break;
 		case 's':
-			arg_index += 1;
 			do_scan = true;
 			break;
 		case 'u':
@@ -214,11 +213,9 @@ int main(int argc, char **argv)
 				return EXIT_FAILURE;
 			}
 			backend = AUTO;
-			arg_index += 2;
-			uri_index = arg_index;
+			arg_uri = optarg;
 			break;
 		case 'a':
-			arg_index += 1;
 			detect_context = true;
 			break;
 		case '?':
@@ -226,7 +223,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if (arg_index >= argc) {
+	if (optind != argc) {
 		fprintf(stderr, "Incorrect number of arguments.\n\n");
 		usage();
 		return EXIT_FAILURE;
@@ -248,11 +245,11 @@ int main(int argc, char **argv)
 	if (detect_context)
 		ctx = autodetect_context();
 	else if (backend == XML)
-		ctx = iio_create_xml_context(argv[xml_index]);
+		ctx = iio_create_xml_context(arg_xml);
 	else if (backend == NETWORK)
-		ctx = iio_create_network_context(argv[ip_index]);
+		ctx = iio_create_network_context(arg_ip);
 	else if (backend == AUTO)
-		ctx = iio_create_context_from_uri(argv[uri_index]);
+		ctx = iio_create_context_from_uri(arg_uri);
 	else
 		ctx = iio_create_default_context();
 


### PR DESCRIPTION
A lot of the IIO tools currently assumes that the argument for an option that
is parsed by getopt_long() is in the argv[] following the option and then
the combination of option and argument always consumes two argv[] entries.

This is not necessarily true though. getopt_long() accepts option and
argument in the same argv[] entry. For short options the argument can
directly follow the option character and for long options the argument can
follow in the same argv[] entry separated by a '=' character.

E.g. both -u ip:192.168.1.1 and -uip:192.168.1.1 as well as --uri
192.168.1.1 and --uri=192.168.1.1 are equivalent and all valid.

As a result of this the tools will show undefined behavior when
option and argument are passed in the same argv[] entry (E.g. crash with a
segmentation fault).

To address this properly use the optarg and optind variables that are
provided by the getopt() interface. optarg points to the start of the
argument for the current option and optind will point to the first non
option argv[] entry after all options have been scanned.
