### PR TITLE
build: trigger libad9361-iio build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,9 @@ matrix:
       osx_image: xcode10.1
       env:
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
+    - os: linux
+      env:
+        - TRIGGER_NEXT_BUILD=true
 
 addons:
   artifacts: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,3 +133,5 @@ deploy:
     on:
       condition: "$TRAVIS_OS_NAME = osx"
       all_branches: true
+after_deploy:
+  - ${TRAVIS_BUILD_DIR}/CI/travis/after_deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,10 +95,6 @@ notifications:
 
 before_deploy:
   - . ${TRAVIS_BUILD_DIR}/CI/travis/before_deploy
-  - openssl aes-256-cbc -K $encrypted_48a720578612_key -iv $encrypted_48a720578612_iv -in ${TRAVIS_BUILD_DIR}/CI/travis/deploy.rsa.enc -out /tmp/deploy.rsa -d
-  - eval "$(ssh-agent -s)"
-  - chmod 600 /tmp/deploy.rsa
-  - ssh-add /tmp/deploy.rsa
 deploy:
   - provider: releases
     api_key:

--- a/CI/travis/after_deploy
+++ b/CI/travis/after_deploy
@@ -1,5 +1,7 @@
 #!/bin/bash -xe
 
+[ "$TRIGGER_NEXT_BUILD" == "true" ] || exit 0
+
 # These Travis-CI vars have to be non-empty
 [ -n "$TRAVIS_PULL_REQUEST" ] || exit 0
 [ -n "$TRAVIS_BRANCH" ] || exit 0
@@ -29,6 +31,23 @@ pipeline_branch() {
 
 # Check if it's a pipeline branch; exit otherwise
 pipeline_branch "$TRAVIS_BRANCH" || exit 0
+
+WAIT_TIME=20 # minutes :(
+
+# Sigh... poll for 20 minutes here...
+# Alright: some explanation:
+#   There is no clean way in Travis-CI to get a status for
+#   when all the jobs finish; there is an alternative to using
+#   build stages, but that would take 2-10 days of development
+#   and testing to get right. We know that the longest running job
+#   takes ~16-18 minutes, so we add a new job that just waits.
+#   Piggy-backing on that slow job would be an idea, but it's not very
+#   future proof, because
+for it in $(seq 1 20) ; do
+	let left='WAIT_TIME - it'
+	echo "$it. Waiting 20 minutes: ${left} minutes left"
+	sleep 60
+done
 
 body="{
 	\"request\": {

--- a/CI/travis/after_deploy
+++ b/CI/travis/after_deploy
@@ -1,0 +1,46 @@
+#!/bin/bash -xe
+
+# These Travis-CI vars have to be non-empty
+[ -n "$TRAVIS_PULL_REQUEST" ] || exit 0
+[ -n "$TRAVIS_BRANCH" ] || exit 0
+[ -n "$ADI_TRAVIS_CI_LIBIIO_TOKEN" ] || exit 0
+
+# Has to be a non-pull-request
+[ "$TRAVIS_PULL_REQUEST" == "false" ] || exit 0
+
+pipeline_branch() {
+	local branch=$1
+
+	# master is a always a pipeline branch
+	[ "$branch" == "master" ] && return 0
+
+	# Check if branch name is 20XX_RY where:
+	#   XX - 14 to 99 /* wooh, that's a lot of years */
+	#   Y  - 1 to 9   /* wooh, that's a lot of releases per year */
+	for year in $(seq 2014 2099) ; do
+		for rel_num in $(seq 1 9) ; do
+			[ "$TRAVIS_BRANCH" == "${year}_R${rel_num}" ] && \
+				return 0
+		done
+	done
+
+	return 1
+}
+
+# Check if it's a pipeline branch; exit otherwise
+pipeline_branch "$TRAVIS_BRANCH" || exit 0
+
+body="{
+	\"request\": {
+		\"branch\":\"$TRAVIS_BRANCH\"
+	}
+}"
+
+curl -s -X POST \
+	-H "Content-Type: application/json" \
+	-H "Accept: application/json" \
+	-H "Travis-API-Version: 3" \
+	-H "Authorization: token $ADI_TRAVIS_CI_LIBIIO_TOKEN" \
+	-d "$body" \
+	https://api.travis-ci.org/repo/analogdevicesinc%2Flibad9361-iio/requests
+

--- a/CI/travis/before_deploy
+++ b/CI/travis/before_deploy
@@ -3,6 +3,13 @@
 # Don't prepare a deploy on a Coverity build
 if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 
+if [ -n "${encrypted_48a720578612_key}${encrypted_48a720578612_iv}" ] ; then
+	openssl aes-256-cbc -K $encrypted_48a720578612_key -iv $encrypted_48a720578612_iv -in ${TRAVIS_BUILD_DIR}/CI/travis/deploy.rsa.enc -out /tmp/deploy.rsa -d
+	eval "$(ssh-agent -s)"
+	chmod 600 /tmp/deploy.rsa
+	ssh-add /tmp/deploy.rsa
+fi
+
 deploy=0
 if [ -z "$TRAVIS_BUILD_DIR" ] ; then
 	t=$(find ./ -name CMakeCache.txt|head -1)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -149,3 +149,5 @@ build_script:
     - copy c:\projects\libiio\CI\travis\zip.txt c:\%ARCHIVE_NAME%\README.txt
     - 7z a "c:\libiio.zip" c:\%ARCHIVE_NAME%
     - appveyor PushArtifact c:\libiio.zip
+after_deploy:
+    - curl -H "Authorization: Bearer $APPVEYOR_TOKEN" -H "Content-Type: application/json" https://ci.appveyor.com/api/roles


### PR DESCRIPTION
 Let's start a "pipeline", where the libiio build triggers a
`libad9361-iio`, which will trigger other builds as well.

We're getting to a point where the lack of automation is starting to hinder
us a bit and changing things in `libiio` are not visible along the way,
until it gets a bit late.

Note that this does not trigger appveyor yet.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>