### PR TITLE
Handle channels that have no modifier or are not indexed

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -103,7 +103,7 @@ static const char * const modifier_names[] = {
  * IIO_NO_MOD is returned. If a modifier was found len_p will be updated with
  * the length of the modifier.
  */
-unsigned int find_channel_modifier(const char *s, size_t *len_p)
+enum iio_modifier find_channel_modifier(const char *s, size_t *len_p)
 {
 	unsigned int i;
 	size_t len;
@@ -152,17 +152,7 @@ void iio_channel_init_finalize(struct iio_channel *chn)
 		return;
 
 	mod++;
-
-	for (i = 0; i < ARRAY_SIZE(modifier_names); i++) {
-		if (!modifier_names[i])
-			continue;
-		len = strlen(modifier_names[i]);
-		if (strncmp(modifier_names[i], mod, len) != 0)
-			continue;
-
-		chn->modifier = (enum iio_modifier) i;
-		break;
-	}
+	chn->modifier = find_channel_modifier(mod, NULL);
 }
 
 static char *get_attr_xml(struct iio_channel_attr *attr, size_t *length)

--- a/iio-private.h
+++ b/iio-private.h
@@ -281,6 +281,7 @@ __api ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 
 void iio_channel_init_finalize(struct iio_channel *chn);
 enum iio_modifier find_channel_modifier(const char *s, size_t *len_p);
+enum iio_chan_type find_channel_type(const char *name);
 
 char *iio_strdup(const char *str);
 

--- a/iio-private.h
+++ b/iio-private.h
@@ -280,7 +280,7 @@ __api ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 		const uint32_t *mask, size_t words);
 
 void iio_channel_init_finalize(struct iio_channel *chn);
-unsigned int find_channel_modifier(const char *s, size_t *len_p);
+enum iio_modifier find_channel_modifier(const char *s, size_t *len_p);
 
 char *iio_strdup(const char *str);
 

--- a/local.c
+++ b/local.c
@@ -1110,21 +1110,17 @@ static int local_set_trigger(const struct iio_device *dev,
 
 static bool is_channel(const char *attr, bool strict)
 {
-	char *ptr = NULL;
-	if (!strncmp(attr, "in_timestamp_", sizeof("in_timestamp_") - 1))
-		return true;
+	int skip_prefix = 0;
+
 	if (!strncmp(attr, "in_", 3))
-		ptr = strchr(attr + 3, '_');
+		skip_prefix = 3;
 	else if (!strncmp(attr, "out_", 4))
-		ptr = strchr(attr + 4, '_');
-	if (!ptr)
+		skip_prefix = 4;
+	if (skip_prefix == 0 || strchr(attr + skip_prefix, '_') == NULL)
 		return false;
 	if (!strict)
 		return true;
-	if (*(ptr - 1) >= '0' && *(ptr - 1) <= '9')
-		return true;
-
-	if (find_channel_modifier(ptr + 1, NULL) != IIO_NO_MOD)
+	if (find_channel_type(attr + skip_prefix) != IIO_CHAN_TYPE_UNKNOWN)
 		return true;
 	return false;
 }


### PR DESCRIPTION
Another attempts to fix #25

The idea is to change is_channel() from looking at index and modifier to a different format:

must start with in_ or out_
next, it should be a channel type
must have an extra '_'.
Test: Using iio_info: before:
iio:device0: cros-ec-light (buffer capable)
2 channels found:
timestamp: (input, index: 1, format: le:S64/64>>0)
illuminance: (input)
3 channel-specific attributes found:
attr 0: calibbias value: 0
attr 1: calibscale value: 56.360700
attr 2: raw value: 55

after:
iio:device0: cros-ec-light (buffer capable)
2 channels found:
illuminance: (input, index: 0, format: le:U16/16>>0)
3 channel-specific attributes found:
attr 0: calibbias value: 0
attr 1: calibscale value: 56.360700
attr 2: raw value: 52
timestamp: (input, index: 1, format: le:S64/64>>0)