### PR TITLE
iio_writedev: fix off by one bug when pushing buffers.

### DIFF
--- a/tests/iio_writedev.c
+++ b/tests/iio_writedev.c
@@ -421,6 +421,7 @@ int main(int argc, char **argv)
 	}
 
 	sample_size = iio_device_get_sample_size(dev);
+	bool num_samples_set = num_samples > 0;
 
 	buffer = iio_device_create_buffer(dev, buffer_size, cyclic_buffer);
 	if (!buffer) {
@@ -443,7 +444,7 @@ int main(int argc, char **argv)
 			size_t write_len, len = (intptr_t) iio_buffer_end(buffer)
 				- (intptr_t) start;
 
-			if (num_samples && len > num_samples * sample_size)
+			if (num_samples_set && len > num_samples * sample_size)
 				len = num_samples * sample_size;
 
 			for (write_len = len; len; ) {
@@ -455,9 +456,9 @@ int main(int argc, char **argv)
 				start = (void *)((intptr_t) start + nb);
 			}
 
-			if (num_samples) {
+			if (num_samples_set) {
 				num_samples -= write_len / sample_size;
-				if (!num_samples)
+				if (!num_samples && write_len < buffer_size * sample_size)
 					quit_all(EXIT_SUCCESS);
 			}
 		} else {


### PR DESCRIPTION
When requesting num_sample samples and num_samples is a multiple of buffer_size, the last data bulk of size buffer_size (i.e. the last buffer) is not pushed to the device.
This is happening because the program is entering the if (!num_samples) statement (line 460), closing the buffer before reaching the line where the buffer is pushed.
To solve this problem, I've modified the if statement, adding the condition that the buffer should not be filled up when calling the quit_all() method.
Therefore, the program will now push the last buffer and quit on the next iteration, when the buffer will be empty.
In this situation, num_samples will become 0 and the program will behave like no num_samples was provided (and therefore pushing all the remaining samples from stdin).
To solve this case, I have added a num_samples_set flag, which is True if and only if num_samples war provided in the program call.

Signed-off-by: Cristi Iacob <cristian.iacob@analog.com>