### PR TITLE
ci,build: add generic mechanism for passing some Travis-CI envs

### DIFF
--- a/CI/travis/inside_docker.sh
+++ b/CI/travis/inside_docker.sh
@@ -17,6 +17,10 @@ else
 	exit 1
 fi
 
+if [ -f "/$LIBNAME/inside-travis-ci-docker-env" ] ; then
+	. /$LIBNAME/inside-travis-ci-docker-env
+fi
+
 $CI/travis/before_install_linux "$OS_TYPE"
 
 $CI/travis/make_linux "$OS_TYPE"


### PR DESCRIPTION
This mechanism has been roughly adapted from the way it's done for the
Linux build.
A file is used on the mount-point that is passed to the docker, and the
'inside_docker.sh' script will load it if found.

Also added 3 common/variables. Two of them are used in the Linux build.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>