### PR TITLE
Revert "sort: when sorting iio_channels, if the index is the same, us…

### DIFF
--- a/sort.c
+++ b/sort.c
@@ -49,11 +49,9 @@ int iio_channel_compare(const void *p1, const void *p2)
 	if (iio_channel_is_scan_element(tmp1) && iio_channel_is_scan_element(tmp2)){
 		if (iio_channel_get_index(tmp1) > iio_channel_get_index(tmp2))
 			return 1;
-		if (iio_channel_get_index(tmp1) < iio_channel_get_index(tmp2))
-			return -1;
-		/* if the index is the same, fall through to ID */
+		return -1;
 	}
-	/* if the ID is the same, input channels first */
+	/* otherwise, if the ID is the same, input channels first */
 	if (strcmp(tmp1->id, tmp2->id) == 0)
 		return !iio_channel_is_output(tmp1);
 


### PR DESCRIPTION
…e ID"

This commit broke interop with previous versions of libiio, in certain scenarios.
The interoperability issue is only a problem in case all channels use the same index,
which is typically only the case with the bit mask channels used for logic analyzers.
This means v0.16 can’t interop with previous versions,
since channels are now sorted differently on the local and remote backend.

This reverts commit 67a994c973e68ddcf48c64ebaa0001c69966f6e8.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>