### PR TITLE
local: pass errors up the stack

### DIFF
--- a/local.c
+++ b/local.c
@@ -425,7 +425,7 @@ static ssize_t local_enable_buffer(const struct iio_device *dev)
 			pdata->buffer_enabled = true;
 	}
 
-	return 0;
+	return ret;
 }
 
 static int local_set_kernel_buffers_count(const struct iio_device *dev,


### PR DESCRIPTION
When a enabling a buffer fails (in the case of triggered buffer not having a trigger set up), the error is currently ignored.

Ensure that errors are passed back up the stack for end user debugging.

Signed-off-by: Robin Getz <Robin.Getz@analog.com>