### PR TITLE
CI/travis: cleanup docker & CentOS quirks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,11 @@ matrix:
         - secure: "OrwnYeUITY2R7pn11WHqsO7c6F9fRY7G5fOh98GGXnw7dAIoSvUhjUE70ehaBzLH0CyO83KgaiyACP8eqRx9BYUd1McrqTFDmYJNVR+Wk01SSjJxaXzU4RMsJPhXH9l5U7BEH5dVk/IFLLaCwYnc35mlADHE2KCGNanvtnRU0gU="
     - os: linux
       env:
-        - OS_TYPE=centos
+        - OS_TYPE=centos_docker
         - OS_VERSION=6
     - os: linux
       env:
-        - OS_TYPE=centos
+        - OS_TYPE=centos_docker
         - OS_VERSION=7
     - os: linux
       env:

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -1,6 +1,13 @@
 #!/bin/sh -xe
 
 handle_centos() {
+	# FIXME: see about adding `libserialport-dev` from EPEL ; maybe libusb-1.0.0-devel...
+	yum -y groupinstall 'Development Tools'
+	yum -y install cmake libxml2-devel libusb1-devel doxygen libaio-devel \
+		avahi-devel bzip2 gzip rpm rpm-build
+}
+
+handle_centos_docker() {
 	sudo apt-get -qq update
 	echo 'DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock -s devicemapper"' | sudo tee /etc/default/docker > /dev/null
 	sudo service docker restart

--- a/CI/travis/inside_bionic_docker.sh
+++ b/CI/travis/inside_bionic_docker.sh
@@ -1,24 +1,13 @@
 #!/bin/sh -xe
 
 LIBNAME="$1"
-TRAVIS_CI="$2"
 
-export TRAVIS_BUILD_DIR="/$LIBNAME"
+cd /$LIBNAME
 
 apt-get -qq update
 apt-get -y install sudo
 
 /$LIBNAME/CI/travis/before_install_linux default
-
-# Check we're in Travis-CI; the only place where this context is valid
-# It makes sure, users won't shoot themselves in the foot while running this script
-if [ "$TRAVIS_CI" == "travis-ci" ] ; then
-	mkdir -p /$LIBNAME/build
-	cd /$LIBNAME/build
-else
-	mkdir -p build
-	cd build
-fi
 
 /$LIBNAME/CI/travis/make_linux "$LIBNAME" default
 

--- a/CI/travis/inside_centos_docker.sh
+++ b/CI/travis/inside_centos_docker.sh
@@ -2,7 +2,8 @@
 
 LIBNAME="$1"
 OS_VERSION="$2"
-TRAVIS_CI="$3"
+
+cd /$LIBNAME
 
 # FIXME: see about adding `libserialport-dev` from EPEL ; maybe libusb-1.0.0-devel...
 yum -y groupinstall 'Development Tools'
@@ -11,9 +12,8 @@ yum -y install cmake libxml2-devel libusb1-devel doxygen libaio-devel \
 
 # FIXME: cmake in CentOS 7 is broken, so we need to patch it for now
 # Remove this when it's fixed; but make sure we're doing this in Travis-CI context
-if [ "$TRAVIS_CI" == "travis-ci" ] ; then
-	if [ "$OS_VERSION" == "7" ] ; then
-		patch -p1 <<-EOF
+if [ "$OS_VERSION" == "7" ] ; then
+	patch -p1 <<-EOF
 --- a/usr/share/cmake/Modules/CPackRPM.cmake
 +++ b/usr/share/cmake/Modules/CPackRPM.cmake
 @@ -703,7 +703,7 @@ if(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST)
@@ -25,18 +25,7 @@ if [ "$TRAVIS_CI" == "travis-ci" ] ; then
    endforeach()
  endif()
  if (CPACK_RPM_PACKAGE_DEBUG)
-		EOF
-	fi
-fi
-
-# Check we're in Travis-CI; the only place where this context is valid
-# It makes sure, users won't shoot themselves in the foot while running this script
-if [ "$TRAVIS_CI" == "travis-ci" ] ; then
-	mkdir -p /${LIBNAME}/build
-	cd /${LIBNAME}/build
-else
-	mkdir -p build
-	cd build
+	EOF
 fi
 
 cmake -DENABLE_PACKAGING=ON ..

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -7,7 +7,6 @@ handle_default() {
 	cd build
 	cmake -DENABLE_PACKAGING=ON -DDEB_DETECT_DEPENDENCIES=ON ..
 	make && make package
-	sudo dpkg -i ${LIBNAME}*.deb
 	if [ -n "${GH_DOC_TOKEN}" ] && \
 			[ -f "./generateDocumentationAndDeploy.sh" ] ; then
 		sh generateDocumentationAndDeploy.sh
@@ -16,6 +15,14 @@ handle_default() {
 }
 
 handle_centos() {
+	mkdir -p build
+	cd build
+	cmake -DENABLE_PACKAGING=ON ..
+	make && make package
+	cd ..
+}
+
+handle_centos_docker() {
 	sudo docker run --rm=true \
 		-v `pwd`:/${LIBNAME}:rw \
 		centos:centos${OS_VERSION} \

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -3,7 +3,8 @@
 if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 
 handle_default() {
-	cd $TRAVIS_BUILD_DIR/build
+	mkdir -p build
+	cd build
 	cmake -DENABLE_PACKAGING=ON -DDEB_DETECT_DEPENDENCIES=ON ..
 	make && make package
 	sudo dpkg -i ${LIBNAME}*.deb
@@ -11,20 +12,21 @@ handle_default() {
 			[ -f "./generateDocumentationAndDeploy.sh" ] ; then
 		sh generateDocumentationAndDeploy.sh
 	fi
+	cd ..
 }
 
 handle_centos() {
 	sudo docker run --rm=true \
 		-v `pwd`:/${LIBNAME}:rw \
 		centos:centos${OS_VERSION} \
-		/bin/bash -xe /${LIBNAME}/CI/travis/inside_centos_docker.sh ${LIBNAME} ${OS_VERSION} travis-ci
+		/bin/bash -xe /${LIBNAME}/CI/travis/inside_centos_docker.sh ${LIBNAME} ${OS_VERSION}
 }
 
 handle_ubuntu_docker() {
 	sudo docker run --rm=true \
 		-v `pwd`:/${LIBNAME}:rw \
 		ubuntu:${OS_VERSION} \
-		/bin/bash -xe /${LIBNAME}/CI/travis/inside_bionic_docker.sh ${LIBNAME} travis-ci
+		/bin/bash -xe /${LIBNAME}/CI/travis/inside_bionic_docker.sh ${LIBNAME}
 }
 
 LIBNAME="$1"


### PR DESCRIPTION
Some of the code added for the CentOS dockers and the Ubuntu Bionic docker looks a bit too quirky/workaround-y.

These changes remove some of those hacks, making the code pretty.

The end-goal here is re-usability, as some of this code is intended to run for `libad9361-iio` and other projects along the pipeline.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>