### PR TITLE
iio_info: warn when iio_channel_get_type = IIO_CHAN_TYPE_UNKNOWN

### DIFF
--- a/tests/iio_info.c
+++ b/tests/iio_info.c
@@ -344,6 +344,9 @@ int main(int argc, char **argv)
 					iio_channel_get_id(ch),
 					name ? name : "", type_name);
 
+			if (iio_channel_get_type(ch) == IIO_CHAN_TYPE_UNKNOWN)
+				printf(", WARN:iio_channel_get_type()=UNKNOWN");
+
 			if (iio_channel_is_scan_element(ch)) {
 				const struct iio_data_format *format =
 					iio_channel_get_data_format(ch);


### PR DESCRIPTION
A few issues (#366, #373)  have popped up recently when
     iio_channel_get_type(ch) == IIO_CHAN_TYPE_UNKNOWN

This helps bring that to the top by easily notifing kernel developers
when they are doing things that aren't understood by the library.

Signed-off-by: Robin Getz <robin.getz@analog.com>