### PR TITLE
cmake: Add LD_LIBRARY_PATH to udev rule

### DIFF
--- a/libiio.rules.cmakein
+++ b/libiio.rules.cmakein
@@ -1,1 +1,1 @@
-SUBSYSTEM=="usb", PROGRAM=="/bin/sh -c '@CMAKE_INSTALL_FULL_BINDIR@/iio_info -s | grep %s{idVendor}:%s{idProduct}'", RESULT!="", MODE="666"
+SUBSYSTEM=="usb", PROGRAM=="/bin/sh -c 'LD_LIBRARY_PATH=@CMAKE_INSTALL_FULL_LIBDIR@ @CMAKE_INSTALL_FULL_BINDIR@/iio_info -s | grep %s{idVendor}:%s{idProduct}'", RESULT!="", MODE="666"


### PR DESCRIPTION
With local installs, libiio.so will not be found when the udev rule is ran due to not having the local lib install dir in the lib path.