### PR TITLE
build,centos,bionic: add ssh-dss algo to EXTRA_SSH env-var

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,14 +59,17 @@ matrix:
       env:
         - OS_TYPE=centos_docker
         - OS_VERSION=6
+        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - os: linux
       env:
         - OS_TYPE=centos_docker
         - OS_VERSION=7
+        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - os: linux
       env:
         - OS_TYPE=ubuntu_docker
         - OS_VERSION=bionic
+        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - compiler: "gcc"
       os: osx
       osx_image: xcode9.2


### PR DESCRIPTION
Recently docker builds have been failing because they couldn't negotiate
the algo for the SSH connection when deploying.
This has already been failing on other builds in a similar fashion, and now
we need to extend this to CentOS & Bionic docker builds.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>