### PR TITLE
appveyor.yml: change versioning to '{branch}.{build}' format

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2015.1.{build}
+version: '{branch}.{build}'
 clone_depth: 1
 
 skip_commits:


### PR DESCRIPTION
The old '2015.1.{build}' format is a bit confusing, because it gives the
impression that something is stuck in the past.

Change this to '{branch}.{build}'.
That way we don't need to care about date/time, since Appveyor will track
that anyway.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>