### PR TITLE
.travis.yml: add host-key algo ssh-dss for xenial deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,9 @@ matrix:
     - compiler: "gcc"
       os: linux
       dist: xenial
-      env: LDIST=-xenial
+      env:
+        - LDIST=-xenial
+        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - compiler: "gcc"
       os: osx
       osx_image: xcode6.4


### PR DESCRIPTION
The version of OpenSSH included in 16.04 disables ssh-dss.
We need to enable it explicitly for this to work.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>