### PR TITLE
.travis.yml,CI/travis/after_deploy: trigger other builds after libiio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,3 +139,6 @@ deploy:
     on:
       condition: "$TRAVIS_OS_NAME = osx"
       all_branches: true
+
+after_deploy:
+  - ${TRAVIS_BUILD_DIR}/CI/travis/after_deploy

--- a/CI/travis/after_deploy
+++ b/CI/travis/after_deploy
@@ -1,0 +1,7 @@
+#!/bin/sh -xe
+
+. CI/travis/lib.sh
+
+should_trigger_next_builds "$TRAVIS_BRANCH" || exit 0
+
+trigger_adi_build "libad9361-iio" "$TRAVIS_BRANCH"

--- a/CI/travis/jobs_running_cnt.py
+++ b/CI/travis/jobs_running_cnt.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+
+import os
+import sys
+import urllib2
+import json
+
+# This is pretty constant, but allow it to be overriden via env-var
+url = os.getenv('TRAVIS_API_URL', 'https://api.travis-ci.org')
+
+if (not url.lower().startswith("https://")):
+    print (0)
+    sys.exit(0)
+
+ci_token = os.getenv('TRAVIS_API_TOKEN')
+build_id = os.getenv('TRAVIS_BUILD_ID')
+
+headers = {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+    'Travis-API-Version': "3",
+    'Authorization': "token {0}".format(ci_token)
+}
+
+# Codacy's bandit linter may complain that we haven't validated
+# this URL for permitted schemes; we have validated this a few lines above
+req = urllib2.Request("{0}/build/{1}/jobs".format(url, build_id),
+		      headers=headers)
+
+response = urllib2.urlopen(req).read()
+json_r = json.loads(response.decode('utf-8'))
+
+jobs_running = 0
+for job in json_r['jobs']:
+    if (job['state'] == 'started'):
+        jobs_running += 1
+
+print (jobs_running)

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -1,5 +1,96 @@
 #!/bin/sh -xe
 
+export TRAVIS_API_URL="https://api.travis-ci.org"
+
+pipeline_branch() {
+	local branch=$1
+
+	[ -n "$branch" ] || return 1
+
+	# master is a always a pipeline branch
+	[ "$branch" = "master" ] && return 0
+
+	# Turn off tracing for a while ; log can fill up here
+	set +x
+	# Check if branch name is 20XX_RY where:
+	#   XX - 14 to 99 /* wooh, that's a lot of years */
+	#   Y  - 1 to 9   /* wooh, that's a lot of releases per year */
+	for year in $(seq 2014 2099) ; do
+		for rel_num in $(seq 1 9) ; do
+			[ "$branch" = "${year}_R${rel_num}" ] && \
+				return 0
+		done
+	done
+	set -x
+
+	return 1
+}
+
+should_trigger_next_builds() {
+	local branch="$1"
+
+	[ -z "${COVERITY_SCAN_PROJECT_NAME}"] || return 1
+
+	# These Travis-CI vars have to be non-empty
+	[ -n "$TRAVIS_PULL_REQUEST" ] || return 1
+	[ -n "$branch" ] || return 1
+	set +x
+	[ -n "$TRAVIS_API_TOKEN" ] || return 1
+	set -x
+
+	# Has to be a non-pull-request
+	[ "$TRAVIS_PULL_REQUEST" = "false" ] || return 1
+
+	pipeline_branch "$branch" || return 1
+
+	if [ -f CI/travis/jobs_running_cnt.py ] ; then
+		local python_script=CI/travis/jobs_running_cnt.py
+	elif [ -f build/jobs_running_cnt.py ] ; then
+		local python_script=build/jobs_running_cnt.py
+	else
+		echo "Could not find 'jobs_running_cnt.py'"
+		return 1
+	fi
+
+	local jobs_cnt=$(python $python_script)
+
+	# Trigger next job if we are the last job running
+	[ "$jobs_cnt" = "1" ]
+}
+
+trigger_build() {
+	local repo_slug="$1"
+	local branch="$2"
+
+	[ -n "$repo_slug" ] || return 1
+	[ -n "$branch" ] || return 1
+
+	local body="{
+		\"request\": {
+			\"branch\":\"$branch\"
+		}
+	}"
+
+	# Turn off tracing here (shortly)
+	set +x
+	curl -s -X POST \
+		-H "Content-Type: application/json" \
+		-H "Accept: application/json" \
+		-H "Travis-API-Version: 3" \
+		-H "Authorization: token $TRAVIS_API_TOKEN" \
+		-d "$body" \
+		https://api.travis-ci.org/repo/$repo_slug/requests
+	set -x
+}
+
+trigger_adi_build() {
+	local adi_repo="$1"
+	local branch="$2"
+
+	[ -n "$adi_repo" ] || return 1
+	trigger_build "analogdevicesinc%2F$adi_repo" "$branch"
+}
+
 get_ldist() {
 	case "$(uname)" in
 	Linux*)


### PR DESCRIPTION
Let's start a "pipeline", where the libiio build triggers a
`libad9361-iio`, which will trigger other builds as well.

We're getting to a point where the lack of automation is starting to hinder
us a bit and changing things in `libiio` are not visible along the way,
until it gets a bit late.

There's a Python script that each job would run, to check if it's the last
job (in the parallel CI run), and the last job, will trigger the next
build.
There's no better way at the moment to do this, without re-factoring the
entire `.travis.yml` file to work with build-stages (a new feature that's a
bit of work to get working properly with our current setup).

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>