### PR TITLE
ci,build: add Ubuntu 20.04 docker builds 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,11 @@ matrix:
       dist: bionic
       env:
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
+    - os: linux
+      env:
+        - OS_TYPE=ubuntu_docker
+        - OS_VERSION=focal
+        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - compiler: "gcc"
       os: osx
       osx_image: xcode10.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,8 @@ matrix:
         - OS_VERSION=7
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - os: linux
+      dist: bionic
       env:
-        - OS_TYPE=ubuntu_docker
-        - OS_VERSION=bionic
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - compiler: "gcc"
       os: osx

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -22,7 +22,8 @@ handle_default() {
 	sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake graphviz \
 		libaio-dev libavahi-client-dev \
 		libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar \
-		bzip2 gzip flex bison git python-pip
+		bzip2 gzip flex bison git lsb-release python3-pip
+
 	if [ -n "${GH_DOC_TOKEN}" ] ; then
 		sudo apt-get install -y doxygen
 	fi

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -19,7 +19,8 @@ handle_ubuntu_docker() {
 
 handle_default() {
 	sudo apt-get -qq update
-	sudo apt-get install -y cmake graphviz libaio-dev libavahi-client-dev \
+	sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake graphviz \
+		libaio-dev libavahi-client-dev \
 		libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar \
 		bzip2 gzip flex bison git python-pip
 	if [ -n "${GH_DOC_TOKEN}" ] ; then

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -320,6 +320,28 @@ ensure_command_exists() {
 	return 1
 }
 
+version_gt() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" != "$1"; }
+version_le() { test "$(echo "$@" | tr " " "\n" | sort -V | head -n 1)" = "$1"; }
+version_lt() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != "$1"; }
+version_ge() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" = "$1"; }
+
+get_codename() {
+	lsb_release -c -s
+}
+
+get_dist_id() {
+	lsb_release -i -s
+}
+
+get_version() {
+	lsb_release -r -s
+}
+
+is_ubuntu_at_least_ver() {
+	[ "$(get_dist_id)" = "Ubuntu" ] || return 1
+	version_ge "$(get_version)" "$1"
+}
+
 print_github_api_rate_limits() {
 	# See https://developer.github.com/v3/rate_limit/
 	# Note: Accessing this endpoint does not count against your REST API rate limit.


### PR DESCRIPTION
Ubuntu 20.04 should be out in a couple of weeks. But docker images are
currently available.
Start using them.

Also, Ubuntu 20.04 seems to start phasing out some Python2 stuff, so we
need to install python3-pip vs python-pip.
We'll still keep python-pip for older distros, until Ubuntu 20.04 is old
enough.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>