### PR TITLE
travis : Add the LDIST for centos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,12 @@ matrix:
       env:
         - OS_TYPE=centos
         - OS_VERSION=6
+        - LDIST=-centos6
     - os: linux
       env:
         - OS_TYPE=centos
         - OS_VERSION=7
+        - LDIST=-centos7
     - compiler: "gcc"
       os: osx
       osx_image: xcode6.4


### PR DESCRIPTION
Currenty - when travis-ci builds for centos, the LDIST is set to trusty, so things get deployed with the trusty namespace. Fix that.

Signed-off-by: Robin Getz <Robin.Getz@analog.com>