### PR TITLE
fix snprintf warnings from gcc 8

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -190,7 +190,7 @@ static char *get_attr_xml(struct iio_channel_attr *attr, size_t *length)
 
 static char * get_scan_element(const struct iio_channel *chn, size_t *length)
 {
-	char buf[1024], repeat[8] = "", *str;
+	char buf[1024], repeat[12] = "", *str;
 	char processed = (chn->format.is_fully_defined ? 'A' - 'a' : 0);
 
 	if (chn->format.repeat > 1)

--- a/tests/iio_attr.c
+++ b/tests/iio_attr.c
@@ -644,7 +644,7 @@ int main(int argc, char **argv)
 						const struct iio_data_format *format =
 							iio_channel_get_data_format(ch);
 						char sign = format->is_signed ? 's' : 'u';
-						char repeat[8] = "";
+						char repeat[12] = "";
 
 						if (format->is_fully_defined)
 							sign += 'A' - 'a';

--- a/tests/iio_info.c
+++ b/tests/iio_info.c
@@ -324,7 +324,7 @@ int main(int argc, char **argv)
 				const struct iio_data_format *format =
 					iio_channel_get_data_format(ch);
 				char sign = format->is_signed ? 's' : 'u';
-				char repeat[8] = "";
+				char repeat[12] = "";
 
 				if (format->is_fully_defined)
 					sign += 'A' - 'a';


### PR DESCRIPTION
In recent versions of gcc, there are a few places where gcc warns:
iio_info.c: In function ‘main’:
iio_info.c:333:41: warning: ‘%u’ directive output may be truncated writing between 1 and 10 bytes into a region of size 7 [-Wformat-truncation=]
      snprintf(repeat, sizeof(repeat), "X%u",
                                         ^~
This fixes the warn by increasing the size of the buffer to 12 from 8.
No functional differences.

Signed-off-by: Robin Getz <robin.getz@analog.com>