### PR TITLE
bindings/csharp: IOBuffer.cs: Add missing read() functionality and fix type casting.

### DIFF
--- a/bindings/csharp/IOBuffer.cs
+++ b/bindings/csharp/IOBuffer.cs
@@ -139,5 +139,15 @@ namespace iio
                 length = array.Length;
             Marshal.Copy(array, 0, iio_buffer_start(buf), (int)length);
         }
+
+        /// <summary>Extract the samples from the <see cref="iio.IOBuffer"/> object.</summary>
+        /// <param name="array">A <c>byte</c> array containing the extracted samples.</param>
+        public void read(byte[] array)
+        {
+            long length = (long) iio_buffer_end(buf) - (long) iio_buffer_start(buf);
+            if (length > array.Length)
+                length = array.Length;
+            Marshal.Copy(iio_buffer_start(buf), array, 0, (int)length);
+        }
     }
 }

--- a/bindings/csharp/IOBuffer.cs
+++ b/bindings/csharp/IOBuffer.cs
@@ -134,10 +134,10 @@ namespace iio
         /// <remarks>The number of samples written will not exceed the size of the buffer.</remarks>
         public void fill(byte[] array)
         {
-            int length = (int) iio_buffer_end(buf) - (int) iio_buffer_start(buf);
+            long length = (long) iio_buffer_end(buf) - (long) iio_buffer_start(buf);
             if (length > array.Length)
                 length = array.Length;
-            Marshal.Copy(array, 0, iio_buffer_start(buf), length);
+            Marshal.Copy(array, 0, iio_buffer_start(buf), (int)length);
         }
     }
 }


### PR DESCRIPTION
- Change the IntPtr cast to long instead of int. (issue #153 )
IntPtr is a platform specific type and is expected to have different
values on 32-bit or 64-bit systems. In C#, int is a 32-bit signed integer,
while a 64-bit integer is represented as long.

- Add missing read() functionality to IOBuffer (issue #154 )

Signed-off-by: Alexandra.Trifan <Alexandra.Trifan@analog.com>