### PR TITLE
avoid some null pointer derefs

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -351,6 +351,9 @@ const char * iio_channel_find_attr(const struct iio_channel *chn,
 ssize_t iio_channel_attr_read(const struct iio_channel *chn,
 		const char *attr, char *dst, size_t len)
 {
+	if (!chn)
+		return -ENOSYS;
+
 	if (chn->dev->ctx->ops->read_channel_attr)
 		return chn->dev->ctx->ops->read_channel_attr(chn,
 				attr, dst, len);
@@ -361,6 +364,9 @@ ssize_t iio_channel_attr_read(const struct iio_channel *chn,
 ssize_t iio_channel_attr_write_raw(const struct iio_channel *chn,
 		const char *attr, const void *src, size_t len)
 {
+	if (!chn)
+		return -ENOSYS;
+
 	if (chn->dev->ctx->ops->write_channel_attr)
 		return chn->dev->ctx->ops->write_channel_attr(chn,
 				attr, src, len);

--- a/device.c
+++ b/device.c
@@ -250,6 +250,9 @@ struct iio_channel * iio_device_find_channel(const struct iio_device *dev,
 		const char *name, bool output)
 {
 	unsigned int i;
+	if (!dev)
+		return NULL;
+
 	for (i = 0; i < dev->nb_channels; i++) {
 		struct iio_channel *chn = dev->channels[i];
 		if (iio_channel_is_output(chn) != output)


### PR DESCRIPTION
`SoapyUtil --probe` can trigger various null pointer derefences while trying to probe a PlutoSDR (https://github.com/pothosware/SoapyPlutoSDR/wiki)

Signed-off-by: Chris Kuethe <chris.kuethe@gmail.com>