### PR TITLE
Add Cmake flags to turn on/off bindings

### DIFF
--- a/CI/travis/make_darwin
+++ b/CI/travis/make_darwin
@@ -3,11 +3,11 @@
 if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 
 cd $TRAVIS_BUILD_DIR/build
-cmake -DOSX_PACKAGE=ON ..
+cmake -DOSX_PACKAGE=ON -DPYTHON_BINDINGS=ON ..
 make
 ls
 
 cd $TRAVIS_BUILD_DIR/build_tar
-cmake -DOSX_PACKAGE=OFF -DENABLE_PACKAGING=ON ..
+cmake -DOSX_PACKAGE=OFF -DENABLE_PACKAGING=ON -DPYTHON_BINDINGS=ON ..
 make && make package
 ls

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -7,7 +7,7 @@ if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 handle_default() {
 	mkdir -p build
 	cd build
-	cmake -DENABLE_PACKAGING=ON -DDEB_DETECT_DEPENDENCIES=ON ..
+	cmake -DENABLE_PACKAGING=ON -DDEB_DETECT_DEPENDENCIES=ON -DPYTHON_BINDINGS=ON ..
 	make && make package
 	if [ -n "${GH_DOC_TOKEN}" ] && \
 			[ -f "./generateDocumentationAndDeploy.sh" ] ; then
@@ -19,7 +19,7 @@ handle_default() {
 handle_centos() {
 	mkdir -p build
 	cd build
-	cmake -DENABLE_PACKAGING=ON ..
+	cmake -DENABLE_PACKAGING=ON -DPYTHON_BINDINGS=ON ..
 	make && make package
 	cd ..
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,9 @@ endif()
 #set(SETUP_PY ${CMAKE_CURRENT_SOURCE_DIR}/bindings/python/setup.py)
 #configure_file(python/setup.py.in ${SETUP_PY} @ONLY)
 
+option(CSHARP_BINDINGS "Install C# bindings" OFF)
+option(PYTHON_BINDINGS "Install Python bindings" OFF)
+option(MATLAB_BINDINGS "Build MATLAB bindings" OFF)
 add_subdirectory(bindings)
 
 if (WITH_MATLAB_BINDINGS_API)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,7 +50,7 @@ build_script:
     # Download a 32-bit version of windres.exe
     - appveyor DownloadFile http://swdownloads.analog.com/cse/build/windres.exe.gz -FileName C:\windres.exe.gz
     - C:\msys64\usr\bin\bash -lc "cd /c ; gunzip windres.exe.gz"
-    - C:\msys64\usr\bin\bash -lc "cmake -G '%GENERATOR%' -DCMAKE_RC_COMPILER=/c/windres.exe -DGIT_EXECUTABLE=C:/Program\ Files/Git/cmd/git.exe -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=/mingw32 -DCMAKE_C_COMPILER:FILEPATH=/mingw32/bin/i686-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER:FILEPATH=/mingw32/bin/i686-w64-mingw32-g++.exe -DCSHARP_BINDINGS:BOOL=OFF -DPKG_CONFIG_EXECUTABLE:FILEPATH=/mingw32/bin/pkg-config.exe -DENABLE_IPV6:BOOL=OFF -DPYTHON_BINDINGS:BOOL=OFF -DLIBSERIALPORT_LIBRARIES=/c/libs/32/libserialport.dll.a -DLIBSERIALPORT_INCLUDE_DIR=/c/include -DLIBLZMA_LIBRARY=c:/msys64/mingw32/lib/liblzma.dll.a /c/projects/libiio && make -j3"
+    - C:\msys64\usr\bin\bash -lc "cmake -G '%GENERATOR%' -DCMAKE_RC_COMPILER=/c/windres.exe -DGIT_EXECUTABLE=C:/Program\ Files/Git/cmd/git.exe -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=/mingw32 -DCMAKE_C_COMPILER:FILEPATH=/mingw32/bin/i686-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER:FILEPATH=/mingw32/bin/i686-w64-mingw32-g++.exe -DPKG_CONFIG_EXECUTABLE:FILEPATH=/mingw32/bin/pkg-config.exe -DENABLE_IPV6:BOOL=OFF -DLIBSERIALPORT_LIBRARIES=/c/libs/32/libserialport.dll.a -DLIBSERIALPORT_INCLUDE_DIR=/c/include -DLIBLZMA_LIBRARY=c:/msys64/mingw32/lib/liblzma.dll.a /c/projects/libiio && make -j3"
 
     # MinGW 64 bit
     - cd c:\projects\libiio
@@ -68,7 +68,7 @@ build_script:
     # set the specific version of doxygen, need to look at this later.
     - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-doxygen-1.8.14-2-any.pkg.tar.xz"
     - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-graphviz-2.40.1-4-any.pkg.tar.xz"
-    - C:\msys64\usr\bin\bash -lc "cmake -G '%GENERATOR%' -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=/mingw64 -DCMAKE_C_COMPILER:FILEPATH=/mingw64/bin/x86_64-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER:FILEPATH=/mingw64/bin/x86_64-w64-mingw32-g++.exe -DCSHARP_BINDINGS:BOOL=OFF -DPKG_CONFIG_EXECUTABLE:FILEPATH=/mingw64/bin/pkg-config.exe -DENABLE_IPV6:BOOL=OFF -DPYTHON_BINDINGS:BOOL=OFF -DLIBSERIALPORT_LIBRARIES=/c/libs/64/libserialport.dll.a -DLIBSERIALPORT_INCLUDE_DIR=/c/include /c/projects/libiio && make -j3"
+    - C:\msys64\usr\bin\bash -lc "cmake -G '%GENERATOR%' -DCMAKE_BUILD_TYPE=%configuration% -DCMAKE_INSTALL_PREFIX=/mingw64 -DCMAKE_C_COMPILER:FILEPATH=/mingw64/bin/x86_64-w64-mingw32-gcc.exe -DCMAKE_CXX_COMPILER:FILEPATH=/mingw64/bin/x86_64-w64-mingw32-g++.exe -DPKG_CONFIG_EXECUTABLE:FILEPATH=/mingw64/bin/pkg-config.exe -DENABLE_IPV6:BOOL=OFF -DLIBSERIALPORT_LIBRARIES=/c/libs/64/libserialport.dll.a -DLIBSERIALPORT_INCLUDE_DIR=/c/include /c/projects/libiio && make -j3"
 
     # Move the tests folder
     - cd c:\projects\libiio
@@ -86,7 +86,7 @@ build_script:
     - mkdir build-win32
     - cd build-win32
     - set MCS_EXECUTABLE_PATH="C:\Windows\Microsoft.NET\Framework\v4.0.30319"
-    - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE:STRING="%configuration%" -DENABLE_IPV6:BOOL=OFF -DCMAKE_SYSTEM_PREFIX_PATH="C:" -DPYTHON_BINDINGS:BOOL=ON -DLIBXML2_LIBRARIES="C:\\libs\\32\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\32\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\32\\libserialport.dll.a" ..
+    - cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE:STRING="%configuration%" -DENABLE_IPV6:BOOL=OFF -DCMAKE_SYSTEM_PREFIX_PATH="C:" -DCSHARP_BINDINGS:BOOL=ON -DPYTHON_BINDINGS:BOOL=ON -DLIBXML2_LIBRARIES="C:\\libs\\32\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\32\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\32\\libserialport.dll.a" ..
     - cmake --build . --config %configuration%
 
     - cd bindings/python
@@ -107,7 +107,7 @@ build_script:
     - echo "Running cmake for Visual Studio 64 bit... "
     - mkdir build-win64
     - cd build-win64
-    - cmake -G "%GENERATOR% Win64" -DCMAKE_BUILD_TYPE:STRING="%configuration%" -DENABLE_IPV6:BOOL=OFF -DCMAKE_SYSTEM_PREFIX_PATH="C:" -DPYTHON_BINDINGS:BOOL=ON -DLIBXML2_LIBRARIES="C:\\libs\\64\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\64\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\64\\libserialport.dll.a" ..
+    - cmake -G "%GENERATOR% Win64" -DCMAKE_BUILD_TYPE:STRING="%configuration%" -DENABLE_IPV6:BOOL=OFF -DCMAKE_SYSTEM_PREFIX_PATH="C:" -DCSHARP_BINDINGS:BOOL=ON -DPYTHON_BINDINGS:BOOL=ON -DLIBXML2_LIBRARIES="C:\\libs\\64\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\64\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\64\\libserialport.dll.a" ..
     - cmake --build . --config %configuration%
 
     - cd bindings/python

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -1,3 +1,11 @@
-add_subdirectory(csharp)
-add_subdirectory(matlab)
-add_subdirectory(python)
+if (CSHARP_BINDINGS)
+	add_subdirectory(csharp)
+endif()
+
+if (MATLAB_BINDINGS)
+	add_subdirectory(matlab)
+endif()
+
+if (PYTHON_BINDINGS)
+	add_subdirectory(python)
+endif()

--- a/bindings/csharp/CMakeLists.txt
+++ b/bindings/csharp/CMakeLists.txt
@@ -15,62 +15,61 @@ find_program(MCS_EXECUTABLE
 mark_as_advanced(MCS_EXECUTABLE)
 
 if (MCS_EXECUTABLE)
-	option(CSHARP_BINDINGS "Install C# bindings" ON)
-
-	if (CSHARP_BINDINGS)
-		set(LIBIIO_CS_PC_IN "${CMAKE_CURRENT_SOURCE_DIR}/libiio-sharp.pc.cmakein")
-		set(LIBIIO_CS_PC "${CMAKE_CURRENT_BINARY_DIR}/libiio-sharp-${VERSION}.pc")
-		configure_file(${LIBIIO_CS_PC_IN} ${LIBIIO_CS_PC} @ONLY)
-		if(NOT SKIP_INSTALL_ALL)
-			install(FILES ${LIBIIO_CS_PC} DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
-		endif()
-
-		set(LIBIIO_CS_DLL_CONFIG_IN "${CMAKE_CURRENT_SOURCE_DIR}/libiio-sharp.dll.config.cmakein")
-		set(LIBIIO_CS_DLL_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/libiio-sharp.dll.config")
-		configure_file(${LIBIIO_CS_DLL_CONFIG_IN} ${LIBIIO_CS_DLL_CONFIG} @ONLY)
-		if(NOT SKIP_INSTALL_ALL)
-			install(FILES ${LIBIIO_CS_DLL_CONFIG} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cli/libiio-sharp-${VERSION})
-		endif()
-
-		set(LIBIIO_CS_VERSION ${VERSION}.0.0)
-		set(LIBIIO_CS_INFO_IN ${CMAKE_CURRENT_SOURCE_DIR}/AssemblyInfo.cs.in)
-		set(LIBIIO_CS_INFO ${CMAKE_CURRENT_BINARY_DIR}/AssemblyInfo.cs)
-		configure_file(${LIBIIO_CS_INFO_IN} ${LIBIIO_CS_INFO} @ONLY)
-
-		set(LIBIIO_CS_DLL "${CMAKE_CURRENT_BINARY_DIR}/libiio-sharp.dll")
-		set(LIBIIO_CS_SOURCES
-			${CMAKE_CURRENT_SOURCE_DIR}/Attr.cs
-			${CMAKE_CURRENT_SOURCE_DIR}/Channel.cs
-			${CMAKE_CURRENT_SOURCE_DIR}/Context.cs
-			${CMAKE_CURRENT_SOURCE_DIR}/Device.cs
-			${CMAKE_CURRENT_SOURCE_DIR}/IOBuffer.cs
-			${CMAKE_CURRENT_SOURCE_DIR}/Trigger.cs
-			${LIBIIO_CS_INFO}
-			)
-
-		foreach(SRC ${LIBIIO_CS_SOURCES})
-			file(TO_NATIVE_PATH ${SRC} TMP)
-			set(LIBIIO_CS_SOURCES_REALPATH ${LIBIIO_CS_SOURCES_REALPATH} ${TMP})
-		endforeach(SRC)
-
-		file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/key.snk SIGN_KEY)
-		file(TO_NATIVE_PATH ${LIBIIO_CS_DLL} LIBIIO_CS_DLL_OUT)
-
-		add_custom_command(OUTPUT ${LIBIIO_CS_DLL}
-			COMMAND ${MCS_EXECUTABLE} /target:library /out:${LIBIIO_CS_DLL_OUT} /debug /keyfile:${SIGN_KEY} ${LIBIIO_CS_SOURCES_REALPATH}
-			DEPENDS ${LIBIIO_CS_SOURCES}
-			)
-
-		add_custom_target(libiio-sharp ALL DEPENDS ${LIBIIO_CS_DLL})
-
-		if(NOT SKIP_INSTALL_ALL)
-			set(DEBUG_SYMBOLS_FILE "")
-			if(EXISTS "${LIBIIO_CS_DLL}.mdb")
-				set(DEBUG_SYMBOLS_FILE "${LIBIIO_CS_DLL}.mdb")
-			elseif(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/libiio-sharp.pdb")
-				set(DEBUG_SYMBOLS_FILE "${CMAKE_CURRENT_BINARY_DIR}/libiio-sharp.pdb")
-			endif()
-			install(FILES ${LIBIIO_CS_DLL} ${DEBUG_SYMBOLS_FILE} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cli/libiio-sharp-${VERSION})
-		endif()
+	message(STATUS "Found C#: Building bindings")
+	set(LIBIIO_CS_PC_IN "${CMAKE_CURRENT_SOURCE_DIR}/libiio-sharp.pc.cmakein")
+	set(LIBIIO_CS_PC "${CMAKE_CURRENT_BINARY_DIR}/libiio-sharp-${VERSION}.pc")
+	configure_file(${LIBIIO_CS_PC_IN} ${LIBIIO_CS_PC} @ONLY)
+	if(NOT SKIP_INSTALL_ALL)
+		install(FILES ${LIBIIO_CS_PC} DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/pkgconfig")
 	endif()
+
+	set(LIBIIO_CS_DLL_CONFIG_IN "${CMAKE_CURRENT_SOURCE_DIR}/libiio-sharp.dll.config.cmakein")
+	set(LIBIIO_CS_DLL_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/libiio-sharp.dll.config")
+	configure_file(${LIBIIO_CS_DLL_CONFIG_IN} ${LIBIIO_CS_DLL_CONFIG} @ONLY)
+	if(NOT SKIP_INSTALL_ALL)
+		install(FILES ${LIBIIO_CS_DLL_CONFIG} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cli/libiio-sharp-${VERSION})
+	endif()
+
+	set(LIBIIO_CS_VERSION ${VERSION}.0.0)
+	set(LIBIIO_CS_INFO_IN ${CMAKE_CURRENT_SOURCE_DIR}/AssemblyInfo.cs.in)
+	set(LIBIIO_CS_INFO ${CMAKE_CURRENT_BINARY_DIR}/AssemblyInfo.cs)
+	configure_file(${LIBIIO_CS_INFO_IN} ${LIBIIO_CS_INFO} @ONLY)
+
+	set(LIBIIO_CS_DLL "${CMAKE_CURRENT_BINARY_DIR}/libiio-sharp.dll")
+	set(LIBIIO_CS_SOURCES
+		${CMAKE_CURRENT_SOURCE_DIR}/Attr.cs
+		${CMAKE_CURRENT_SOURCE_DIR}/Channel.cs
+		${CMAKE_CURRENT_SOURCE_DIR}/Context.cs
+		${CMAKE_CURRENT_SOURCE_DIR}/Device.cs
+		${CMAKE_CURRENT_SOURCE_DIR}/IOBuffer.cs
+		${CMAKE_CURRENT_SOURCE_DIR}/Trigger.cs
+		${LIBIIO_CS_INFO}
+		)
+
+	foreach(SRC ${LIBIIO_CS_SOURCES})
+		file(TO_NATIVE_PATH ${SRC} TMP)
+		set(LIBIIO_CS_SOURCES_REALPATH ${LIBIIO_CS_SOURCES_REALPATH} ${TMP})
+	endforeach(SRC)
+
+	file(TO_NATIVE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/key.snk SIGN_KEY)
+	file(TO_NATIVE_PATH ${LIBIIO_CS_DLL} LIBIIO_CS_DLL_OUT)
+
+	add_custom_command(OUTPUT ${LIBIIO_CS_DLL}
+		COMMAND ${MCS_EXECUTABLE} /target:library /out:${LIBIIO_CS_DLL_OUT} /debug /keyfile:${SIGN_KEY} ${LIBIIO_CS_SOURCES_REALPATH}
+		DEPENDS ${LIBIIO_CS_SOURCES}
+		)
+
+	add_custom_target(libiio-sharp ALL DEPENDS ${LIBIIO_CS_DLL})
+
+	if(NOT SKIP_INSTALL_ALL)
+		set(DEBUG_SYMBOLS_FILE "")
+		if(EXISTS "${LIBIIO_CS_DLL}.mdb")
+			set(DEBUG_SYMBOLS_FILE "${LIBIIO_CS_DLL}.mdb")
+		elseif(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/libiio-sharp.pdb")
+			set(DEBUG_SYMBOLS_FILE "${CMAKE_CURRENT_BINARY_DIR}/libiio-sharp.pdb")
+		endif()
+		install(FILES ${LIBIIO_CS_DLL} ${DEBUG_SYMBOLS_FILE} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cli/libiio-sharp-${VERSION})
+	endif()
+else()
+	message(FATAL_ERROR "C# compiler search failed : Can not build C# bindings")
 endif()

--- a/bindings/matlab/CMakeLists.txt
+++ b/bindings/matlab/CMakeLists.txt
@@ -8,19 +8,18 @@ mark_as_advanced(MATLAB_EXECUTABLE)
 option(WITH_MATLAB_BINDINGS_API "Enable MATLAB bindings API" ON)
 
 if (MATLAB_EXECUTABLE AND NOT SKIP_INSTALL_ALL)
-	option(MATLAB_BINDINGS "Install MATLAB bindings" ON)
-
-	if (MATLAB_BINDINGS)
-		install(
-			DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-			DESTINATION "${CMAKE_INSTALL_PREFIX}/share/libiio"
-			PATTERN "CMakeLists.txt" EXCLUDE
-		)
-		install(
-			CODE "execute_process(
-				COMMAND ${MATLAB_EXECUTABLE} -nodesktop
-					-nodisplay -r \"cd('${CMAKE_INSTALL_PREFIX}/share/libiio/matlab');iio_installer_script;exit;\"
-				OUTPUT_QUIET)")
-		set(WITH_MATLAB_BINDINGS_API ON CACHE BOOL "" FORCE)
-	endif()
+	message(STATUS "Found MATLAB: Building bindings")
+	install(
+		DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+		DESTINATION "${CMAKE_INSTALL_PREFIX}/share/libiio"
+		PATTERN "CMakeLists.txt" EXCLUDE
+	)
+	install(
+		CODE "execute_process(
+			COMMAND ${MATLAB_EXECUTABLE} -nodesktop
+				-nodisplay -r \"cd('${CMAKE_INSTALL_PREFIX}/share/libiio/matlab');iio_installer_script;exit;\"
+			OUTPUT_QUIET)")
+	set(WITH_MATLAB_BINDINGS_API ON CACHE BOOL "" FORCE)
+else()
+	message(FATAL_ERROR "MATLAB search failed : Can not build bindings")
 endif()

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -13,21 +13,19 @@ else()
 endif()
 
 if (Python_Interpreter_FOUND)
-	option(PYTHON_BINDINGS "Install Python bindings" ON)
+	message(STATUS "Found Python: Building bindings")
+	set(SETUP_PY_IN ${CMAKE_CURRENT_SOURCE_DIR}/setup.py.cmakein)
+	set(SETUP_PY ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
 
-	if (PYTHON_BINDINGS)
+	configure_file(${SETUP_PY_IN} ${SETUP_PY})
 
-		set(SETUP_PY_IN ${CMAKE_CURRENT_SOURCE_DIR}/setup.py.cmakein)
-		set(SETUP_PY ${CMAKE_CURRENT_BINARY_DIR}/setup.py)
+	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/iio.py  ${CMAKE_CURRENT_BINARY_DIR}/iio.py COPYONLY)
 
-		configure_file(${SETUP_PY_IN} ${SETUP_PY})
+	add_custom_target(libiio-py ALL DEPENDS ${SETUP_PY} COMMAND ${Python_EXECUTABLE} ${SETUP_PY} --quiet build)
 
-		configure_file(${CMAKE_CURRENT_SOURCE_DIR}/iio.py  ${CMAKE_CURRENT_BINARY_DIR}/iio.py COPYONLY)
-
-		add_custom_target(libiio-py ALL DEPENDS ${SETUP_PY} COMMAND ${Python_EXECUTABLE} ${SETUP_PY} --quiet build)
-
-		if(NOT SKIP_INSTALL_ALL)
-			install(CODE "execute_process(WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${Python_EXECUTABLE} ${SETUP_PY} install --root=\$ENV{DESTDIR}/ --prefix=${CMAKE_INSTALL_PREFIX})")
-		endif()
+	if(NOT SKIP_INSTALL_ALL)
+		install(CODE "execute_process(WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND ${Python_EXECUTABLE} ${SETUP_PY} install --root=\$ENV{DESTDIR}/ --prefix=${CMAKE_INSTALL_PREFIX})")
 	endif()
+else()
+	message(FATAL_ERROR "Python search failed : Can not build Python bindings")
 endif()


### PR DESCRIPTION
Many distributions have patches to change the CMake to turn off bindings
This internalize that to the upstream package in a sustainable manner.

The flags default to on, so it will not change the default behaviour.
Flag names are borrowed from libm2k

Signed-off-by: Robin Getz <robin.getz@analog.com>