### PR TITLE
local: Improve support for channels with extended names

### DIFF
--- a/local.c
+++ b/local.c
@@ -1135,7 +1135,7 @@ static char * get_channel_id(const char *attr)
 	size_t len;
 
 	attr = strchr(attr, '_') + 1;
-	ptr = strchr(attr, '_');
+	ptr = strrchr(attr, '_');
 	if (find_channel_modifier(ptr + 1, &len) != IIO_NO_MOD)
 		ptr += len + 1;
 


### PR DESCRIPTION
On Chrome OS devices, there is a driver named 'cros_ec_sensors_ring',
which defines a channel of type IIO_ACCEL with an extended name of "flag".

When trying to parse the 'en' attribute of this channel, libiio parses it
as a 'flag_en' attribute of the 'accel' channel instead, in turn causing
the context creation to fail due to an unrecognized attribute name.

This patch works around this issue by locating the last underscore as
the channel name marker, instead of the first. This, in turn, yields a
correct channel name of 'accel_flag' and a valid attribute name 'en'.

To the best of my understanding, this should not change the behavior of
libiio for channels that do not have an extended name.

Signed-off-by: Enrico Granata <granata.enrico@gmail.com>