### PR TITLE
Cleanup includes

### DIFF
--- a/backend.c
+++ b/backend.c
@@ -15,10 +15,10 @@
  * Lesser General Public License for more details.
  */
 
+#include <string.h>
+
 #include "iio-config.h"
 #include "iio-private.h"
-
-#include <string.h>
 
 unsigned int iio_get_backends_count(void)
 {

--- a/buffer.c
+++ b/buffer.c
@@ -16,11 +16,11 @@
  *
  * */
 
-#include "iio-config.h"
-#include "iio-private.h"
-
 #include <errno.h>
 #include <string.h>
+
+#include "iio-config.h"
+#include "iio-private.h"
 
 struct callback_wrapper_data {
 	ssize_t (*callback)(const struct iio_channel *, void *, size_t, void *);

--- a/channel.c
+++ b/channel.c
@@ -16,12 +16,12 @@
  *
  * */
 
-#include "debug.h"
-#include "iio-private.h"
-
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+
+#include "debug.h"
+#include "iio-private.h"
 
 static const char * const iio_chan_type_name_spec[] = {
 	[IIO_VOLTAGE] = "voltage",

--- a/context.c
+++ b/context.c
@@ -16,13 +16,13 @@
  *
  * */
 
+#include <errno.h>
+#include <string.h>
+
 #include "debug.h"
 #include "iio-config.h"
 #include "iio-private.h"
 #include "sort.h"
-
-#include <errno.h>
-#include <string.h>
 
 #ifdef _WIN32
 #define LOCAL_BACKEND 0

--- a/debug.h
+++ b/debug.h
@@ -19,9 +19,9 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
-#include "iio-config.h"
-
 #include <stdio.h>
+
+#include "iio-config.h"
 
 #define NoLog_L 0
 #define Error_L 1

--- a/device.c
+++ b/device.c
@@ -16,13 +16,13 @@
  *
  * */
 
-#include "debug.h"
-#include "iio-private.h"
-
-#include <inttypes.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
+
+#include "debug.h"
+#include "iio-private.h"
 
 static char *get_attr_xml(const char *attr, size_t *length, enum iio_attr_type type)
 {

--- a/dns_sd_avahi.c
+++ b/dns_sd_avahi.c
@@ -16,19 +16,18 @@
  *
  * */
 
-#include "iio.h"
-
 #include <errno.h>
 #include <stdbool.h>
 #include <string.h>
 #include <time.h>
 
-#include <avahi-common/error.h>
-#include <avahi-common/simple-watch.h>
 #include <avahi-client/client.h>
 #include <avahi-client/lookup.h>
+#include <avahi-common/error.h>
+#include <avahi-common/simple-watch.h>
 
 #include "debug.h"
+#include "iio.h"
 
 struct avahi_discovery_data {
 	AvahiSimplePoll *poll;

--- a/dns_sd_bonjour.c
+++ b/dns_sd_bonjour.c
@@ -18,8 +18,9 @@
 
 #include <errno.h>
 #include <sys/types.h>
-#include <netinet/in.h>
+
 #include <arpa/inet.h>
+#include <netinet/in.h>
 
 #include <CFNetwork/CFNetwork.h>
 

--- a/examples/ad9361-iiostream.c
+++ b/examples/ad9361-iiostream.c
@@ -19,11 +19,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  **/
 
+#include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <string.h>
-#include <signal.h>
 #include <stdio.h>
+#include <string.h>
 
 #ifdef __APPLE__
 #include <iio/iio.h>

--- a/examples/ad9371-iiostream.c
+++ b/examples/ad9371-iiostream.c
@@ -20,11 +20,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  **/
 
+#include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <string.h>
-#include <signal.h>
 #include <stdio.h>
+#include <string.h>
 
 #ifdef __APPLE__
 #include <iio/iio.h>

--- a/examples/adrv9009-iiostream.c
+++ b/examples/adrv9009-iiostream.c
@@ -20,11 +20,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  **/
 
+#include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <string.h>
-#include <signal.h>
 #include <stdio.h>
+#include <string.h>
 
 #ifdef __APPLE__
 #include <iio/iio.h>

--- a/examples/dummy-iiostream.c
+++ b/examples/dummy-iiostream.c
@@ -73,16 +73,15 @@
  *
  **/
 
+#include <assert.h>
+#include <errno.h>
+#include <getopt.h>
+#include <inttypes.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
-#include <signal.h>
-#include <stdio.h>
-#include <errno.h>
-#include <getopt.h>
-#include <inttypes.h>
 
 #ifdef __APPLE__
 #include <iio/iio.h>

--- a/examples/iio-monitor.c
+++ b/examples/iio-monitor.c
@@ -27,8 +27,8 @@
 #include <locale.h>
 #include <pthread.h>
 #include <stdbool.h>
-#include <unistd.h>
 #include <string.h>
+#include <unistd.h>
 
 #ifdef __APPLE__
 #include <iio/iio.h>

--- a/iio-private.h
+++ b/iio-private.h
@@ -19,12 +19,12 @@
 #ifndef __IIO_PRIVATE_H__
 #define __IIO_PRIVATE_H__
 
+#include <stdbool.h>
+
 /* Include public interface */
 #include "iio.h"
 
 #include "iio-config.h"
-
-#include <stdbool.h>
 
 #ifdef _MSC_BUILD
 #define inline __inline

--- a/iio.h
+++ b/iio.h
@@ -27,9 +27,9 @@ extern "C" {
 #endif
 
 #include <limits.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <stddef.h>
 
 #if (defined(_WIN32) || defined(__MBED__))
 #ifndef _SSIZE_T_DEFINED

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -16,15 +16,15 @@
  *
  */
 
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
 #include "debug.h"
 #include "iiod-client.h"
 #include "iio-lock.h"
 #include "iio-private.h"
-
-#include <errno.h>
-#include <inttypes.h>
-#include <string.h>
-#include <stdio.h>
 
 struct iiod_client {
 	struct iio_context_pdata *pdata;

--- a/iiod/iiod.c
+++ b/iiod/iiod.c
@@ -16,12 +16,6 @@
  *
  * */
 
-#include "../debug.h"
-#include "../iio.h"
-#include "../iio-config.h"
-#include "ops.h"
-#include "thread-pool.h"
-
 #include <arpa/inet.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -34,19 +28,26 @@
 #include <stdbool.h>
 #include <string.h>
 #include <sys/eventfd.h>
-#include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #ifdef HAVE_AVAHI
-#include <avahi-common/thread-watch.h>
-#include <avahi-common/error.h>
-#include <avahi-common/alternative.h>
-#include <avahi-common/malloc.h>
 #include <avahi-client/client.h>
 #include <avahi-client/publish.h>
+#include <avahi-common/alternative.h>
 #include <avahi-common/domain.h>
+#include <avahi-common/error.h>
+#include <avahi-common/malloc.h>
+#include <avahi-common/thread-watch.h>
 #endif
+
+#include "../debug.h"
+#include "../iio-config.h"
+#include "../iio.h"
+
+#include "ops.h"
+#include "thread-pool.h"
 
 #define MY_NAME "iiod"
 

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -16,22 +16,23 @@
  *
  * */
 
-#include "ops.h"
-#include "parser.h"
-#include "thread-pool.h"
-#include "../debug.h"
-#include "../iio-private.h"
-
 #include <errno.h>
+#include <fcntl.h>
 #include <limits.h>
-#include <pthread.h>
 #include <poll.h>
+#include <pthread.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <string.h>
 #include <sys/eventfd.h>
 #include <time.h>
-#include <fcntl.h>
-#include <signal.h>
+
+
+#include "../debug.h"
+#include "../iio-private.h"
+#include "ops.h"
+#include "parser.h"
+#include "thread-pool.h"
 
 int yyparse(yyscan_t scanner);
 

--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -19,21 +19,22 @@
 #ifndef __OPS_H__
 #define __OPS_H__
 
-#include "../iio-private.h"
-#include "queue.h"
-
 #include <endian.h>
 #include <errno.h>
+#include <poll.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <poll.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
 #if WITH_AIO
 #include <libaio.h>
 #endif
+
+#include "../iio-private.h"
+
+#include "queue.h"
 
 #ifndef __bswap_constant_16
 #define __bswap_constant_16(x) \

--- a/iiod/thread-pool.c
+++ b/iiod/thread-pool.c
@@ -15,8 +15,6 @@
  * Lesser General Public License for more details.
  */
 
-#include "thread-pool.h"
-
 #include <errno.h>
 #include <pthread.h>
 #include <signal.h>
@@ -24,6 +22,8 @@
 #include <stdlib.h>
 #include <sys/eventfd.h>
 #include <unistd.h>
+
+#include "thread-pool.h"
 
 /*
  * This is used to make sure that all active threads have finished cleanup when

--- a/iiod/usbd.c
+++ b/iiod/usbd.c
@@ -15,15 +15,16 @@
  * Lesser General Public License for more details.
  */
 
-#include "../debug.h"
-#include "../iio-private.h"
-#include "ops.h"
-#include "thread-pool.h"
-
 #include <fcntl.h>
 #include <linux/usb/functionfs.h>
 #include <stdint.h>
 #include <string.h>
+
+#include "../debug.h"
+#include "../iio-private.h"
+
+#include "ops.h"
+#include "thread-pool.h"
 
 /* u8"IIO" for non-c11 compilers */
 #define NAME "\x0049\x0049\x004F"

--- a/local.c
+++ b/local.c
@@ -16,12 +16,9 @@
  *
  * */
 
-#include "debug.h"
-#include "iio-private.h"
-#include "sort.h"
-
 #include <dirent.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <limits.h>
 #include <poll.h>
 #include <stdbool.h>
@@ -31,17 +28,18 @@
 #include <sys/eventfd.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
-#include <sys/types.h>
 #include <sys/stat.h>
-#include <unistd.h>
-#include <string.h>
+#include <sys/types.h>
 #include <sys/utsname.h>
 #include <time.h>
 #include <unistd.h>
-#include <fcntl.h>
 #ifdef WITH_LOCAL_CONFIG
 #include <ini.h>
 #endif
+
+#include "debug.h"
+#include "iio-private.h"
+#include "sort.h"
 
 #define DEFAULT_TIMEOUT_MS 1000
 

--- a/lock.c
+++ b/lock.c
@@ -16,8 +16,6 @@
  *
  */
 
-#include "iio-config.h"
-
 #ifdef _WIN32
 #include <windows.h>
 #elif !defined(NO_THREADS)
@@ -25,6 +23,8 @@
 #endif
 
 #include <stdlib.h>
+
+#include "iio-config.h"
 
 struct iio_mutex {
 #ifdef NO_THREADS

--- a/network.c
+++ b/network.c
@@ -16,11 +16,6 @@
  *
  * */
 
-#include "iio-config.h"
-#include "iio-private.h"
-#include "iio-lock.h"
-#include "iiod-client.h"
-
 #include <errno.h>
 #include <fcntl.h>
 #include <stdbool.h>
@@ -38,17 +33,21 @@
 
 #else /* _WIN32 */
 #include <arpa/inet.h>
+#include <net/if.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
-#include <net/if.h>
-#include <sys/mman.h>
 #include <poll.h>
+#include <sys/mman.h>
 #include <sys/socket.h>
 #include <unistd.h>
 #endif /* _WIN32 */
 
 #include "debug.h"
+#include "iio-config.h"
+#include "iio-lock.h"
+#include "iio-private.h"
+#include "iiod-client.h"
 
 #define DEFAULT_TIMEOUT_MS 5000
 

--- a/scan.c
+++ b/scan.c
@@ -15,12 +15,12 @@
  * Lesser General Public License for more details.
  */
 
-#include "iio-config.h"
-#include "iio-private.h"
-
 #include <errno.h>
 #include <stdbool.h>
 #include <string.h>
+
+#include "iio-config.h"
+#include "iio-private.h"
 
 struct iio_scan_context {
 #ifdef WITH_USB_BACKEND

--- a/serial.c
+++ b/serial.c
@@ -16,16 +16,16 @@
  *
  * */
 
-#include "debug.h"
-#include "iio-private.h"
-#include "iio-lock.h"
-#include "iiod-client.h"
-
 #include <errno.h>
 #include <libserialport.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "debug.h"
+#include "iio-private.h"
+#include "iio-lock.h"
+#include "iiod-client.h"
 
 #define DEFAULT_TIMEOUT_MS 1000
 

--- a/sort.c
+++ b/sort.c
@@ -16,8 +16,9 @@
  *
  * */
 
-#include "iio-private.h"
 #include <string.h>
+
+#include "iio-private.h"
 
 /* These are a few functions to do sorting via qsort for various
  * iio structures. For more info, see the qsort(3) man page.

--- a/tests/gen_code.c
+++ b/tests/gen_code.c
@@ -17,10 +17,10 @@
  *
  * */
 
-#include <stdio.h>
-#include <string.h>
 #include <errno.h>
 #include <iio.h>
+#include <stdio.h>
+#include <string.h>
 
 static FILE *fd = NULL;
 static char *uri;

--- a/tests/iio_attr.c
+++ b/tests/iio_attr.c
@@ -20,14 +20,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  * */
 
+#include <ctype.h>
 #include <errno.h>
 #include <getopt.h>
 #include <iio.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
 #include <sys/types.h>
+
 #include "gen_code.h"
 
 #define MY_NAME "iio_attr"

--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -25,7 +25,6 @@
 #include <signal.h>
 #include <stdio.h>
 #include <string.h>
-#include <errno.h>
 
 #define MY_NAME "iio_readdev"
 

--- a/tests/iio_stresstest.c
+++ b/tests/iio_stresstest.c
@@ -18,17 +18,17 @@
 
 #define _DEFAULT_SOURCE
 
+#include <errno.h>
 #include <getopt.h>
 #include <iio.h>
+#include <limits.h>
+#include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 #include <string.h>
-#include <pthread.h>
-#include <unistd.h>
-#include <errno.h>
-#include <limits.h>
-#include <sys/time.h>
 #include <sys/sysctl.h>
+#include <sys/time.h>
+#include <unistd.h>
 
 #define MY_NAME "iio_stresstest"
 

--- a/tests/iio_writedev.c
+++ b/tests/iio_writedev.c
@@ -26,12 +26,11 @@
 #include <signal.h>
 #include <stdio.h>
 #include <string.h>
-#include <errno.h>
 
 #ifdef _WIN32
-#include <windows.h>
 #include <fcntl.h>
 #include <io.h>
+#include <windows.h>
 #else
 #include <unistd.h>
 #endif

--- a/usb.c
+++ b/usb.c
@@ -16,10 +16,6 @@
  *
  * */
 
-#include "iio-lock.h"
-#include "iio-private.h"
-#include "iiod-client.h"
-
 #include <ctype.h>
 #include <errno.h>
 #include <libusb.h>
@@ -31,6 +27,9 @@
 #endif
 
 #include "debug.h"
+#include "iio-lock.h"
+#include "iio-private.h"
+#include "iiod-client.h"
 
 #define DEFAULT_TIMEOUT_MS 5000
 

--- a/utilities.c
+++ b/utilities.c
@@ -19,14 +19,14 @@
 /* Force the XSI version of strerror_r */
 #undef _GNU_SOURCE
 
-#include "iio-config.h"
-#include "iio-private.h"
-
 #include <errno.h>
 #include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include "iio-config.h"
+#include "iio-private.h"
 
 #if defined(_WIN32) || \
 		(defined(__APPLE__) && defined(__MACH__)) || \

--- a/xml.c
+++ b/xml.c
@@ -16,12 +16,12 @@
  *
  * */
 
-#include "debug.h"
-#include "iio-private.h"
-
 #include <errno.h>
 #include <libxml/tree.h>
 #include <string.h>
+
+#include "debug.h"
+#include "iio-private.h"
 
 static int add_attr_to_channel(struct iio_channel *chn, xmlNode *n)
 {


### PR DESCRIPTION
Use a consistent style for include directives throughout the project.
  * Sort includes in a group alphabetically
  * Include global headers before local headers

The main motivation behind this is to eliminate duplicated includes.
Secondary motivation is to have consistent style.

Signed-off-by: Lars-Peter Clausen <lars@metafoo.de>