### PR TITLE
usb: Add trigger support to the USB backend

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -1,7 +1,7 @@
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *
- * Copyright (C) 2015 Analog Devices, Inc.
+ * Copyright (C) 2015 - 2020 Analog Devices, Inc.
  * Author: Paul Cercueil <paul.cercueil@analog.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -399,6 +399,25 @@ static int usb_set_timeout(struct iio_context *ctx, unsigned int timeout)
 	return ret;
 }
 
+static int usb_get_trigger(const struct iio_device *dev,
+                const struct iio_device **trigger)
+{
+	struct iio_context_pdata *pdata = dev->ctx->pdata;
+
+	return iiod_client_get_trigger(pdata->iiod_client,
+			&pdata->io_ctx, dev, trigger);
+}
+
+static int usb_set_trigger(const struct iio_device *dev,
+                const struct iio_device *trigger)
+{
+	struct iio_context_pdata *pdata = dev->ctx->pdata;
+
+	return iiod_client_set_trigger(pdata->iiod_client,
+			&pdata->io_ctx, dev, trigger);
+}
+
+
 static void usb_shutdown(struct iio_context *ctx)
 {
 	unsigned int i;
@@ -514,6 +533,8 @@ static const struct iio_backend_ops usb_ops = {
 	.read_channel_attr = usb_read_chn_attr,
 	.write_device_attr = usb_write_dev_attr,
 	.write_channel_attr = usb_write_chn_attr,
+	.get_trigger = usb_get_trigger,
+	.set_trigger = usb_set_trigger,
 	.set_kernel_buffers_count = usb_set_kernel_buffers_count,
 	.set_timeout = usb_set_timeout,
 	.shutdown = usb_shutdown,


### PR DESCRIPTION
This fixes #384

I think this was just missing, and will be necessary as we do
more IMU/accelerometer devices on RPi.

Signed-off-by: Robin Getz <robin.getz@analog.com>