### PR TITLE
CI/travis/jobs_running_cnt.py: count `created` states as well

### DIFF
--- a/CI/travis/jobs_running_cnt.py
+++ b/CI/travis/jobs_running_cnt.py
@@ -32,7 +32,7 @@ json_r = json.loads(response.decode('utf-8'))
 
 jobs_running = 0
 for job in json_r['jobs']:
-    if (job['state'] == 'started'):
+    if (job['state'] in [ 'started', 'created' ]):
         jobs_running += 1
 
 print (jobs_running)


### PR DESCRIPTION
Previously we were just counting `started` states, but it seems that
Travis-CI has a `created` state for jobs, which is before the `started`
state.
This means some builds were triggering before the entire job group would
finish.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>