### PR TITLE
Revert ".travis.yml: move SSH key logic into shell script from yaml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,10 @@ notifications:
 
 before_deploy:
   - . ${TRAVIS_BUILD_DIR}/CI/travis/before_deploy
-
+  - openssl aes-256-cbc -K $encrypted_48a720578612_key -iv $encrypted_48a720578612_iv -in ${TRAVIS_BUILD_DIR}/CI/travis/deploy.rsa.enc -out /tmp/deploy.rsa -d
+  - eval "$(ssh-agent -s)"
+  - chmod 600 /tmp/deploy.rsa
+  - ssh-add /tmp/deploy.rsa
 deploy:
   - provider: releases
     api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ env:
   - secure: "bYHqhcYYuSbciQa5mBqMxs3CbJkrxxD7/G4zDW2war1IcMh8AC/KPeoYIuhd/L2Mg9+tP++xCznKUJzX85Hu+8EyrMGkC/6zWpGYgyO27DH7wl+9AJjR191WJKkg+S6OqZmb/5v0rdJMDnGOZHrRVB3Vec9dBT+jDTQbyxrckxE="
   # DEPLOY_TO directory
   - secure: "PMp93w9HAYd0pR4aw2LT1sMIVmA06f01Xq2jaGW2iy74n3GrqBYe7H9aMR0WD1S6KH9sFydqFI11bCpwUQXPopl+8MPA34AS7V2gaxDUdE+UZnKKXpKV6KRPRp/txlryuEGspjFJM0bo5g1H5lPBSBFj8PB1Bf6BiloGl8TTuiY="
-  # ENCRYPTED_xxx vars are used to check whether this build is deploying anything or not
-  - ENCRYPTED_KEY=$encrypted_48a720578612_key
-  - ENCRYPTED_IV=$encrypted_48a720578612_iv
   - BRANCH_PULL=$TRAVIS_PULL_REQUEST_BRANCH
   - PULL=$TRAVIS_PULL_REQUEST
   - BRANCH=$TRAVIS_BRANCH

--- a/CI/travis/before_deploy
+++ b/CI/travis/before_deploy
@@ -2,7 +2,8 @@
 
 . CI/travis/lib.sh
 
-is_deployable_travis_ci_run || exit 0
+# Don't prepare a deploy on a Coverity build
+if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 
 deploy=0
 if [ -z "$TRAVIS_BUILD_DIR" ] ; then

--- a/CI/travis/before_deploy
+++ b/CI/travis/before_deploy
@@ -4,11 +4,6 @@
 
 is_deployable_travis_ci_run || exit 0
 
-openssl aes-256-cbc -K $encrypted_48a720578612_key -iv $encrypted_48a720578612_iv -in ${TRAVIS_BUILD_DIR}/CI/travis/deploy.rsa.enc -out /tmp/deploy.rsa -d
-eval "$(ssh-agent -s)"
-chmod 600 /tmp/deploy.rsa
-ssh-add /tmp/deploy.rsa
-
 deploy=0
 if [ -z "$TRAVIS_BUILD_DIR" ] ; then
 	t=$(find ./ -name CMakeCache.txt|head -1)

--- a/CI/travis/deploy
+++ b/CI/travis/deploy
@@ -2,10 +2,6 @@
 
 cd $TRAVIS_BUILD_DIR
 
-. CI/travis/lib.sh
-
-is_deployable_travis_ci_run || exit 0
-
 send()
 {
 if [ "$#" -ne 3 ] ; then

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -1,14 +1,5 @@
 #!/bin/sh -xe
 
-is_deployable_travis_ci_run() {
-	# Don't deploy on a Coverity build
-	[ -z "${COVERITY_SCAN_PROJECT_NAME}" ] || return 1
-
-	# If we don't have SSH keys, don't bother
-	[ -n "${ENCRYPTED_KEY}" ] || return 1
-	[ -n "${ENCRYPTED_IV}" ] || return 1
-}
-
 get_ldist() {
 	case "$(uname)" in
 	Linux*)


### PR DESCRIPTION
These patches sexpose a security risk, by potentially displaying secret
information in the logs.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>