### PR TITLE
appveyor: install graphviz

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,8 +42,11 @@ build_script:
     - C:\msys64\usr\bin\bash -lc "rm /mingw32/etc/gdbinit"
     # Newer llvm breaks doxygen, use old version for now
     - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm http://repo.msys2.org/mingw/i686/mingw-w64-i686-llvm-5.0.0-3-any.pkg.tar.xz http://repo.msys2.org/mingw/i686/mingw-w64-i686-clang-5.0.0-3-any.pkg.tar.xz"
-    - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy  mingw-w64-i686-gcc mingw-w64-i686-libusb mingw-w64-i686-cmake mingw-w64-i686-libxml2 mingw-w64-i686-pkg-config mingw-w64-i686-libzip mingw-w64-i686-doxygen"
-    - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm http://repo.msys2.org/mingw/i686/mingw-w64-i686-curl-7.61.1-2-any.pkg.tar.xz "
+    # set the specific version of doxygen (06-Jun-2018), need to look at this later.
+    - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm http://repo.msys2.org/mingw/i686/mingw-w64-i686-doxygen-1.8.14-2-any.pkg.tar.xz"
+    - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm http://repo.msys2.org/mingw/i686/mingw-w64-i686-graphviz-2.40.1-4-any.pkg.tar.xz"
+    - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy  mingw-w64-i686-gcc mingw-w64-i686-libusb mingw-w64-i686-cmake mingw-w64-i686-libxml2 mingw-w64-i686-pkg-config mingw-w64-i686-libzip"
+    - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm http://repo.msys2.org/mingw/i686/mingw-w64-i686-curl-7.61.1-2-any.pkg.tar.xz"
     # Download a 32-bit version of windres.exe
     - appveyor DownloadFile http://swdownloads.analog.com/cse/build/windres.exe.gz -FileName C:\windres.exe.gz
     - C:\msys64\usr\bin\bash -lc "cd /c ; gunzip windres.exe.gz"
@@ -60,7 +63,10 @@ build_script:
     - C:\msys64\usr\bin\bash -lc "rm /mingw64/etc/gdbinit"
     # Newer llvm breaks doxygen, use old version for now
     - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-llvm-5.0.0-3-any.pkg.tar.xz http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-clang-5.0.0-3-any.pkg.tar.xz"
-    - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy  mingw-w64-x86_64-gcc mingw-w64-x86_64-libusb mingw-w64-x86_64-cmake mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pkg-config mingw-w64-x86_64-libzip mingw-w64-x86_64-doxygen"
+    # set the specific version of doxygen, need to look at this later.
+    - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-doxygen-1.8.14-2-any.pkg.tar.xz"
+    - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-graphviz-2.40.1-4-any.pkg.tar.xz"
+    - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy  mingw-w64-x86_64-gcc mingw-w64-x86_64-libusb mingw-w64-x86_64-cmake mingw-w64-x86_64-libxml2 mingw-w64-x86_64-pkg-config mingw-w64-x86_64-libzip"
     - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-curl-7.61.1-2-any.pkg.tar.xz"
     - C:\msys64\usr\bin\bash -lc "cmake -G '%GENERATOR%' -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=/mingw64 -DCMAKE_C_COMPILER:FILEPATH=/mingw64/bin/x86_64-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER:FILEPATH=/mingw64/bin/x86_64-w64-mingw32-g++.exe -DCSHARP_BINDINGS:BOOL=OFF -DPKG_CONFIG_EXECUTABLE:FILEPATH=/mingw64/bin/pkg-config.exe -DENABLE_IPV6:BOOL=OFF -DPYTHON_BINDINGS:BOOL=OFF -DLIBSERIALPORT_LIBRARIES=/c/libs/64/libserialport.dll.a -DLIBSERIALPORT_INCLUDE_DIR=/c/include /c/projects/libiio && make -j3"
 


### PR DESCRIPTION
For some reason, cmake in appveyor is failing since it can't find dot; so install it.

Signed-off-by: Robin Getz <robin.getz@analog.com>