### PR TITLE
Revert "network: errno should be already negative"

### DIFF
--- a/network.c
+++ b/network.c
@@ -1484,7 +1484,7 @@ struct iio_context * network_create_context(const char *host)
 
 	fd = create_socket(res, DEFAULT_TIMEOUT_MS);
 	if (fd < 0) {
-		errno = fd;
+		errno = -fd;
 		goto err_free_addrinfo;
 	}
 


### PR DESCRIPTION
Reverts analogdevicesinc/libiio#382

This was a problem in the application, not the library.

The man page for errno states:
Valid error numbers are all positive numbers

The semantics used is `ret` is negative, and errno should be positive.
