### PR TITLE
IIOD: Fix bug in mask bit tests (continued)

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -223,14 +223,14 @@ ssize_t iio_buffer_foreach_sample(struct iio_buffer *buffer,
 				break;
 
 			/* Test if the buffer has samples for this channel */
-			if (!TEST_BIT(buffer->mask, chn->index))
+			if (!TEST_BIT(buffer->mask, chn->number))
 				continue;
 
 			if ((ptr - start) % length)
 				ptr += length - ((ptr - start) % length);
 
 			/* Test if the client wants samples from this channel */
-			if (TEST_BIT(dev->mask, chn->index)) {
+			if (TEST_BIT(dev->mask, chn->number)) {
 				ssize_t ret = callback(chn,
 						(void *) ptr, length, d);
 				if (ret < 0)

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -362,7 +362,7 @@ static ssize_t send_sample(const struct iio_channel *chn,
 		void *src, size_t length, void *d)
 {
 	struct sample_cb_info *info = d;
-	if (chn->index < 0 || !TEST_BIT(info->mask, chn->index))
+	if (chn->index < 0 || !TEST_BIT(info->mask, chn->number))
 		return 0;
 	if (info->nb_bytes < length)
 		return 0;
@@ -389,7 +389,7 @@ static ssize_t receive_sample(const struct iio_channel *chn,
 		void *dst, size_t length, void *d)
 {
 	struct sample_cb_info *info = d;
-	if (chn->index < 0 || !TEST_BIT(info->mask, chn->index))
+	if (chn->index < 0 || !TEST_BIT(info->mask, chn->number))
 		return 0;
 	if (info->cpt == info->nb_bytes)
 		return 0;
@@ -560,7 +560,10 @@ static void rw_thd(struct thread_pool *pool, void *d)
 				struct iio_channel *chn = dev->channels[i];
 				long index = chn->index;
 
-				if (index >= 0 && TEST_BIT(entry->mask, i))
+				if (index < 0)
+					continue;
+
+				if (TEST_BIT(entry->mask, chn->number))
 					iio_channel_enable(chn);
 				else
 					iio_channel_disable(chn);


### PR DESCRIPTION
From: #198 

Previously, the index field of struct iio_channel was being used to test
against the buffer field of struct iio_device and struct iio_buffer.
This is incorrect because the index of the first channel may be non-zero
and the indexes may not be contiguous. For further evidence, look at
iio_channel_enable/disable() which use number rather than index.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>