### PR TITLE
Udev rules are now also installed with respect to CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,7 +468,7 @@ if (WITH_USB_BACKEND AND CMAKE_SYSTEM_NAME MATCHES "^Linux")
 	option(INSTALL_UDEV_RULE "Install a udev rule for detection of USB devices" ON)
 
 	if (INSTALL_UDEV_RULE)
-		set(UDEV_RULES_INSTALL_DIR /lib/udev/rules.d CACHE PATH "default install path for udev rules")
+		set(UDEV_RULES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/udev/rules.d" CACHE PATH "default install path for udev rules")
 
 		configure_file(libiio.rules.cmakein ${CMAKE_CURRENT_BINARY_DIR}/90-libiio.rules @ONLY)
 		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/90-libiio.rules DESTINATION ${UDEV_RULES_INSTALL_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -468,7 +468,11 @@ if (WITH_USB_BACKEND AND CMAKE_SYSTEM_NAME MATCHES "^Linux")
 	option(INSTALL_UDEV_RULE "Install a udev rule for detection of USB devices" ON)
 
 	if (INSTALL_UDEV_RULE)
-		set(UDEV_RULES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/udev/rules.d" CACHE PATH "default install path for udev rules")
+		if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+			set(UDEV_RULES_INSTALL_DIR "/lib/udev/rules.d" CACHE PATH "default install path for udev rules")
+		else()
+			set(UDEV_RULES_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib/udev/rules.d" CACHE PATH "Install path for udev rules prefixed with provided CMAKE_INSTALL_PREFIX")
+		endif()
 
 		configure_file(libiio.rules.cmakein ${CMAKE_CURRENT_BINARY_DIR}/90-libiio.rules @ONLY)
 		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/90-libiio.rules DESTINATION ${UDEV_RULES_INSTALL_DIR})


### PR DESCRIPTION
When using a CMAKE_INSTALL_PREFIX_PATH, the CMakeLists.txt didn't respected this var.

Example command to reproduce:
mkdir -p build/output && cmake -G "Unix Makefiles" -B ./build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX:PATH=${PWD}/build/output/ -S . && make -C build -j8 install

Not sure if this is on purpose or a bug, so please advice. It works for my case though.