### PR TITLE
CI/travis/deploy: lib-ify the upload function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ env:
   # ENCRYPTED_xxx vars are used to check whether this build is deploying anything or not
   - ENCRYPTED_KEY=$encrypted_48a720578612_key
   - ENCRYPTED_IV=$encrypted_48a720578612_iv
-  - BRANCH_PULL=$TRAVIS_PULL_REQUEST_BRANCH
-  - PULL=$TRAVIS_PULL_REQUEST
-  - BRANCH=$TRAVIS_BRANCH
 
 services:
   - docker

--- a/CI/travis/deploy
+++ b/CI/travis/deploy
@@ -7,8 +7,8 @@ cd $TRAVIS_BUILD_DIR
 is_deployable_travis_ci_run || exit 0
 
 #    from                   to             suffix
-upload_file_to_swdownloads ${RELEASE_PKG_FILE_DEB} ${TARGET_DEB} .deb
-upload_file_to_swdownloads ${RELEASE_PKG_FILE_RPM} ${TARGET_RPM} .rpm
-upload_file_to_swdownloads ${RELEASE_PKG_FILE_TGZ} ${TARGET_TGZ} .tar.gz
-upload_file_to_swdownloads ${RELEASE_PKG_FILE_PKG} ${TARGET_PKG} .pkg
+upload_file_to_swdownloads libiio ${RELEASE_PKG_FILE_DEB} ${TARGET_DEB} .deb
+upload_file_to_swdownloads libiio ${RELEASE_PKG_FILE_RPM} ${TARGET_RPM} .rpm
+upload_file_to_swdownloads libiio ${RELEASE_PKG_FILE_TGZ} ${TARGET_TGZ} .tar.gz
+upload_file_to_swdownloads libiio ${RELEASE_PKG_FILE_PKG} ${TARGET_PKG} .pkg
 

--- a/CI/travis/deploy
+++ b/CI/travis/deploy
@@ -6,69 +6,9 @@ cd $TRAVIS_BUILD_DIR
 
 is_deployable_travis_ci_run || exit 0
 
-send()
-{
-if [ "$#" -ne 3 ] ; then
-	echo "skipping deployment of something"
-        echo "send called with $@"
-	return
-fi
-
-if [ "x$1" = "x" ] ; then
-	echo no file to send
-	return
-fi
-
-if [ ! -r "$1" ] ; then
-	echo "file $1 is not readable"
-	ls -l $1
-	return
-fi
-
-if [ $BRANCH_PULL ] ; then
-	branch=$BRANCH_PULL
-else
-	branch=$BRANCH
-fi
-
-FROM=$1
-TO=${branch}_$2
-LATE=${branch}_latest_libiio${LDIST}$3
-GLOB=${DEPLOY_TO}/${branch}_libiio-*
-
-echo attemting to deploy $FROM to $TO
-echo and ${branch}_libiio${LDIST}$3
-ssh -V
-
-echo "cd ${DEPLOY_TO}" > script$3
-if curl -m 10 -s -I -f -o /dev/null http://swdownloads.analog.com/cse/travis_builds/${TO} ; then
-	echo "rm ${TO}" >> script$3
-fi
-echo "put ${FROM} ${TO}" >> script$3
-echo "ls -l ${TO}" >> script$3
-if curl -m 10 -s -I -f -o /dev/null http://swdownloads.analog.com/cse/travis_builds/${LATE} ; then
-	echo "rm ${LATE}" >> script$3
-fi
-echo "symlink ${TO} ${LATE}" >> script$3
-echo "ls -l ${LATE}" >> script$3
-echo "bye" >> script$3
-
-sftp ${EXTRA_SSH} -b script$3 ${SSHUSER}@${SSHHOST}
-
-# limit things to a few files, so things don't grow forever
-if [ "$3" = ".deb" ] ; then
-	for files in $(ssh ${EXTRA_SSH} ${SSHUSER}@${SSHHOST} \
-		"ls -lt ${GLOB}" | tail -n +100 | awk '{print $NF}')
-	do
-		ssh ${EXTRA_SSH} ${SSHUSER}@${SSHHOST} \
-			"rm ${DEPLOY_TO}/${files}"
-	done
-fi
-}
-
 #    from                   to             suffix
-send ${RELEASE_PKG_FILE_DEB} ${TARGET_DEB} .deb
-send ${RELEASE_PKG_FILE_RPM} ${TARGET_RPM} .rpm
-send ${RELEASE_PKG_FILE_TGZ} ${TARGET_TGZ} .tar.gz
-send ${RELEASE_PKG_FILE_PKG} ${TARGET_PKG} .pkg
+upload_file_to_swdownloads ${RELEASE_PKG_FILE_DEB} ${TARGET_DEB} .deb
+upload_file_to_swdownloads ${RELEASE_PKG_FILE_RPM} ${TARGET_RPM} .rpm
+upload_file_to_swdownloads ${RELEASE_PKG_FILE_TGZ} ${TARGET_TGZ} .tar.gz
+upload_file_to_swdownloads ${RELEASE_PKG_FILE_PKG} ${TARGET_PKG} .pkg
 

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -55,3 +55,68 @@ brew_install_or_upgrade() {
 		shift
 	done
 }
+
+upload_file_to_swdownloads() {
+	if [ "$#" -ne 3 ] ; then
+		echo "skipping deployment of something"
+		echo "send called with $@"
+		return 1
+	fi
+
+	if [ "x$1" = "x" ] ; then
+		echo no file to send
+		return 1
+	fi
+
+	if [ ! -r "$1" ] ; then
+		echo "file $1 is not readable"
+		ls -l $1
+		return 1
+	fi
+
+	if [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ] ; then
+		local branch=$TRAVIS_PULL_REQUEST_BRANCH
+	else
+		local branch=$TRAVIS_BRANCH
+	fi
+
+	# Temporarily disable tracing from here
+	set +x
+
+	local FROM=$1
+	local TO=${branch}_$2
+	local LATE=${branch}_latest_libiio${LDIST}$3
+	local GLOB=${DEPLOY_TO}/${branch}_libiio-*
+
+	echo attemting to deploy $FROM to $TO
+	echo and ${branch}_libiio${LDIST}$3
+	ssh -V
+
+	echo "cd ${DEPLOY_TO}" > script$3
+	if curl -m 10 -s -I -f -o /dev/null http://swdownloads.analog.com/cse/travis_builds/${TO} ; then
+		echo "rm ${TO}" >> script$3
+	fi
+	echo "put ${FROM} ${TO}" >> script$3
+	echo "ls -l ${TO}" >> script$3
+	if curl -m 10 -s -I -f -o /dev/null http://swdownloads.analog.com/cse/travis_builds/${LATE} ; then
+		echo "rm ${LATE}" >> script$3
+	fi
+	echo "symlink ${TO} ${LATE}" >> script$3
+	echo "ls -l ${LATE}" >> script$3
+	echo "bye" >> script$3
+
+	sftp ${EXTRA_SSH} -b script$3 ${SSHUSER}@${SSHHOST}
+
+	# limit things to a few files, so things don't grow forever
+	if [ "$3" = ".deb" ] ; then
+		for files in $(ssh ${EXTRA_SSH} ${SSHUSER}@${SSHHOST} \
+			"ls -lt ${GLOB}" | tail -n +100 | awk '{print $NF}')
+		do
+			ssh ${EXTRA_SSH} ${SSHUSER}@${SSHHOST} \
+				"rm ${DEPLOY_TO}/${files}"
+		done
+	fi
+
+	# Re-enable tracing
+	set -x
+}

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -57,7 +57,7 @@ brew_install_or_upgrade() {
 }
 
 upload_file_to_swdownloads() {
-	if [ "$#" -ne 3 ] ; then
+	if [ "$#" -ne 4 ] ; then
 		echo "skipping deployment of something"
 		echo "send called with $@"
 		return 1
@@ -83,13 +83,14 @@ upload_file_to_swdownloads() {
 	# Temporarily disable tracing from here
 	set +x
 
-	local FROM=$1
-	local FNAME=$2
-	local EXT=$3
+	local LIBNAME=$1
+	local FROM=$2
+	local FNAME=$3
+	local EXT=$4
 
 	local TO=${branch}_${FNAME}
-	local LATE=${branch}_latest_libiio${LDIST}${EXT}
-	local GLOB=${DEPLOY_TO}/${branch}_libiio-*
+	local LATE=${branch}_latest_${LIBNAME}${LDIST}${EXT}
+	local GLOB=${DEPLOY_TO}/${branch}_${LIBNAME}-*
 
 	if curl -m 10 -s -I -f -o /dev/null http://swdownloads.analog.com/cse/travis_builds/${TO} ; then
 		local RM_TO="rm ${TO}"
@@ -100,7 +101,7 @@ upload_file_to_swdownloads() {
 	fi
 
 	echo attemting to deploy $FROM to $TO
-	echo and ${branch}_libiio${LDIST}${EXT}
+	echo and ${branch}_${LIBNAME}${LDIST}${EXT}
 	ssh -V
 
 	mkdir -p build


### PR DESCRIPTION
The `send()` function is 90-99% re-usable for uploading artifacts, and cleaning them.
The cleaning up part, will need some work, but the first step is to make it a library-type function.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>