### PR TITLE
iio_adi_xflow_check: Avoid accessing device after context destruction

### DIFF
--- a/tests/iio_adi_xflow_check.c
+++ b/tests/iio_adi_xflow_check.c
@@ -339,10 +339,10 @@ int main(int argc, char **argv)
 		}
 	}
 
+	pthread_join(monitor_thread, NULL);
+
 	iio_buffer_destroy(buffer);
 	iio_context_destroy(ctx);
-
-	pthread_join(monitor_thread, NULL);
 
 	return 0;
 }


### PR DESCRIPTION
The monitor thread must be joined before the call
to iio_context_destroy, otherwise iio_device_reg_read
and iio_device_reg_write might be called after context
destruction.

Signed-off-by: Julien Malik <julien.malik@paraiso.me>