### PR TITLE
usb: Increase ctrl pipe timeout

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -150,7 +150,7 @@ static unsigned int usb_calculate_remote_timeout(unsigned int timeout)
 	return timeout / 2;
 }
 
-#define USB_PIPE_CTRL_TIMEOUT 200 /* These should not take long */
+#define USB_PIPE_CTRL_TIMEOUT 1000 /* These should not take long */
 
 #define IIO_USD_CMD_RESET_PIPES 0
 #define IIO_USD_CMD_OPEN_PIPE 1


### PR DESCRIPTION
Experimental testing shows that with the current timeout if the remote system
is under high load the timeout is triggered occasionally.

To mitigate this issue increase the timeout.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>