### PR TITLE
travis-ci: add build for Ubuntu 18.04 and drop Ubuntu 12.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,10 @@ matrix:
       env:
         - OS_TYPE=centos
         - OS_VERSION=7
+    - os: linux
+      env:
+        - OS_TYPE=ubuntu_docker
+        - OS_VERSION=bionic
     - compiler: "gcc"
       os: osx
       osx_image: xcode6.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,6 @@ matrix:
       env: LDIST=DO_NOT_DEPLOY
     - compiler: "gcc"
       os: linux
-      dist: precise
-    - compiler: "gcc"
-      os: linux
       dist: trusty
     - compiler: "gcc"
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,9 +58,6 @@ matrix:
         - OS_VERSION=bionic
     - compiler: "gcc"
       os: osx
-      osx_image: xcode6.4
-    - compiler: "gcc"
-      os: osx
       osx_image: xcode7.3
     - compiler: "gcc"
       os: osx

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -11,9 +11,16 @@ handle_centos() {
 	sudo docker pull centos:centos${OS_VERSION}
 }
 
+handle_ubuntu_docker() {
+	sudo apt-get -qq update
+	sudo service docker restart
+	sleep 5
+	sudo docker pull ubuntu:${OS_VERSION}
+}
+
 handle_default() {
 	sudo apt-get -qq update
-	sudo apt-get install -y cmake doxygen libaio-dev libavahi-client-dev libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar bzip2 gzip
+	sudo apt-get install -y cmake doxygen libaio-dev libavahi-client-dev libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar bzip2 gzip flex bison git
 	if [ `sudo apt-cache search libserialport-dev | wc -l` -gt 0 ] ; then
 		sudo apt-get install -y libserialport-dev
 	fi

--- a/CI/travis/inside_bionic_docker.sh
+++ b/CI/travis/inside_bionic_docker.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -xe
+
+TRAVIS_CI="$1"
+
+apt-get -qq update
+apt-get -y install sudo
+
+source /libiio/CI/travis/before_install_linux default
+
+# Check we're in Travis-CI; the only place where this context is valid
+# It makes sure, users won't shoot themselves in the foot while running this script
+if [ "$TRAVIS_CI" == "travis-ci" ] ; then
+	mkdir -p /libiio/build
+	cd /libiio/build
+else
+	mkdir -p build
+	cd build
+fi
+
+cmake -DENABLE_PACKAGING=ON -DDEB_DETECT_DEPENDENCIES=ON ..
+make
+make package
+
+dpkg -i libiio*.deb
+# need to find this out inside the container
+. /libiio/CI/travis/get_ldist
+echo "$(get_ldist)" > /libiio/build/.LDIST

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -16,6 +16,13 @@ handle_centos() {
 		/bin/bash -xe /libiio/CI/travis/inside_centos_docker.sh ${OS_VERSION} travis-ci
 }
 
+handle_ubuntu_docker() {
+	sudo docker run --rm=true \
+		-v `pwd`:/libiio:rw \
+		ubuntu:${OS_VERSION} \
+		/bin/bash -xe /libiio/CI/travis/inside_bionic_docker.sh travis-ci
+}
+
 OS_TYPE=${1:-default}
 OS_VERSION="$2"
 

--- a/cmake/LinuxPackaging.cmake
+++ b/cmake/LinuxPackaging.cmake
@@ -48,6 +48,9 @@ if(DEB_DETECT_DEPENDENCIES AND DPKG_CMD AND DPKGQ_CMD)
 	if(WITH_XML_BACKEND)
 		set(PACKAGES "${PACKAGES} libxml2")
 	endif()
+	if(WITH_SERIAL_BACKEND)
+		set(PACKAGES "${PACKAGES} libserialport0")
+	endif()
 	# find the version of the installed package, which is hard to do in
 	# cmake first, turn the list into an list (seperated by semicolons)
 	string(REGEX REPLACE " " ";" PACKAGES ${PACKAGES})
@@ -100,7 +103,7 @@ if(DEB_DETECT_DEPENDENCIES AND DPKG_CMD AND DPKGQ_CMD)
 		${CPACK_DEBIAN_PACKAGE_DEPENDS})
 else()
 	# assume everything is turned on, and running on a modern OS
-	set(CPACK_DEBIAN_PACKAGE_DEPENDS "libaio (>= 0.3.109), libavahi-client (>= 0.6.31), libavahi-common (>= 0.6.31), libc6 (>= 2.19), libusb-1.0-0 (>= 2:1.0.17), libxml2 (>= 2.9.1)")
+	set(CPACK_DEBIAN_PACKAGE_DEPENDS "libaio (>= 0.3.109), libavahi-client (>= 0.6.31), libavahi-common (>= 0.6.31), libc6 (>= 2.19), libusb-1.0-0 (>= 2:1.0.17), libxml2 (>= 2.9.1), libserialport0 (>=0.1.1)")
 	message(STATUS "Using default dependencies for packaging")
 endif()
 


### PR DESCRIPTION
- Add a docker build for Ubuntu 18.04.1 LTS (Bionic Beaver) : EOL April 2023.
- Ubuntu 12.04.5 LTS reached its regular End of Life on April 28, 2017 so we should remove the corresponding Travis CI build. 
- Builds with Xcode 6.4 in Travis CI are deprecated and will be removed in January 2019, so we can remove the Xcode 6.4 builds from Travis CI.


Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>