### PR TITLE
usb: add libusb version to context attributes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ endif()
 find_library(LIBUSB_LIBRARIES usb-1.0)
 find_path(LIBUSB_INCLUDE_DIR libusb-1.0/libusb.h)
 if (LIBUSB_LIBRARIES AND LIBUSB_INCLUDE_DIR)
+	message(STATUS "Looking for libusb-1.0 : Found")
 	option(WITH_USB_BACKEND "Enable the libusb backend" ON)
 
 	if(WITH_USB_BACKEND)
@@ -169,7 +170,16 @@ if (LIBUSB_LIBRARIES AND LIBUSB_INCLUDE_DIR)
 		set(NEED_THREADS 1)
 
 		include_directories(${LIBUSB_INCLUDE_DIR})
+
+		set(TEMP ${CMAKE_REQUIRED_LIBRARIES})
+		set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES}
+			 ${LIBUSB_LIBRARIES})
+		check_symbol_exists(libusb_get_version "libusb-1.0/libusb.h"
+			HAS_LIBUSB_GETVERSION)
+		set(CMAKE_REQUIRED_LIBRARIES ${TEMP})
 	endif()
+else()
+	message(STATUS "Looking for libusb-1.0 : Failed; building without usb")
 endif()
 
 find_library(LIBSERIALPORT_LIBRARIES serialport)

--- a/iio-config.h.cmakein
+++ b/iio-config.h.cmakein
@@ -26,5 +26,6 @@
 #cmakedefine HAVE_IPV6
 #cmakedefine HAVE_AVAHI
 #cmakedefine NO_THREADS
+#cmakedefine HAS_LIBUSB_GETVERSION
 
 #endif /* IIO_CONFIG_H */

--- a/usb.c
+++ b/usb.c
@@ -740,6 +740,22 @@ static int usb_populate_context_attrs(struct iio_context *ctx,
 		}
 	}
 
+#ifdef HAS_LIBUSB_GETVERSION
+	/*
+	 * libusb_get_version was added 2012-04-17: v1.0.10,
+	 * before LIBUSB_API_VERSION was added - Jan 8, 2014
+	 * so, you can't use that to determine if it is here
+	 */
+	{
+	struct libusb_version const *ver = libusb_get_version();
+	iio_snprintf(buffer, sizeof(buffer), "%i.%i.%i.%i%s",
+			ver->major, ver->minor, ver->micro,
+			ver->nano, ver->rc);
+	ret = iio_context_add_attr(ctx, "usb,libusb", buffer);
+	if (ret < 0)
+		return ret;
+	}
+#endif
 	return 0;
 }
 


### PR DESCRIPTION
When debugging, it's always nice to know the libusb version. This makes it easy to find.

Signed-off-by: Robin Getz <robin.getz@analog.com>