### PR TITLE
build,CI/travis: setup CentOS testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: c
+sudo: required
 
 env:
   global:
@@ -11,6 +12,9 @@ env:
   - BRANCH_PULL=$TRAVIS_PULL_REQUEST_BRANCH
   - PULL=$TRAVIS_PULL_REQUEST
   - BRANCH=$TRAVIS_BRANCH
+
+services:
+  - docker
 
 matrix:
   include:
@@ -46,6 +50,14 @@ matrix:
       env:
         - LDIST=-xenial
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
+    - os: linux
+      env:
+        - OS_TYPE=centos
+        - OS_VERSION=6
+    - os: linux
+      env:
+        - OS_TYPE=centos
+        - OS_VERSION=7
     - compiler: "gcc"
       os: osx
       osx_image: xcode6.4
@@ -68,7 +80,7 @@ addons:
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./CI/travis/before_install_darwin ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./CI/travis/before_install_linux ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./CI/travis/before_install_linux "$OS_TYPE" "$OS_VERSION" ; fi
   - if [[ -n "$COVERITY_SCAN_PROJECT_NAME" ]] ; then echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca- ; fi
   - if [ -n "$COVERITY_SCAN_PROJECT_NAME" -a "$TRAVIS_EVENT_TYPE" == "cron" ] ; then curl -s 'https://scan.coverity.com/scripts/travisci_build_coverity_scan.sh' | bash || true ; fi
 
@@ -76,7 +88,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir -p $TRAVIS_BUILD_DIR/build_tar ; fi
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ${TRAVIS_BUILD_DIR}/CI/travis/make_linux; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ${TRAVIS_BUILD_DIR}/CI/travis/make_linux "$OS_TYPE" "$OS_VERSION" ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ${TRAVIS_BUILD_DIR}/CI/travis/make_darwin; fi
 
 notifications:

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -1,8 +1,25 @@
 #!/bin/sh
 
-sudo apt-get -qq update
-sudo apt-get install -y cmake doxygen libaio-dev libavahi-client-dev libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar bzip2 gzip
-if [ `sudo apt-cache search libserialport-dev | wc -l` -gt 0 ] ; then
-	sudo apt-get install -y libserialport-dev
-fi
+handle_centos() {
+	sudo apt-get -qq update
+	echo 'DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock -s devicemapper"' | sudo tee /etc/default/docker > /dev/null
+	sudo service docker restart
 
+	# FIXME: The example had a `sleep 5` ; remove it later
+	sleep 5
+
+	sudo docker pull centos:centos${OS_VERSION}
+}
+
+handle_default() {
+	sudo apt-get -qq update
+	sudo apt-get install -y cmake doxygen libaio-dev libavahi-client-dev libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar bzip2 gzip
+	if [ `sudo apt-cache search libserialport-dev | wc -l` -gt 0 ] ; then
+		sudo apt-get install -y libserialport-dev
+	fi
+}
+
+OS_TYPE=${1:-default}
+OS_VERSION=${2}
+
+handle_${OS_TYPE}

--- a/CI/travis/inside_centos_docker.sh
+++ b/CI/travis/inside_centos_docker.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -xe
+
+OS_VERSION="$1"
+TRAVIS_CI="$2"
+
+# FIXME: see about adding `libserialport-dev` from EPEL ; maybe libusb-1.0.0-devel...
+yum -y groupinstall 'Development Tools'
+yum -y install cmake libxml2-devel libusb1-devel doxygen libaio-devel \
+	avahi-devel bzip2 gzip rpm rpm-build
+
+# Check we're in Travis-CI; the only place where this context is valid
+# It makes sure, users won't shoot themselves in the foot while running this script
+if [ "$TRAVIS_CI" == "travis-ci" ] ; then
+	mkdir -p /libiio/build
+	cd /libiio/build
+else
+	mkdir -p build
+	cd build
+fi
+
+cmake -DENABLE_PACKAGING=ON ..
+make
+make package
+
+if [ "$TRAVIS_CI" == "travis-ci" ] ; then
+	yum -y install /libiio/build/libiio-*.rpm
+fi

--- a/CI/travis/inside_centos_docker.sh
+++ b/CI/travis/inside_centos_docker.sh
@@ -8,6 +8,26 @@ yum -y groupinstall 'Development Tools'
 yum -y install cmake libxml2-devel libusb1-devel doxygen libaio-devel \
 	avahi-devel bzip2 gzip rpm rpm-build
 
+# FIXME: cmake in CentOS 7 is broken, so we need to patch it for now
+# Remove this when it's fixed; but make sure we're doing this in Travis-CI context
+if [ "$TRAVIS_CI" == "travis-ci" ] ; then
+	if [ "$OS_VERSION" == "7" ] ; then
+		patch -p1 <<-EOF
+--- a/usr/share/cmake/Modules/CPackRPM.cmake
++++ b/usr/share/cmake/Modules/CPackRPM.cmake
+@@ -703,7 +703,7 @@ if(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST)
+    message("CPackRPM:Debug: CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST= \${CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST}")
+  endif()
+   foreach(_DIR \${CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST})
+-    list(APPEND _RPM_DIRS_TO_OMIT "-o;-path;.\${_DIR}")
++    list(APPEND _RPM_DIRS_TO_OMIT "-o -path \${_DIR}")
+   endforeach()
+ endif()
+ if (CPACK_RPM_PACKAGE_DEBUG)
+		EOF
+	fi
+fi
+
 # Check we're in Travis-CI; the only place where this context is valid
 # It makes sure, users won't shoot themselves in the foot while running this script
 if [ "$TRAVIS_CI" == "travis-ci" ] ; then

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -6,6 +6,7 @@ handle_default() {
 	cd $TRAVIS_BUILD_DIR/build
 	cmake -DENABLE_PACKAGING=ON -DDEB_DETECT_DEPENDENCIES=ON ..
 	make && make package
+	sudo dpkg -i libiio*.deb
 }
 
 handle_centos() {

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -2,7 +2,21 @@
 
 if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 
-cd $TRAVIS_BUILD_DIR/build
-cmake -DENABLE_PACKAGING=ON -DDEB_DETECT_DEPENDENCIES=ON ..
-make && make package
+handle_default() {
+	cd $TRAVIS_BUILD_DIR/build
+	cmake -DENABLE_PACKAGING=ON -DDEB_DETECT_DEPENDENCIES=ON ..
+	make && make package
+}
+
+handle_centos() {
+	sudo docker run --rm=true \
+		-v `pwd`:/libiio:rw \
+		centos:centos${OS_VERSION} \
+		/bin/bash -xe /libiio/CI/travis/inside_centos_docker.sh ${OS_VERSION} travis-ci
+}
+
+OS_TYPE=${1:-default}
+OS_VERSION="$2"
+
+handle_${OS_TYPE}
 

--- a/cmake/LinuxPackaging.cmake
+++ b/cmake/LinuxPackaging.cmake
@@ -100,7 +100,7 @@ if(DEB_DETECT_DEPENDENCIES AND DPKG_CMD AND DPKGQ_CMD)
 		${CPACK_DEBIAN_PACKAGE_DEPENDS})
 else()
 	# assume everything is turned on, and running on a modern OS
-	set(CPACK_DEBIAN_PACKAGE_DEPENDS "libaio-dev (>= 0.3.109), libavahi-client-dev (>= 0.6.31), libavahi-common-dev (>= 0.6.31), libc6-dev (>= 2.19), libusb-1.0-0-dev (>= 2:1.0.17), libxml2-dev (>= 2.9.1)")
+	set(CPACK_DEBIAN_PACKAGE_DEPENDS "libaio (>= 0.3.109), libavahi-client (>= 0.6.31), libavahi-common (>= 0.6.31), libc6 (>= 2.19), libusb-1.0-0 (>= 2:1.0.17), libxml2 (>= 2.9.1)")
 	message(STATUS "Using default dependencies for packaging")
 endif()
 

--- a/cmake/LinuxPackaging.cmake
+++ b/cmake/LinuxPackaging.cmake
@@ -6,6 +6,7 @@ FIND_PROGRAM(RPMBUILD_CMD rpmbuild)
 if (RPMBUILD_CMD)
 	set(CPACK_PACKAGE_RELOCATABLE OFF)
 	set(CPACK_GENERATOR ${CPACK_GENERATOR};RPM)
+	set(CPACK_RPM_PACKAGE_REQUIRES "libaio >= 0.3.107, avahi >= 0.6.25, libusb1 >= 1.0.9, libxml2 >= 2.7.6")
 endif()
 
 set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY 0)
@@ -103,6 +104,9 @@ else()
 	message(STATUS "Using default dependencies for packaging")
 endif()
 
-message(STATUS "Package dependencies: " ${CPACK_DEBIAN_PACKAGE_DEPENDS})
+message(STATUS "Package dependencies (.deb): " ${CPACK_DEBIAN_PACKAGE_DEPENDS})
+if (CPACK_RPM_PACKAGE_REQUIRES)
+	message(STATUS "Package dependencies (.rpm): " ${CPACK_RPM_PACKAGE_REQUIRES})
+endif()
 
 include(CPack)


### PR DESCRIPTION
Adapted from blog-post:
     https://derekweitzel.com/2016/05/03/building-centos-packages-on-travisci/
    
This essentially uses CentOS docker images to run the libiio build and
create RPM packages, which is a bit closer to the real-world case of RPM
usage.
    
We're not doing any deployments of these files just yet.
This just builds them and confirms that we can build and install on
CentOS, and offers the procedure to do it.
A later change-set will add deployment of CentOS RPMs, since these seem to
be interesting for people.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>