### PR TITLE
utilities.c: Consider OS X a platform that has locale support

### DIFF
--- a/utilities.c
+++ b/utilities.c
@@ -28,7 +28,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if defined(_WIN32) || (defined(__USE_XOPEN2K8) && \
+#if defined(_WIN32) || \
+		(defined(__APPLE__) && defined(__MACH__)) || \
+		(defined(__USE_XOPEN2K8) && \
 		(!defined(__UCLIBC__) || defined(__UCLIBC_HAS_LOCALE__)))
 #define LOCALE_SUPPORT
 #endif


### PR DESCRIPTION
__MACH__ is added to exclude iOS as it hasn't been tested whether iOS has locale support or not.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>