### PR TITLE
Fix #325, remove dead code/compiler warning

### DIFF
--- a/tests/iio_attr.c
+++ b/tests/iio_attr.c
@@ -526,8 +526,6 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	if (attr_index && !argv[attr_index])
 		return EXIT_FAILURE;
-	if (wbuf && !wbuf)
-		return EXIT_FAILURE;
 	if (wbuf && ((device_index && (!strcmp(".", argv[device_index]) ||
 				        strchr(argv[device_index], '*'))) ||
 		     (channel_index && (!strcmp(".", argv[channel_index]) ||


### PR DESCRIPTION
With the right compiler flags we get:
./tests/iio_attr.c:529:11: warning: logical 'and' of mutually exclusive tests is always false [-Wlogical-op]

since the code looks like: "if (wbuf && !wbuf)"

This patch removed the offending/dead lines.

Signed-off-by: Robin Getz <robin.getz@analog.com>