### PR TITLE
examples: Add -Wextra & -pedantic-errors to the example Makefile

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -16,7 +16,7 @@
 
 TARGETS := ad9361-iiostream ad9371-iiostream adrv9009-iiostream dummy-iiostream iio-monitor
 
-CFLAGS = -Wall -DIIO_CHECK_RET
+CFLAGS = -Wall -Wextra -pedantic -DIIO_CHECK_RET
 
 UNAME_S := $(shell uname -s)
 

--- a/examples/ad9361-iiostream.c
+++ b/examples/ad9361-iiostream.c
@@ -87,7 +87,7 @@ static void shutdown()
 
 static void handle_sig(int sig)
 {
-	printf("Waiting for process to finish...\n");
+	printf("Waiting for process to finish... Got signal %d\n", sig);
 	stop = true;
 }
 
@@ -134,7 +134,7 @@ static bool get_ad9361_stream_dev(struct iio_context *ctx, enum iodev d, struct 
 }
 
 /* finds AD9361 streaming IIO channels */
-static bool get_ad9361_stream_ch(struct iio_context *ctx, enum iodev d, struct iio_device *dev, int chid, struct iio_channel **chn)
+static bool get_ad9361_stream_ch(__notused struct iio_context *ctx, enum iodev d, struct iio_device *dev, int chid, struct iio_channel **chn)
 {
 	*chn = iio_device_find_channel(dev, get_ch_name("voltage", chid), d == TX);
 	if (!*chn)

--- a/examples/ad9371-iiostream.c
+++ b/examples/ad9371-iiostream.c
@@ -85,7 +85,7 @@ static void shutdown()
 
 static void handle_sig(int sig)
 {
-	printf("Waiting for process to finish...\n");
+	printf("Waiting for process to finish... Got signal %d\n", sig);
 	stop = true;
 }
 
@@ -152,7 +152,7 @@ static bool get_ad9371_stream_dev(struct iio_context *ctx, enum iodev d, struct 
 }
 
 /* finds AD9371 streaming IIO channels */
-static bool get_ad9371_stream_ch(struct iio_context *ctx, enum iodev d, struct iio_device *dev, int chid, char modify, struct iio_channel **chn)
+static bool get_ad9371_stream_ch(__notused struct iio_context *ctx, enum iodev d, struct iio_device *dev, int chid, char modify, struct iio_channel **chn)
 {
 	*chn = iio_device_find_channel(dev, modify ? get_ch_name_mod("voltage", chid, modify) : get_ch_name("voltage", chid), d == TX);
 	if (!*chn)
@@ -201,7 +201,7 @@ bool cfg_ad9371_streaming_ch(struct iio_context *ctx, struct stream_cfg *cfg, en
 }
 
 /* simple configuration and streaming */
-int main (int argc, char **argv)
+int main (__notused int argc, __notused char **argv)
 {
 	// Streaming devices
 	struct iio_device *tx;

--- a/examples/adrv9009-iiostream.c
+++ b/examples/adrv9009-iiostream.c
@@ -85,7 +85,7 @@ static void shutdown()
 
 static void handle_sig(int sig)
 {
-	printf("Waiting for process to finish...\n");
+	printf("Waiting for process to finish... Got signal %d\n", sig);
 	stop = true;
 }
 
@@ -152,7 +152,7 @@ static bool get_adrv9009_stream_dev(struct iio_context *ctx, enum iodev d, struc
 }
 
 /* finds adrv9009 streaming IIO channels */
-static bool get_adrv9009_stream_ch(struct iio_context *ctx, enum iodev d, struct iio_device *dev, int chid, char modify, struct iio_channel **chn)
+static bool get_adrv9009_stream_ch(__notused struct iio_context *ctx, enum iodev d, struct iio_device *dev, int chid, char modify, struct iio_channel **chn)
 {
 	*chn = iio_device_find_channel(dev, modify ? get_ch_name_mod("voltage", chid, modify) : get_ch_name("voltage", chid), d == TX);
 	if (!*chn)
@@ -197,7 +197,7 @@ bool cfg_adrv9009_streaming_ch(struct iio_context *ctx, struct stream_cfg *cfg, 
 }
 
 /* simple configuration and streaming */
-int main (int argc, char **argv)
+int main (__notused int argc, __notused char **argv)
 {
 	// Streaming devices
 	struct iio_device *tx;

--- a/examples/iio-monitor.c
+++ b/examples/iio-monitor.c
@@ -38,9 +38,9 @@
 
 #define ARRAY_SIZE(x) (sizeof(x) ? sizeof(x) / sizeof((x)[0]) : 0)
 
-#define RED	020
-#define YELLOW	040
-#define BLUE	050
+#define RED	020u
+#define YELLOW	040u
+#define BLUE	050u
 
 static int selected = -1;
 
@@ -224,11 +224,11 @@ static struct iio_context *show_contexts_screen(void)
 	struct iio_context *ctx = NULL;
 	struct iio_scan_context *scan_ctx;
 	struct iio_context_info **info;
-	unsigned int num_contexts;
+	int num_contexts;
 	CDKSCREEN *screen;
 	CDKSCROLL *list;
 	const char *uri;
-	unsigned int i;
+	int i;
 	bool free_uri;
 	char **items;
 	int ret;


### PR DESCRIPTION
and clean up the resulting errors. This resolves a few codacy issues
that have been lingering for awhile. There shouldn't be any functional
changes from these. I tested most, but not all, since they were all
pretty similar.

Signed-off-by: Robin Getz <robin.getz@analog.com>