### PR TITLE
travis-ci: Do a make install so libiio is on system path

### DIFF
--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -5,6 +5,7 @@ if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 . CI/travis/lib.sh
 
 handle_default() {
+	echo "### making build dir"
 	mkdir -p build
 	cd build
 
@@ -21,10 +22,22 @@ handle_default() {
 	# set it back, to error immediately.
 	set -e
 
+	echo "### cmake -DENABLE_PACKAGING=ON -DDEB_DETECT_DEPENDENCIES=ON"
+	echo "          -DPYTHON_BINDINGS=ON ${DOC_FOUND}"
 	cmake -DENABLE_PACKAGING=ON -DDEB_DETECT_DEPENDENCIES=ON \
 		-DPYTHON_BINDINGS=ON ${DOC_FOUND} ..
 
+	echo "### make"
 	make
+	if [ "$TRAVIS" = "true" ] ; then
+		# make sure the *.so can be found during make package
+		echo "### Installing package as root"
+		sudo make install
+		# get rid of anything that will cause a problem
+		echo "### Deleting install_manifest.txt (created as root)"
+		sudo rm ./install_manifest.txt
+	fi
+	echo "### make package"
 	make package
 	if [ -n "${GH_DOC_TOKEN}" ] && \
 			[ -f "./generateDocumentationAndDeploy.sh" ] ; then
@@ -36,6 +49,7 @@ handle_default() {
 	if [ "$LDIST" = "DO_NOT_DEPLOY" ] ; then
 		./CI/travis/check_kernel.sh
 	fi
+	echo "### All done building"
 }
 
 handle_centos() {


### PR DESCRIPTION
This is a small tweak to try to reduce the travis-ci noise
today, we get errors like:

running install
Traceback (most recent call last):
  File "/home/travis/build/analogdevicesinc/libiio/build/bindings/python/setup.py", line 89, in <module>
    setup(**config)
  File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/home/travis/build/analogdevicesinc/libiio/build/bindings/python/setup.py", line 43, in run
    self._check_libiio_installed()
  File "/home/travis/build/analogdevicesinc/libiio/build/bindings/python/setup.py", line 66, in _check_libiio_installed
    raise Exception(msg)
Exception: The libiio library could not be found.
            libiio needs to be installed first before the python bindings.
            The latest release can be found on GitHub:
            https://github.com/analogdevicesinc/libiio/releases

Since the libiio isn't installed, and on path during the make package
step. This commit does that.

Signed-off-by: Robin Getz <robin.getz@analog.com>