### PR TITLE
CI/travis/inside_docker.sh: handle lowercase `ci` dir

### DIFF
--- a/CI/travis/inside_docker.sh
+++ b/CI/travis/inside_docker.sh
@@ -8,10 +8,19 @@ export TRAVIS_BUILD_DIR="/$LIBNAME"
 
 cd /$LIBNAME
 
-/$LIBNAME/CI/travis/before_install_linux "$OS_TYPE"
+if [ -d "/$LIBNAME/CI" ] ; then
+	CI="/$LIBNAME/CI"
+elif [ -d "/$LIBNAME/ci" ] ; then
+	CI="/$LIBNAME/ci"
+else
+	echo "No CI/ci directory present"
+	exit 1
+fi
 
-/$LIBNAME/CI/travis/make_linux "$OS_TYPE"
+$CI/travis/before_install_linux "$OS_TYPE"
+
+$CI/travis/make_linux "$OS_TYPE"
 
 # need to find this out inside the container
-. /${LIBNAME}/CI/travis/lib.sh
+. $CI/travis/lib.sh
 echo "$(get_ldist)" > /${LIBNAME}/build/.LDIST


### PR DESCRIPTION
Some repos will have a lowercase `ci` dir.
The `inside_docker.sh` should handle them as well.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>