### PR TITLE
local: Fix low-speed mode

### DIFF
--- a/local.c
+++ b/local.c
@@ -816,6 +816,16 @@ static int enable_high_speed(const struct iio_device *dev)
 	unsigned int i;
 	int ret, fd = pdata->fd;
 
+	/*
+	 * For the BLOCK_ALLOC_IOCTL ioctl it is not possible to distingush
+	 * between an error during the allocation (e.g. incorrect size) or
+	 * whether the high-speed interface is not supported. BLOCK_FREE_IOCTL does
+	 * never fail if the device supports the high-speed interface, so we use it
+	 * here. Calling it when no blocks are allocated the ioctl has no effect.
+	 */
+	ret = ioctl_nointr(fd, BLOCK_FREE_IOCTL, NULL);
+	if (ret < 0)
+		return -ENOSYS;
 
 	if (pdata->cyclic) {
 		nb_blocks = 1;


### PR DESCRIPTION
Commit e6754cb84a8b ("local: Return error when no blocks could be
allocated") made the wrong assumption that the BLOCK_ALLOC_IOCTL will
return the ENOSYS error when high-speed mode is not supported. This is not
the case though and the ioctl returns the EINVAL error instead.

This breaks low-speed support since libiio now assumes that high-speed mode
is always supported and something went wrong when trying to allocate the
high-speed buffer and never tries to fallback to low-speed mode.

Unfortunately it is not possible to distinguish between a EINVAL that means
high-speed mode is not supported and a EINVAL that means high-speed mode is
supported but something went wrong when allocating the high-speed buffer.

To avoid this use the BLOCK_FREE_IOCTL to check whether high-speed mode is
supported or not. If high-speed mode is supported BLOCK_FREE_IOCTL will
never return an error, if it is not supported it will return the EINVAL
error.

Fixes: e6754cb84a8b ("local: Return error when no blocks could be allocated")
Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>