### PR TITLE
ci,build: split 'make && make package' commands

### DIFF
--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -19,7 +19,9 @@ handle_ubuntu_docker() {
 
 handle_default() {
 	sudo apt-get -qq update
-	sudo apt-get install -y cmake graphviz libaio-dev libavahi-client-dev libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar bzip2 gzip flex bison git
+	sudo apt-get install -y cmake graphviz libaio-dev libavahi-client-dev \
+		libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar \
+		bzip2 gzip flex bison git python-pip
 	if [ -n "${GH_DOC_TOKEN}" ] ; then
 		sudo apt-get install -y doxygen
 	fi

--- a/CI/travis/make_darwin
+++ b/CI/travis/make_darwin
@@ -9,5 +9,6 @@ ls
 
 cd $TRAVIS_BUILD_DIR/build_tar
 cmake -DOSX_PACKAGE=OFF -DENABLE_PACKAGING=ON -DPYTHON_BINDINGS=ON ..
-make && make package
+make
+make package
 ls

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -24,7 +24,8 @@ handle_default() {
 	cmake -DENABLE_PACKAGING=ON -DDEB_DETECT_DEPENDENCIES=ON \
 		-DPYTHON_BINDINGS=ON ${DOC_FOUND} ..
 
-	make && make package
+	make
+	make package
 	if [ -n "${GH_DOC_TOKEN}" ] && \
 			[ -f "./generateDocumentationAndDeploy.sh" ] ; then
 		sh generateDocumentationAndDeploy.sh
@@ -36,7 +37,8 @@ handle_centos() {
 	mkdir -p build
 	cd build
 	cmake -DENABLE_PACKAGING=ON -DPYTHON_BINDINGS=ON ..
-	make && make package
+	make
+	make package
 	cd ..
 }
 


### PR DESCRIPTION
Fixes #398 

For some reason, doing `make && make package` doesn't seem to yield a
compiler/build error on Linux.
This may be due to how '/bin/sh' interprets command concatenation via '&&'.
Splitting the make commands seems to help.

See:
  https://travis-ci.org/github/analogdevicesinc/libiio/builds/661401114

This is essentially branch 'rgetz-review-zeroconfupdates' rebased with this
change.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>