### PR TITLE
Fixed warnings on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,12 @@ if (CMAKE_COMPILER_IS_GNUCC)
 	endif()
 endif()
 
+if(APPLE)
+	#full Single Unix Standard v3 (SUSv3) conformance (the Unix API)
+	add_definitions(-D_DARWIN_C_SOURCE)
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic -Wno-unused-parameter -Wno-sign-compare")
+endif()
+
 include(CheckSymbolExists)
 check_symbol_exists(strdup "string.h" HAS_STRDUP)
 check_symbol_exists(strerror_r "string.h" HAS_STRERROR_R)

--- a/tests/iio_stresstest.c
+++ b/tests/iio_stresstest.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <sys/time.h>
+#include <sys/sysctl.h>
 
 #define MY_NAME "iio_stresstest"
 


### PR DESCRIPTION
- "warning: implicit declaration of function 'sysctlbyname' is invalid in C99"
- "error: unknown type name 'u_int'" after including <sys/sysctl.h>

Signed-off-by: Matej Kenda <matejken@gmail.com>