### PR TITLE
minor sorting cleanups

### DIFF
--- a/context.c
+++ b/context.c
@@ -206,7 +206,7 @@ static void reorder_channels(struct iio_device *dev)
 
 	/* Reorder channels by index */
 	 qsort(dev->channels, dev->nb_channels, sizeof(struct iio_channel *),
-                qsort_iio_channel);
+                iio_channel_compare);
 
 	for (i = 0; i < dev->nb_channels; i++)
 		dev->channels[i]->number = i;

--- a/context.c
+++ b/context.c
@@ -208,8 +208,12 @@ static void reorder_channels(struct iio_device *dev)
 	 qsort(dev->channels, dev->nb_channels, sizeof(struct iio_channel *),
                 iio_channel_compare);
 
-	for (i = 0; i < dev->nb_channels; i++)
-		dev->channels[i]->number = i;
+	for (i = 0; i < dev->nb_channels; i++) {
+		struct iio_channel *chn = dev->channels[i];
+		chn->number = i;
+		qsort(chn->attrs, chn->nb_attrs, sizeof(struct iio_channel_attr),
+			iio_channel_attr_compare);
+	}
 }
 
 int iio_context_init(struct iio_context *ctx)

--- a/local.c
+++ b/local.c
@@ -1767,9 +1767,6 @@ static int create_device(void *d, const char *path)
 		free_protected_attrs(chn);
 		if (ret < 0)
 			goto err_free_scan_elements;
-
-		qsort(chn->attrs,  chn->nb_attrs, sizeof(struct iio_channel_attr),
-			iio_channel_attr_compare);
 	}
 
 	ret = detect_and_move_global_attrs(dev);

--- a/local.c
+++ b/local.c
@@ -1713,7 +1713,7 @@ static int add_buffer_attributes(struct iio_device *dev, const char *devpath)
 			return ret;
 
 		qsort(dev->buffer_attrs, dev->nb_buffer_attrs, sizeof(char *),
-			qsort_iio_buffer_attr);
+			iio_buffer_attr_compare);
 	}
 
 	return 0;
@@ -1769,7 +1769,7 @@ static int create_device(void *d, const char *path)
 			goto err_free_scan_elements;
 
 		qsort(chn->attrs,  chn->nb_attrs, sizeof(struct iio_channel_attr),
-			qsort_iio_channel_attr);
+			iio_channel_attr_compare);
 	}
 
 	ret = detect_and_move_global_attrs(dev);
@@ -1777,7 +1777,7 @@ static int create_device(void *d, const char *path)
 		goto err_free_device;
 
 	qsort(dev->attrs,  dev->nb_attrs, sizeof(char *),
-		qsort_iio_device_attr);
+		iio_device_attr_compare);
 
 	dev->words = (dev->nb_channels + 31) / 32;
 	if (dev->words) {
@@ -2003,7 +2003,7 @@ struct iio_context * local_create_context(void)
 		goto err_context_destroy;
 
 	qsort(ctx->devices, ctx->nb_devices, sizeof(struct iio_device *),
-		qsort_iio_device);
+		iio_device_compare);
 
 	foreach_in_dir(ctx, "/sys/kernel/debug/iio", true, add_debug);
 

--- a/local.c
+++ b/local.c
@@ -1159,7 +1159,7 @@ static char * get_short_attr_name(struct iio_channel *chn, const char *attr)
 
 	if (chn->name) {
 		size_t len = strlen(chn->name);
-		if  (strncmp(chn->name, ptr, len) == 0 && ptr[len] == '_')
+		if (strncmp(chn->name, ptr, len) == 0 && ptr[len] == '_')
 			ptr += len + 1;
 	}
 
@@ -1754,7 +1754,7 @@ static int create_device(void *d, const char *path)
 	ret = add_buffer_attributes(dev, path);
 	if (ret < 0)
 		goto err_free_device;
-	
+
 	ret = add_scan_elements(dev, path);
 	if (ret < 0)
 		goto err_free_scan_elements;
@@ -1773,7 +1773,7 @@ static int create_device(void *d, const char *path)
 	if (ret < 0)
 		goto err_free_device;
 
-	qsort(dev->attrs,  dev->nb_attrs, sizeof(char *),
+	qsort(dev->attrs, dev->nb_attrs, sizeof(char *),
 		iio_device_attr_compare);
 
 	dev->words = (dev->nb_channels + 31) / 32;

--- a/sort.c
+++ b/sort.c
@@ -19,9 +19,15 @@
 #include "iio-private.h"
 #include <string.h>
 
-/* These are a few functions to do sorting for various
+/* These are a few functions to do sorting via qsort for various
  * iio structures. For more info, see the qsort(3) man page.
- * If the structures are updated, the sort functions may
+ *
+ * The qsort comparison function must return an integer less than, equal to,
+ * or greater than zero if the first argument is considered to be
+ * respectively less than, equal to, or greater than the second. If two
+ * members compare as equal, their order in the sort order is undefined.
+ *
+ * If the structures are updated, the compare functions may
  * need to be updated.
  *
  * The actual arguments to these function are "pointers to
@@ -29,7 +35,7 @@
  * to char", hence the cast plus dereference
  */
 
-int qsort_iio_channel(const void *p1, const void *p2)
+int iio_channel_compare(const void *p1, const void *p2)
 {
 	const struct iio_channel *tmp1 = *(struct iio_channel **)p1;
 	const struct iio_channel *tmp2 = *(struct iio_channel **)p2;
@@ -53,7 +59,7 @@ int qsort_iio_channel(const void *p1, const void *p2)
 	return strcmp(tmp1->id, tmp2->id);
 }
 
-int qsort_iio_channel_attr(const void *p1, const void *p2)
+int iio_channel_attr_compare(const void *p1, const void *p2)
 {
 	const struct iio_channel_attr *tmp1 = (struct iio_channel_attr *)p1;
 	const struct iio_channel_attr *tmp2 = (struct iio_channel_attr *)p2;
@@ -61,7 +67,7 @@ int qsort_iio_channel_attr(const void *p1, const void *p2)
 	return strcmp(tmp1->name, tmp2->name);
 }
 
-int qsort_iio_device(const void *p1, const void *p2)
+int iio_device_compare(const void *p1, const void *p2)
 {
 	const struct iio_device *tmp1 = *(struct iio_device **)p1;
 	const struct iio_device *tmp2 = *(struct iio_device **)p2;
@@ -69,7 +75,7 @@ int qsort_iio_device(const void *p1, const void *p2)
 	return strcmp(tmp1->id, tmp2->id);
 }
 
-int qsort_iio_device_attr(const void *p1, const void *p2)
+int iio_device_attr_compare(const void *p1, const void *p2)
 {
 	const char *tmp1 = *(const char **)p1;
 	const char *tmp2 = *(const char **)p2;
@@ -77,7 +83,7 @@ int qsort_iio_device_attr(const void *p1, const void *p2)
 	return strcmp(tmp1, tmp2);
 }
 
-int qsort_iio_buffer_attr(const void *p1, const void *p2)
+int iio_buffer_attr_compare(const void *p1, const void *p2)
 {
 	const char *tmp1 = *(const char **)p1;
 	const char *tmp2 = *(const char **)p2;

--- a/sort.c
+++ b/sort.c
@@ -49,9 +49,11 @@ int iio_channel_compare(const void *p1, const void *p2)
 	if (iio_channel_is_scan_element(tmp1) && iio_channel_is_scan_element(tmp2)){
 		if (iio_channel_get_index(tmp1) > iio_channel_get_index(tmp2))
 			return 1;
-		return -1;
+		if (iio_channel_get_index(tmp1) < iio_channel_get_index(tmp2))
+			return -1;
+		/* if the index is the same, fall through to ID */
 	}
-	/* otherwise, if the ID is the same, input channels first */
+	/* if the ID is the same, input channels first */
 	if (strcmp(tmp1->id, tmp2->id) == 0)
 		return !iio_channel_is_output(tmp1);
 

--- a/sort.h
+++ b/sort.h
@@ -19,10 +19,10 @@
 #ifndef __IIO_QSORT_H__
 #define __IIO_QSORT_H__
 
-int qsort_iio_channel(const void *p1, const void *p2);
-int qsort_iio_channel_attr(const void *p1, const void *p2);
-int qsort_iio_device(const void *p1, const void *p2);
-int qsort_iio_device_attr(const void *p1, const void *p2);
-int qsort_iio_buffer_attr(const void *p1, const void *p2);
+int iio_channel_compare(const void *p1, const void *p2);
+int iio_channel_attr_compare(const void *p1, const void *p2);
+int iio_device_compare(const void *p1, const void *p2);
+int iio_device_attr_compare(const void *p1, const void *p2);
+int iio_buffer_attr_compare(const void *p1, const void *p2);
 
 #endif /* __IIO_QSORT_H__ */


### PR DESCRIPTION
- change functions names to more descriptive iio_*_compare
- move attribute sorting into context.c
- when sorting iio_channel, if index is the same, use ID
- fix whitespace issues that were accidently committed

Signed-off-by: Robin Getz <robin.getz@analog.com>