### PR TITLE
network: errno should be already negative

### DIFF
--- a/network.c
+++ b/network.c
@@ -1484,7 +1484,7 @@ struct iio_context * network_create_context(const char *host)
 
 	fd = create_socket(res, DEFAULT_TIMEOUT_MS);
 	if (fd < 0) {
-		errno = -fd;
+		errno = fd;
 		goto err_free_addrinfo;
 	}
 


### PR DESCRIPTION
Don't make errno positive by accidently flipping the sign

This turns iio_strerror() from this:
   Unable to create IIO context Unknown error -110 (110)
into:
   Unable to create IIO context Connection timed out (-110)

Signed-off-by: Robin Getz <robin.getz@analog.com>