### PR TITLE
CI/travis/lib.sh: fix triggering multiple builds

### DIFF
--- a/CI/travis/jobs_running_cnt.py
+++ b/CI/travis/jobs_running_cnt.py
@@ -32,7 +32,11 @@ json_r = json.loads(response.decode('utf-8'))
 
 jobs_running = 0
 for job in json_r['jobs']:
-    if (job['state'] in [ 'started', 'created' ]):
+    # bump number of jobs higher, so nothing triggers
+    if (job['state'] in [ 'canceled', 'failed' ]):
+        jobs_running += 99
+        break
+    if (job['state'] in [ 'started', 'created', 'queued', 'received' ]):
         jobs_running += 1
 
 print (jobs_running)


### PR DESCRIPTION
Travis CI has multiple job states to account for (queued, received, etc).
In some conditions, the number of created + started == 1, which typically
happens during multiple Travis-CI builds running.

It's also hard to say "job[state] not in [list states]" since there are so
many job states to account for. So we try to account for the ones we could
identify so far.

Travis' API docs are not that great either. They claims it's
self-documenting. Oh well...
Links:
  https://docs.travis-ci.com/user/developer/#api-v3
  https://developer.travis-ci.com/resource/jobs#Jobs

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>