### PR TITLE
build,ci: os-x: install packages if they don't exist

### DIFF
--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -2,4 +2,4 @@
 
 . CI/travis/lib.sh
 
-brew_install_or_upgrade cmake doxygen libusb libxml2
+brew_install_if_not_exists cmake doxygen libusb libxml2

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -160,6 +160,18 @@ brew_install_or_upgrade() {
 	done
 }
 
+__brew_install_if_not_exists() {
+	brew ls --version $1 || \
+		brew install $1
+}
+
+brew_install_if_not_exists() {
+	while [ -n "$1" ] ; do
+		__brew_install_if_not_exists "$1" || return 1
+		shift
+	done
+}
+
 sftp_cmd_pipe() {
 	sftp ${EXTRA_SSH} ${SSHUSER}@${SSHHOST}
 }


### PR DESCRIPTION
Previously, they were being installed. And if they were already installed
we would have upgraded them, which takes quite some time.

On older OS X versions, this can take too much.
So, just install packages only if they aren't already.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>