### PR TITLE
Fix bug in mask bit tests

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -223,14 +223,14 @@ ssize_t iio_buffer_foreach_sample(struct iio_buffer *buffer,
 				break;
 
 			/* Test if the buffer has samples for this channel */
-			if (!TEST_BIT(buffer->mask, chn->index))
+			if (!TEST_BIT(buffer->mask, chn->number))
 				continue;
 
 			if ((ptr - start) % length)
 				ptr += length - ((ptr - start) % length);
 
 			/* Test if the client wants samples from this channel */
-			if (TEST_BIT(dev->mask, chn->index)) {
+			if (TEST_BIT(dev->mask, chn->number)) {
 				ssize_t ret = callback(chn,
 						(void *) ptr, length, d);
 				if (ret < 0)
@@ -272,7 +272,7 @@ void * iio_buffer_first(const struct iio_buffer *buffer,
 			break;
 
 		/* Test if the buffer has samples for this channel */
-		if (!TEST_BIT(buffer->mask, cur->index))
+		if (!TEST_BIT(buffer->mask, cur->number))
 			continue;
 
 		/* Two channels with the same index use the same samples */


### PR DESCRIPTION
Previously, the index field of struct iio_channel was being used to test
against the buffer field of struct iio_device and struct iio_buffer.
This is incorrect because the index of the first channel may be non-zero
and the indexes may not be contiguous. For further evidence, look at
iio_channel_enable/disable() which use number rather than index.