### PR TITLE
ci,lib: fix typo; correct is `brew list --versions`

### DIFF
--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -150,7 +150,7 @@ get_ldist() {
 __brew_install_or_upgrade() {
 	brew install $1 || \
 		brew upgrade $1 || \
-		brew ls --version $1
+		brew ls --versions $1
 }
 
 brew_install_or_upgrade() {
@@ -161,7 +161,7 @@ brew_install_or_upgrade() {
 }
 
 __brew_install_if_not_exists() {
-	brew ls --version $1 || \
+	brew ls --versions $1 || \
 		brew install $1
 }
 


### PR DESCRIPTION
The issue only shows up when using the `brew_install_if_not_exists`
function, because that one checks if the package is installed first, and
only then installs it.

`brew ls --version` also seems to be valid, but it looks like it prints
`brew Version` and exits successfully.

For this check, we only need `brew ls`, but using `brew list --versions`
also prints in the log the current installed versions, which is useful when
debugging.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>