### PR TITLE
CI/travis/get_ldist: move dpkg check in if check

### DIFF
--- a/CI/travis/get_ldist
+++ b/CI/travis/get_ldist
@@ -16,8 +16,7 @@ get_ldist() {
 			return 0
 		fi
 		. /etc/os-release
-		command dpkg --version >/dev/null 2>&1
-		if [ "$?" -ne 0 ] ; then
+		if ! command dpkg --version &> /dev/null ; then
 			echo $ID-$VERSION_ID-$(uname -m)
 		else
 			echo $ID-$VERSION_ID-$(dpkg --print-architecture)


### PR DESCRIPTION
This is simpler, and works well when enabling the `-e` (errexit) shell
option. Otherwise the shell exits when `command dpkg` returns a non-zero
exit code.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>