### PR TITLE
Network: Only resolve interface name on IPv6 link-local addresses

### DIFF
--- a/network.c
+++ b/network.c
@@ -1537,15 +1537,17 @@ struct iio_context * network_create_context(const char *host)
 		inet_ntop(AF_INET6, &in->sin6_addr,
 				description, INET6_ADDRSTRLEN);
 
-		ptr = if_indextoname(in->sin6_scope_id, description +
-				strlen(description) + 1);
-		if (!ptr) {
-			ret = -errno;
-			ERROR("Unable to lookup interface of IPv6 address\n");
-			goto err_free_description;
-		}
+		if (IN6_IS_ADDR_LINKLOCAL(&in->sin6_addr)) {
+			ptr = if_indextoname(in->sin6_scope_id, description +
+					strlen(description) + 1);
+			if (!ptr) {
+				ret = -errno;
+				ERROR("Unable to lookup interface of IPv6 address\n");
+				goto err_free_description;
+			}
 
-		*(ptr - 1) = '%';
+			*(ptr - 1) = '%';
+		}
 	}
 #endif
 	if (res->ai_family == AF_INET) {


### PR DESCRIPTION
It turns out that resolving interface name from
`sockaddr_in6->sin6_scope_id` only works on link-local addresses. This
resulted in errors when connecting to iiod over global ipv6 (see #296). This PR fixes that.

I have not been able to test this on WIN32, but I have found multiple
pieces of win32 code using this macro, which all seem to pull it from
`<ws2tcpip.h>` which is already included in network.c so I'm confident it
will work.