### PR TITLE
usb: be more verbose when unable to claim an interface

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -844,7 +844,8 @@ struct iio_context * usb_create_context(unsigned int bus,
 	ret = libusb_claim_interface(hdl, interface);
 	if (ret) {
 		ret = -(int) libusb_to_errno(ret);
-		ERROR("Unable to claim interface %u: %i\n", interface, ret);
+		ERROR("Unable to claim interface %u:%u:%u: %i\n",
+		      bus, address, interface, ret);
 		goto err_libusb_close;
 	}
 


### PR DESCRIPTION
This added the entire usb interface (bus and address) in the error message, which was not there.

Signed-off-by: Robin Getz <robin.getz@analog.com>