### PR TITLE
iio_readdev: Fix corrupt data that was being captured on Windows

### DIFF
--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -84,6 +84,8 @@ static void quit_all(int sig)
 #ifdef _WIN32
 
 #include <windows.h>
+#include <io.h>
+#include <fcntl.h>
 
 BOOL WINAPI sig_handler_fn(DWORD dwCtrlType)
 {
@@ -377,6 +379,14 @@ int main(int argc, char **argv)
 		iio_context_destroy(ctx);
 		return EXIT_FAILURE;
 	}
+
+#ifdef _WIN32
+	/*
+	 * Deactivate the translation for the stdout. Otherwise, bytes that have
+	 * the same value as line feed character (LF) will be translated to CR-LF.
+	 */
+	_setmode(_fileno(stdout), _O_BINARY);
+#endif
 
 	while (app_running) {
 		int ret = iio_buffer_refill(buffer);


### PR DESCRIPTION
The captured data is sent to stdout but during this process (on Windows)
any byte that has the same value as line feed character (LF) gets
converted to CF-LF characters. This dissrupts the alignment of bytes
that represent the samples of the device.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>