### PR TITLE
local: Fix the checking of the buffer size returned by kernel

### DIFF
--- a/local.c
+++ b/local.c
@@ -509,7 +509,7 @@ static ssize_t local_get_buffer(const struct iio_device *dev,
 	}
 
 	/* Requested buffer size is too big! */
-	if (pdata->last_dequeued < 0 && bytes_used != block.size)
+	if (pdata->last_dequeued < 0 && bytes_used > block.size)
 		return -EFBIG;
 
 	pdata->last_dequeued = block.id;


### PR DESCRIPTION
This PR solves #190 

Verify that the kernel does not return a buffer smaller than the number of bytes that are requested.

Issue: a call to iio_buffer_push_partial() right after creating the buffer with a small number of bytes, fails with -EFBIG.
This fixes that.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>