### PR TITLE
sorting: ensure sorting happens after global attributes are added

### DIFF
--- a/local.c
+++ b/local.c
@@ -1767,15 +1767,18 @@ static int create_device(void *d, const char *path)
 		free_protected_attrs(chn);
 		if (ret < 0)
 			goto err_free_scan_elements;
-
-		qsort(chn->attrs,  chn->nb_attrs, sizeof(struct iio_channel_attr),
-			iio_channel_attr_compare);
 	}
 
 	ret = detect_and_move_global_attrs(dev);
 	if (ret < 0)
 		goto err_free_device;
 
+	/* sorting is done after global attrs are added */
+	for (i = 0; i < dev->nb_channels; i++) {
+		struct iio_channel *chn = dev->channels[i];
+		qsort(chn->attrs,  chn->nb_attrs, sizeof(struct iio_channel_attr),
+			iio_channel_attr_compare);
+	}
 	qsort(dev->attrs, dev->nb_attrs, sizeof(char *),
 		iio_device_attr_compare);
 


### PR DESCRIPTION
If global attributes are added after sorting, they are not included
in the sort, which defeats the purpose of things. This puts things
in the proper order (add all the attributes, then sort them).

Signed-off-by: Robin Getz <robin.getz@analog.com>