### PR TITLE
travis-ci: recent upgrades in the travis-ci infrastructure caused som…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,14 +59,17 @@ matrix:
       env:
         - OS_TYPE=centos_docker
         - OS_VERSION=6
+        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - os: linux
       env:
         - OS_TYPE=centos_docker
         - OS_VERSION=7
+        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - os: linux
       env:
         - OS_TYPE=ubuntu_docker
         - OS_VERSION=bionic
+        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - compiler: "gcc"
       os: osx
       osx_image: xcode9.2


### PR DESCRIPTION
…e breakages in deployments

Requires adding -oHostKeyAlgorithms=+ssh-dss on a few more distributions

Signed-off-by: Robin Getz <robin.getz@analog.com>