### PR TITLE
ci,os-x: disable brew's default install cleanup

### DIFF
--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -3,6 +3,9 @@
 export TRAVIS_API_URL="https://api.travis-ci.org"
 LOCAL_BUILD_DIR=${LOCAL_BUILD_DIR:-build}
 
+HOMEBREW_NO_INSTALL_CLEANUP=1
+export HOMEBREW_NO_INSTALL_CLEANUP
+
 COMMON_SCRIPTS="jobs_running_cnt.py inside_docker.sh"
 
 echo_red()   { printf "\033[1;31m$*\033[m\n"; }


### PR DESCRIPTION
Whenever running `brew install` and `brew cleanup` hasn't been run for 30
days, `brew cleanup` will be run.

For Travis-CI's OS-X images, this is often true, which just consumes time.

Travis-CI has an opt-out env-var `HOMEBREW_NO_INSTALL_CLEANUP` which
disables this behavior when set.
Most about it here:
  https://github.com/Homebrew/brew/pull/5472/commits/8144667a718f8f1afead3efa74c97d28dbc82c63

`libiio` is not affected by this default `brew cleanup` behavior (yet).
However, since these scripts are propagated in other repos, then it makes
sense to have this behavior default here.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>