### PR TITLE
local.c: make sure dst is null-terminated if fread fails

### DIFF
--- a/local.c
+++ b/local.c
@@ -717,6 +717,8 @@ static ssize_t local_read_dev_attr(const struct iio_device *dev,
 	ret = fread(dst, 1, len, f);
 	if (ret > 0)
 		dst[ret - 1] = '\0';
+	else
+		dst[0] = '\0';
 	fflush(f);
 	if (ferror(f))
 		ret = -errno;


### PR DESCRIPTION
This should fix coverity issue:

```
*** CID 343595:  Memory - illegal accesses  (STRING_NULL)
/home/travis/build/analogdevicesinc/libiio/local.c: 1090 in local_get_trigger()

1087             nb = dev->ctx->nb_devices;
1088             for (i = 0; i < (size_t) nb; i++) {
1089                     const struct iio_device *cur = dev->ctx->devices[i];
>>>     CID 343595:  Memory - illegal accesses  (STRING_NULL)
>>>     Passing unterminated string "buf" to "strcmp", which expects a null-terminated string.
1090                     if (cur->name && !strcmp(cur->name, buf)) {
1091                             *trigger = cur;

```
Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>