### PR TITLE
#352 Match global attributes for differential channels.

### DIFF
--- a/local.c
+++ b/local.c
@@ -1483,15 +1483,15 @@ static unsigned int is_global_attr(struct iio_channel *chn, const char *attr)
 	// Check for matching global differential attr, like "voltage-voltage"
 	dashptr = strchr(attr, '-');
 	if (dashptr && dashptr > attr && dashptr < ptr) {
-		unsigned int len1 = dashptr - attr,
-					 len2 = ptr - dashptr - 1;
+		unsigned int len1 = dashptr - attr;
+		unsigned int len2 = ptr - dashptr - 1;
 		const char*  iddashptr = strchr(chn->id, '-');
-		if (iddashptr && strlen(iddashptr+1) > len2 &&
+		if (iddashptr && strlen(iddashptr + 1) > len2 &&
 			iddashptr - chn->id > len1 &&
 			chn->id[len1] >= '0' && chn->id[len1] <= '9' &&
 			!strncmp(chn->id, attr, len1) &&
-			iddashptr[len2+1] >= '0' && iddashptr[len2+1] <= '9' &&
-			!strncmp(iddashptr+1, dashptr+1, len2))
+			iddashptr[len2 + 1] >= '0' && iddashptr[len2 + 1] <= '9' &&
+			!strncmp(iddashptr + 1, dashptr + 1, len2))
 			return 1;
 	}
 

--- a/local.c
+++ b/local.c
@@ -1465,7 +1465,7 @@ static int add_channel(struct iio_device *dev, const char *name,
 static unsigned int is_global_attr(struct iio_channel *chn, const char *attr)
 {
 	unsigned int len;
-	char *ptr;
+	char *ptr, *dashptr;
 
 	if (!chn->is_output && !strncmp(attr, "in_", 3))
 		attr += 3;
@@ -1479,6 +1479,19 @@ static unsigned int is_global_attr(struct iio_channel *chn, const char *attr)
 		return 0;
 
 	len = ptr - attr;
+
+	// Check if matching global differential attr,
+	// like "voltage-voltage"
+	dashptr = strchr(attr, '-');
+	if (dashptr && dashptr > attr && dashptr < ptr) {
+		unsigned int len1 = dashptr - attr,
+					 len2 = ptr - dashptr - 1;
+		if (chn->id[len1] >= '0' && chn->id[len1] <= '9' &&
+			!strncmp(chn->id, attr, len1) &&
+			chn->id[len+1] >= '0' && chn->id[len+1] <= '9' &&
+			!strncmp(chn->id+len1+2, attr+len1+1, len2))
+			return 1;
+	}
 
 	if (strncmp(chn->id, attr, len))
 		return 0;

--- a/local.c
+++ b/local.c
@@ -1480,16 +1480,18 @@ static unsigned int is_global_attr(struct iio_channel *chn, const char *attr)
 
 	len = ptr - attr;
 
-	// Check if matching global differential attr,
-	// like "voltage-voltage"
+	// Check for matching global differential attr, like "voltage-voltage"
 	dashptr = strchr(attr, '-');
 	if (dashptr && dashptr > attr && dashptr < ptr) {
 		unsigned int len1 = dashptr - attr,
 					 len2 = ptr - dashptr - 1;
-		if (chn->id[len1] >= '0' && chn->id[len1] <= '9' &&
+		const char*  iddashptr = strchr(chn->id, '-');
+		if (iddashptr && strlen(iddashptr+1) > len2 &&
+			iddashptr - chn->id > len1 &&
+			chn->id[len1] >= '0' && chn->id[len1] <= '9' &&
 			!strncmp(chn->id, attr, len1) &&
-			chn->id[len+1] >= '0' && chn->id[len+1] <= '9' &&
-			!strncmp(chn->id+len1+2, attr+len1+1, len2))
+			iddashptr[len2+1] >= '0' && iddashptr[len2+1] <= '9' &&
+			!strncmp(iddashptr+1, dashptr+1, len2))
 			return 1;
 	}
 


### PR DESCRIPTION
Signed-off-by: fpagliughi <fpagliughi@mindspring.com>

This probably isn't a complete solution for release, but does seem to fix the limited case of some differential channels. I also wasn't sure when some attributes might be private (if I should look for a special case to return 2).