### PR TITLE
CI/travis/lib.sh: fix dangling quote in symlink command

### DIFF
--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -191,7 +191,7 @@ upload_file_to_swdownloads() {
 		ls -l ${TO}
 
 		${RM_LATE}
-		symlink ${TO} ${LATE}"
+		symlink ${TO} ${LATE}
 		ls -l ${LATE}
 		bye
 	EOF


### PR DESCRIPTION
This seems to have slipped through after doing a few rebases.
I've fixed it a few times on local branches.

The SFTP script did not error out, so that's why it wasn't caught there.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>