### PR TITLE
Python: Fixed loading of libiio on non-Windows systems 

### DIFF
--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -61,10 +61,9 @@ _BufferPtr = _POINTER(_Buffer)
 
 if 'Windows' in _system():
 	_iiolib = 'libiio.dll'
-elif 'Darwin' in _system():
-	_iiolib = 'iio'
 else:
-	_iiolib = 'libiio.so.0'
+	# Non-windows, possibly Posix system
+	_iiolib = 'iio'
 
 _lib = _cdll(find_library(_iiolib), use_errno = True, use_last_error = True)
 


### PR DESCRIPTION
Fixed loading of libiio on non-Windows systems where find_library shall find it in the path if the specified name is 'iio'.

Fixes error when importing module iio on Linux. 

Signed-off-by: Matej Kenda <matejken@gmail.com>