### PR TITLE
CI/travis: make shell scripts more pendantic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 obj-*
 *.deb
 
+*.swp
+
 libiio.iss
 libiio.pc
 

--- a/CI/travis/before_deploy
+++ b/CI/travis/before_deploy
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -xe
 
 # Don't prepare a deploy on a Coverity build
 if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi

--- a/CI/travis/before_deploy
+++ b/CI/travis/before_deploy
@@ -27,7 +27,7 @@ check_file()
 temp=""
 for i in $(find ./ -name CMakeCache.txt)
 do
-hit=$(find $(dirname ${i}) -maxdepth 1 -name "libiio*.$1" | grep -v -- ${LDIST})
+hit=$(find $(dirname ${i}) -maxdepth 1 -name "libiio*.$1" -a ! -name "*${LDIST}*")
 if [ "$(echo ${hit} | wc -w)" -gt "1"  ] ; then
 	echo "I am confused - more than 2 $1 files!"
 	echo $hit

--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -xe
 
 brew update
 if ! brew ls --version cmake &>/dev/null; then

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -xe
 
 sudo apt-get -qq update
 sudo apt-get install -y cmake doxygen libaio-dev libavahi-client-dev libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar bzip2 gzip

--- a/CI/travis/deploy
+++ b/CI/travis/deploy
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -xe
 
 cd $TRAVIS_BUILD_DIR
 

--- a/CI/travis/make_darwin
+++ b/CI/travis/make_darwin
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -xe
 
 if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -xe
 
 if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 


### PR DESCRIPTION
As scripts grow in size, it's a good idea to exit & fail them on the first non-zero exit code.

That also enforces us to re-think the code, and not ignore any non-successful parts of the CI scripts.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>