### PR TITLE
General: Rework the Windows installer and the zip artifact.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,21 +79,48 @@ build_script:
     - set GENERATOR=Visual Studio 12
     - cd c:\projects\libiio
     - set folder-path=c:\projects\libiio\build-win32
+
      #MSVC 32 bit
+    - set PATH=C:\\Python37;C:\\Python37\\libs;%PATH%
     - echo "Running cmake for Visual Studio 32 bit... "
     - mkdir build-win32
     - cd build-win32
     - set MCS_EXECUTABLE_PATH="C:\Windows\Microsoft.NET\Framework\v4.0.30319"
-    - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE:STRING="%configuration%" -DENABLE_IPV6:BOOL=OFF -DCMAKE_SYSTEM_PREFIX_PATH="C:" -DPYTHON_BINDINGS:BOOL=OFF -DLIBXML2_LIBRARIES="C:\\libs\\32\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\32\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\32\\libserialport.dll.a" ..
+    - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE:STRING="%configuration%" -DENABLE_IPV6:BOOL=OFF -DCMAKE_SYSTEM_PREFIX_PATH="C:" -DPYTHON_BINDINGS:BOOL=ON -DLIBXML2_LIBRARIES="C:\\libs\\32\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\32\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\32\\libserialport.dll.a" ..
     - cmake --build . --config %configuration%
 
+    - cd bindings/python
+    - python.exe setup.py bdist_wininst
+    - ps: Get-ChildItem dist\libiio-*.exe | Rename-Item -NewName "libiio-py37-win32.exe"
+    - ps: cp dist\*.exe .
+    - ps: rm dist\*.exe
+    - set PATH=C:\\Python36;C:\\Python36\\libs;%PATH%
+    - python.exe setup.py bdist_wininst
+    - ls dist
+    - ps: Get-ChildItem dist\libiio-*.exe | Rename-Item -NewName "libiio-py36-win32.exe"
+    - ps: cp dist\*.exe .
+    - ps: rm dist\*.exe
+
     #MSVC 64 bit
+    - set PATH=C:\Python37-x64;C:\\Python37-x64\\libs;%PATH%
     - cd c:\projects\libiio
     - echo "Running cmake for Visual Studio 64 bit... "
     - mkdir build-win64
     - cd build-win64
-    - cmake -G "%GENERATOR% Win64" -DCMAKE_BUILD_TYPE:STRING="%configuration%" -DENABLE_IPV6:BOOL=OFF -DCMAKE_SYSTEM_PREFIX_PATH="C:" -DPYTHON_BINDINGS:BOOL=OFF -DLIBXML2_LIBRARIES="C:\\libs\\64\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\64\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\64\\libserialport.dll.a" ..
+    - cmake -G "%GENERATOR% Win64" -DCMAKE_BUILD_TYPE:STRING="%configuration%" -DENABLE_IPV6:BOOL=OFF -DCMAKE_SYSTEM_PREFIX_PATH="C:" -DPYTHON_BINDINGS:BOOL=ON -DLIBXML2_LIBRARIES="C:\\libs\\64\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\64\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\64\\libserialport.dll.a" ..
     - cmake --build . --config %configuration%
+
+    - cd bindings/python
+    - python.exe setup.py bdist_wininst
+    - ps: Get-ChildItem dist\libiio-*.exe | Rename-Item -NewName "libiio-py37-amd64.exe"
+    - ps: cp dist\*.exe .
+    - ps: rm dist\*.exe
+    - set PATH=C:\Python36-x64;C:\\Python36-x64\\libs;%PATH%
+    - python.exe setup.py bdist_wininst
+    - ps: Get-ChildItem dist\libiio-*.exe | Rename-Item -NewName "libiio-py36-amd64.exe"
+    - ps: cp dist\*.exe .
+    - ps: rm dist\*.exe
+    - cd c:\projects\libiio\build-win64
 
     #Create the installer
     - ISCC %folder-path%\libiio.iss
@@ -109,6 +136,10 @@ build_script:
     - copy iio.h c:\%ARCHIVE_NAME%\include
     - copy build-win32\Release\libiio.* c:\%ARCHIVE_NAME%\MS32
     - copy build-win64\Release\libiio.* c:\%ARCHIVE_NAME%\MS64
+    - copy build-win32\bindings\csharp\libiio-sharp.dll c:\%ARCHIVE_NAME%\MS32
+    - copy build-win64\bindings\csharp\libiio-sharp.dll c:\%ARCHIVE_NAME%\MS64
+    - copy build-win32\bindings\python\*.exe c:\%ARCHIVE_NAME%\MS32
+    - copy build-win64\bindings\python\*.exe c:\%ARCHIVE_NAME%\MS64
     - copy build-mingw-win32\Release\libiio.* c:\%ARCHIVE_NAME%\MinGW32
     - copy build-mingw-win64\Release\libiio.* c:\%ARCHIVE_NAME%\MinGW64
     - del c:\%ARCHIVE_NAME%\MinGW32\libiio.iss

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -7,10 +7,13 @@ if (PYTHONINTERP_FOUND)
 	option(PYTHON_BINDINGS "Install Python bindings" ON)
 
 	if (PYTHON_BINDINGS)
+
 		set(SETUP_PY_IN ${CMAKE_CURRENT_SOURCE_DIR}/setup.py.cmakein)
 		set(SETUP_PY ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
 
 		configure_file(${SETUP_PY_IN} ${SETUP_PY})
+
+		configure_file(${CMAKE_CURRENT_SOURCE_DIR}/iio.py  ${CMAKE_CURRENT_BINARY_DIR}/iio.py COPYONLY)
 
 		add_custom_target(libiio-py ALL DEPENDS ${SETUP_PY} COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} --quiet build)
 

--- a/bindings/python/setup.py.cmakein
+++ b/bindings/python/setup.py.cmakein
@@ -17,7 +17,6 @@ from distutils.core import setup
 
 setup(name='libiio',
 		version='${VERSION}',
-		package_dir={'': '${CMAKE_CURRENT_SOURCE_DIR}'},
 		description='Library to use the Industrial IO devices',
 		url='https://github.com/analogdevicesinc/libiio',
 		py_modules=['iio'],

--- a/libiio.iss.cmakein
+++ b/libiio.iss.cmakein
@@ -44,6 +44,9 @@ Name: "turkish"; MessagesFile: "compiler:Languages\Turkish.isl"
 Name: "ukrainian"; MessagesFile: "compiler:Languages\Ukrainian.isl"
 
 [Files]
+Source: "C:\projects\libiio\build-win32\bindings\python\libiio-py37-win32.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall;
+Source: "C:\projects\libiio\build-win64\bindings\python\libiio-py37-amd64.exe"; DestDir: "{tmp}"; Flags: deleteafterinstall;
+
 Source: "C:\projects\libiio\build-win32\Release\libiio.dll"; DestDir: "{sys}"; Flags: 32bit
 Source: "C:\projects\libiio\build-win64\Release\libiio.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode
 
@@ -67,3 +70,10 @@ Source: "C:\projects\libiio\build-win32\bindings\csharp\libiio-sharp.dll"; DestD
 
 Source: "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\redist\x86\Microsoft.VC120.CRT\msvcr120.dll"; DestDir: "{sys}"; Flags: onlyifdoesntexist 32bit
 Source: "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\redist\x64\Microsoft.VC120.CRT\msvcr120.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Flags: onlyifdoesntexist
+
+[Tasks]
+Name:	"install_python_bindings"; Description: "Install libiio Python 3.7 bindings"
+
+[Run]
+Filename: "{tmp}\libiio-py37-amd64.exe"; StatusMsg: "Installing Python bindings"; Check: Is64BitInstallMode; Tasks: install_python_bindings; Flags: skipifsilent
+Filename: "{tmp}\libiio-py37-win32.exe"; StatusMsg: "Installing Python bindings"; Check: not Is64BitInstallMode; Tasks: install_python_bindings; Flags: skipifsilent


### PR DESCRIPTION
- Add an option in the libiio installer to install Python bindings.
- Add Python bindings installers for Python 3.7 and 3.6 in the archive.
- Add csharp bindings in the archive.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>