### PR TITLE
deployment : export the LDIST var which is needed in other scripts

### DIFF
--- a/CI/travis/before_deploy
+++ b/CI/travis/before_deploy
@@ -19,11 +19,11 @@ fi
 pwd
 
 if [ -z "${LDIST}" -a -f "build/.LDIST" ] ; then
-	LDIST="-$(cat build/.LDIST)"
+	export LDIST="-$(cat build/.LDIST)"
 fi
 if [ -z "${LDIST}" ] ; then
 	. CI/travis/get_ldist
-	LDIST="-$(get_ldist)"
+	export LDIST="-$(get_ldist)"
 fi
 
 check_file()


### PR DESCRIPTION
properly export the var LDIST, so it can be used in other deployment scripts,
like ./CI/travis/deploy

Signed-off-by: Robin Getz <robin.getz@analog.com>