### PR TITLE
CI/travis: lib-ify docker logic

### DIFF
--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -1,5 +1,7 @@
 #!/bin/sh -xe
 
+. CI/travis/lib.sh
+
 handle_centos() {
 	# FIXME: see about adding `libserialport-dev` from EPEL ; maybe libusb-1.0.0-devel...
 	yum -y groupinstall 'Development Tools'
@@ -8,16 +10,11 @@ handle_centos() {
 }
 
 handle_centos_docker() {
-	sudo apt-get -qq update
-	echo 'DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock -s devicemapper"' | sudo tee /etc/default/docker > /dev/null
-	sudo service docker restart
-	sudo docker pull centos:centos${OS_VERSION}
+	prepare_docker_image "centos:centos${OS_VERSION}"
 }
 
 handle_ubuntu_docker() {
-	sudo apt-get -qq update
-	sudo service docker restart
-	sudo docker pull ubuntu:${OS_VERSION}
+	prepare_docker_image "ubuntu:${OS_VERSION}"
 }
 
 handle_default() {

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -2,6 +2,8 @@
 
 export TRAVIS_API_URL="https://api.travis-ci.org"
 
+COMMON_SCRIPTS="jobs_running_cnt.py inside_bionic_docker.sh inside_centos_docker.sh"
+
 get_script_path() {
 	local script="$1"
 
@@ -240,3 +242,13 @@ run_docker_script() {
 		$DOCKER_IMAGE \
 		/bin/bash -xe /${LIBNAME}/${DOCKER_SCRIPT} ${LIBNAME} ${OS_VERSION}
 }
+
+# Other scripts will download lib.sh [this script] and lib.sh will
+# in turn download the other scripts it needs.
+# This gives way more flexibility when changing things, as they propagate
+for script in $COMMON_SCRIPTS ; do
+	[ ! -f "CI/travis/$script" ] || continue
+	mkdir -p build
+	wget https://raw.githubusercontent.com/analogdevicesinc/libiio/master/CI/travis/$script \
+		-O build/$script
+done

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -221,3 +221,22 @@ upload_file_to_swdownloads() {
 
 	return 0
 }
+
+prepare_docker_image() {
+	local DOCKER_IMAGE="$1"
+	sudo apt-get -qq update
+	echo 'DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock -s devicemapper"' | sudo tee /etc/default/docker > /dev/null
+	sudo service docker restart
+	sudo docker pull "$DOCKER_IMAGE"
+}
+
+run_docker_script() {
+	local DOCKER_SCRIPT="$(get_script_path $1)"
+	local LIBNAME="$2"
+	local DOCKER_IMAGE="$3"
+	local OS_VERSION="$4"
+	sudo docker run --rm=true \
+		-v $(pwd):/${LIBNAME}:rw \
+		$DOCKER_IMAGE \
+		/bin/bash -xe /${LIBNAME}/${DOCKER_SCRIPT} ${LIBNAME} ${OS_VERSION}
+}

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -2,6 +2,20 @@
 
 export TRAVIS_API_URL="https://api.travis-ci.org"
 
+get_script_path() {
+	local script="$1"
+
+	[ -n "$script" ] || return 1
+
+	if [ -f "CI/travis/$script" ] ; then
+		echo "CI/travis/$script"
+	elif [ -f "build/$script" ] ; then
+		echo "build/$script"
+	else
+		return 1
+	fi
+}
+
 pipeline_branch() {
 	local branch=$1
 
@@ -43,11 +57,8 @@ should_trigger_next_builds() {
 
 	pipeline_branch "$branch" || return 1
 
-	if [ -f CI/travis/jobs_running_cnt.py ] ; then
-		local python_script=CI/travis/jobs_running_cnt.py
-	elif [ -f build/jobs_running_cnt.py ] ; then
-		local python_script=build/jobs_running_cnt.py
-	else
+	local python_script="$(get_script_path jobs_running_cnt.py)"
+	if [ -z "$python_script" ] ; then
 		echo "Could not find 'jobs_running_cnt.py'"
 		return 1
 	fi

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -2,6 +2,8 @@
 
 if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 
+. CI/travis/lib.sh
+
 handle_default() {
 	mkdir -p build
 	cd build
@@ -23,17 +25,13 @@ handle_centos() {
 }
 
 handle_centos_docker() {
-	sudo docker run --rm=true \
-		-v `pwd`:/${LIBNAME}:rw \
-		centos:centos${OS_VERSION} \
-		/bin/bash -xe /${LIBNAME}/CI/travis/inside_centos_docker.sh ${LIBNAME} ${OS_VERSION}
+	run_docker_script inside_centos_docker.sh \
+		"${LIBNAME}" "centos:centos${OS_VERSION}"
 }
 
 handle_ubuntu_docker() {
-	sudo docker run --rm=true \
-		-v `pwd`:/${LIBNAME}:rw \
-		ubuntu:${OS_VERSION} \
-		/bin/bash -xe /${LIBNAME}/CI/travis/inside_bionic_docker.sh ${LIBNAME}
+	run_docker_script inside_bionic_docker.sh \
+		"${LIBNAME}" "ubuntu:${OS_VERSION}"
 }
 
 LIBNAME="$1"


### PR DESCRIPTION
We want to re-use the docker logic in other repos (e.g. libad9361-iio).
We need to lib-ify that logic, since we won't download `make_linux` and
`before_install_linux` and similar files.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>