### PR TITLE
[RFC] build,.travis.yml: drop xcode 8 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,9 +57,6 @@ matrix:
         - OS_VERSION=bionic
     - compiler: "gcc"
       os: osx
-      osx_image: xcode8
-    - compiler: "gcc"
-      os: osx
       osx_image: xcode9.2
       env:
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss


### PR DESCRIPTION
Builds for Xcode 8 take up about 30+ minutes.
The build also reports:
```
Warning: You are using macOS 10.11.
We (and Apple) do not provide support for this old version.
```

Maybe it's a good time to remove.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>