### PR TITLE
CI/travis/lib.sh: rework artifact removal via SFTP

### DIFF
--- a/CI/travis/after_deploy
+++ b/CI/travis/after_deploy
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 . CI/travis/lib.sh
 

--- a/CI/travis/before_deploy
+++ b/CI/travis/before_deploy
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 . CI/travis/lib.sh
 

--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 . CI/travis/lib.sh
 

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 . CI/travis/lib.sh
 

--- a/CI/travis/deploy
+++ b/CI/travis/deploy
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 . CI/travis/lib.sh
 

--- a/CI/travis/inside_docker.sh
+++ b/CI/travis/inside_docker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 LIBNAME="$1"
 OS_TYPE="$2"

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 export TRAVIS_API_URL="https://api.travis-ci.org"
 
@@ -32,7 +32,6 @@ pipeline_branch() {
 	# master is a always a pipeline branch
 	[ "$branch" = "master" ] && return 0
 
-	# Turn off tracing for a while ; log can fill up here
 	set +x
 	# Check if branch name is 20XX_RY where:
 	#   XX - 14 to 99 /* wooh, that's a lot of years */
@@ -43,7 +42,6 @@ pipeline_branch() {
 				return 0
 		done
 	done
-	set -x
 
 	return 1
 }
@@ -58,7 +56,6 @@ should_trigger_next_builds() {
 	[ -n "$branch" ] || return 1
 	set +x
 	[ -n "$TRAVIS_API_TOKEN" ] || return 1
-	set -x
 
 	# Has to be a non-pull-request
 	[ "$TRAVIS_PULL_REQUEST" = "false" ] || return 1
@@ -99,7 +96,6 @@ trigger_build() {
 		-H "Authorization: token $TRAVIS_API_TOKEN" \
 		-d "$body" \
 		https://api.travis-ci.org/repo/$repo_slug/requests
-	set -x
 }
 
 trigger_adi_build() {
@@ -269,7 +265,7 @@ run_docker_script() {
 	sudo docker run --rm=true \
 		-v "$(pwd):/${MOUNTPOINT}:rw" \
 		$DOCKER_IMAGE \
-		/bin/bash -xe "/${MOUNTPOINT}/${DOCKER_SCRIPT}" "${MOUNTPOINT}" "${OS_TYPE}"
+		/bin/bash -e "/${MOUNTPOINT}/${DOCKER_SCRIPT}" "${MOUNTPOINT}" "${OS_TYPE}"
 }
 
 ensure_command_exists() {

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -4,6 +4,10 @@ export TRAVIS_API_URL="https://api.travis-ci.org"
 
 COMMON_SCRIPTS="jobs_running_cnt.py inside_docker.sh"
 
+echo_red()   { printf "\033[1;31m$*\033[m\n"; }
+echo_green() { printf "\033[1;32m$*\033[m\n"; }
+echo_blue()  { printf "\033[1;34m$*\033[m\n"; }
+
 get_script_path() {
 	local script="$1"
 

--- a/CI/travis/make_darwin
+++ b/CI/travis/make_darwin
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 


### PR DESCRIPTION
We can avoid downloading artifacts to see if they exist or now. This saves
a bit of time and some bandwidth. If we just do a `rm` command via SFTP
and allow it to fail, this should be just as good.

The `sftp` command is also wrapped into it's own function, to unclutter
some of the SFTP logic.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>