### PR TITLE
fix #425: add IIO_ prefix to INFO, WARN, DEBUG and ERROR macros

### DIFF
--- a/debug.h
+++ b/debug.h
@@ -47,50 +47,50 @@
 
 #if (LOG_LEVEL >= Debug_L)
 # ifdef COLOR_DEBUG
-#  define DEBUG(str, ...) \
+#  define IIO_DEBUG(str, ...) \
     fprintf(stdout, COLOR_DEBUG "DEBUG: " str COLOR_END, ##__VA_ARGS__)
 # else
-#  define DEBUG(...) \
+#  define IIO_DEBUG(...) \
     fprintf(stdout, "DEBUG: " __VA_ARGS__)
 # endif
 #else
-#define DEBUG(...) do { } while (0)
+#define IIO_DEBUG(...) do { } while (0)
 #endif
 
 #if (LOG_LEVEL >= Info_L)
 # ifdef COLOR_INFO
-#  define INFO(str, ...) \
+#  define IIO_INFO(str, ...) \
     fprintf(stdout, COLOR_INFO str COLOR_END, ##__VA_ARGS__)
 # else
-#  define INFO(...) \
+#  define IIO_INFO(...) \
     fprintf(stdout, __VA_ARGS__)
 # endif
 #else
-#define INFO(...) do { } while (0)
+#define IIO_INFO(...) do { } while (0)
 #endif
 
 #if (LOG_LEVEL >= Warning_L)
 # ifdef COLOR_WARNING
-#  define WARNING(str, ...) \
+#  define IIO_WARNING(str, ...) \
     fprintf(stderr, COLOR_WARNING "WARNING: " str COLOR_END, ##__VA_ARGS__)
 # else
-#  define WARNING(...) \
+#  define IIO_WARNING(...) \
     fprintf(stderr, "WARNING: " __VA_ARGS__)
 # endif
 #else
-#define WARNING(...) do { } while (0)
+#define IIO_WARNING(...) do { } while (0)
 #endif
 
 #if (LOG_LEVEL >= Error_L)
 # ifdef COLOR_ERROR
-#  define ERROR(str, ...) \
+#  define IIO_ERROR(str, ...) \
     fprintf(stderr, COLOR_ERROR "ERROR: " str COLOR_END, ##__VA_ARGS__)
 # else
-#  define ERROR(...) \
+#  define IIO_ERROR(...) \
     fprintf(stderr, "ERROR: " __VA_ARGS__)
 # endif
 #else
-#define ERROR(...) do { } while (0)
+#define IIO_ERROR(...) do { } while (0)
 #endif
 
 #endif

--- a/dns_sd.c
+++ b/dns_sd.c
@@ -53,7 +53,7 @@ static void dnssd_remove_node(struct dns_sd_discovery_data **ddata, int n)
 			ldata = ndata;
 			i++;
 		}
-		ERROR("dnssd_remove_node call when %i exceeds list length (%i)\n", n, i);
+		IIO_ERROR("dnssd_remove_node call when %i exceeds list length (%i)\n", n, i);
 	}
 
 	*ddata = d;
@@ -78,7 +78,7 @@ static int dnssd_fill_context_info(struct iio_context_info *info,
 
 	ctx = network_create_context(addr_str);
 	if (!ctx) {
-		ERROR("No context at %s\n", addr_str);
+		IIO_ERROR("No context at %s\n", addr_str);
 		return -ENOMEM;
 	}
 
@@ -173,20 +173,20 @@ void port_knock_discovery_data(struct dns_sd_discovery_data **ddata)
 
 		/* getaddrinfo() returns a list of address structures */
 		if (ret) {
-			DEBUG("Unable to find host ('%s'): %s\n",
+			IIO_DEBUG("Unable to find host ('%s'): %s\n",
 					ndata->hostname,
 					gai_strerror(ret));
 		} else {
 			for (rp = res; rp != NULL; rp = rp->ai_next) {
 				fd = create_socket(rp, DEFAULT_TIMEOUT_MS);
 				if (fd < 0) {
-					DEBUG("Unable to open %s%s socket ('%s:%d' %s)\n",
+					IIO_DEBUG("Unable to open %s%s socket ('%s:%d' %s)\n",
 							rp->ai_family == AF_INET ? "ipv4" : "",
 							rp->ai_family == AF_INET6? "ipv6" : "",
 					ndata->hostname, ndata->port, ndata->addr_str);
 				} else {
 					close(fd);
-					DEBUG("Something %s%s at '%s:%d' %s)\n",
+					IIO_DEBUG("Something %s%s at '%s:%d' %s)\n",
 							rp->ai_family == AF_INET ? "ipv4" : "",
 							rp->ai_family == AF_INET6? "ipv6" : "",
 							ndata->hostname, ndata->port, ndata->addr_str);
@@ -226,7 +226,7 @@ void remove_dup_discovery_data(struct dns_sd_discovery_data **ddata)
 		for (j = i + 1, mdata = ndata->next; mdata->next != NULL; mdata = mdata->next) {
 			if (!strcmp(mdata->hostname, ndata->hostname) &&
 					!strcmp(mdata->addr_str, ndata->addr_str)){
-				DEBUG("Removing duplicate in list: '%s'\n",
+				IIO_DEBUG("Removing duplicate in list: '%s'\n",
 						ndata->hostname);
 				dnssd_remove_node(&d, j);
 			}
@@ -260,7 +260,7 @@ int dnssd_context_scan(struct iio_scan_backend_context *ctx,
 	for (ndata = ddata; ndata->next != NULL; ndata = ndata->next) {
 		info = iio_scan_result_add(scan_result, 1);
 		if (!info) {
-			ERROR("Out of memory when adding new scan result\n");
+			IIO_ERROR("Out of memory when adding new scan result\n");
 			ret = -ENOMEM;
 			break;
 		}
@@ -268,7 +268,7 @@ int dnssd_context_scan(struct iio_scan_backend_context *ctx,
 		ret = dnssd_fill_context_info(*info,
 				ndata->hostname, ndata->addr_str,ndata->port);
 		if (ret < 0) {
-			DEBUG("Failed to add %s (%s) err: %d\n", ndata->hostname, ndata->addr_str, ret);
+			IIO_DEBUG("Failed to add %s (%s) err: %d\n", ndata->hostname, ndata->addr_str, ret);
 			break;
 		}
 	}

--- a/dns_sd_avahi.c
+++ b/dns_sd_avahi.c
@@ -77,13 +77,13 @@ static void __avahi_resolver_cb(AvahiServiceResolver *resolver,
 	struct dns_sd_discovery_data *ddata = (struct dns_sd_discovery_data *) d;
 
 	if (!resolver) {
-		ERROR("Fatal Error in Avahi Resolver\n");
+		IIO_ERROR("Fatal Error in Avahi Resolver\n");
 		return;
 	}
 
 	switch(event) {
 	case AVAHI_RESOLVER_FAILURE:
-		ERROR("Avahi Resolver: Failed resolve service '%s' "
+		IIO_ERROR("Avahi Resolver: Failed resolve service '%s' "
 				"of type '%s' in domain '%s': %s\n",
 				name, type, domain,
 				avahi_strerror(
@@ -114,13 +114,13 @@ static void __avahi_resolver_cb(AvahiServiceResolver *resolver,
 			ddata->next->poll = ddata->poll;
 			ddata->next->lock = ddata->lock;
 		} else {
-			ERROR("Avahi Resolver : memory failure\n");
+			IIO_ERROR("Avahi Resolver : memory failure\n");
 		}
 		iio_mutex_unlock(ddata->lock);
 
-		DEBUG("Avahi Resolver : service '%s' of type '%s' in domain '%s':\n",
+		IIO_DEBUG("Avahi Resolver : service '%s' of type '%s' in domain '%s':\n",
 				name, type, domain);
-		DEBUG("\t\t%s:%u (%s)\n", host_name, port, ddata->addr_str);
+		IIO_DEBUG("\t\t%s:%u (%s)\n", host_name, port, ddata->addr_str);
 
 		break;
 		}
@@ -139,25 +139,25 @@ static void __avahi_browser_cb(AvahiServiceBrowser *browser,
 	int i;
 
 	if (!browser) {
-		ERROR("Fatal Error in Avahi Browser\n");
+		IIO_ERROR("Fatal Error in Avahi Browser\n");
 		return;
 	}
 
 	switch (event) {
 	case AVAHI_BROWSER_REMOVE:
-		DEBUG("Avahi Browser : REMOVE : "
+		IIO_DEBUG("Avahi Browser : REMOVE : "
 				"service '%s' of type '%s' in domain '%s'\n",
 				name, type, domain);
 		break;
 	case AVAHI_BROWSER_NEW:
-		DEBUG("Avahi Browser : NEW: "
+		IIO_DEBUG("Avahi Browser : NEW: "
 				"service '%s' of type '%s' in domain '%s'\n",
 				name, type, domain);
 		if(!avahi_service_resolver_new(client, iface,
 				proto, name, type, domain,
 				AVAHI_PROTO_UNSPEC, 0,
 				__avahi_resolver_cb, d)) {
-			ERROR("Failed to resolve service '%s\n", name);
+			IIO_ERROR("Failed to resolve service '%s\n", name);
 		} else {
 			iio_mutex_lock(ddata->lock);
 			ddata->found++;
@@ -167,7 +167,7 @@ static void __avahi_browser_cb(AvahiServiceBrowser *browser,
 	case AVAHI_BROWSER_ALL_FOR_NOW:
 		/* Wait for a max of 1 second */
 		i = 0;
-		DEBUG("Avahi Browser : ALL_FOR_NOW Browser : %d, Resolved : %d\n",
+		IIO_DEBUG("Avahi Browser : ALL_FOR_NOW Browser : %d, Resolved : %d\n",
 				ddata->found, ddata->resolved);
 		/* 200 * 5ms = wait 1 second */
 		while ((ddata->found != ddata->resolved)  && i <= 200) {
@@ -180,11 +180,11 @@ static void __avahi_browser_cb(AvahiServiceBrowser *browser,
 		avahi_simple_poll_quit(ddata->poll);
 		break;
 	case AVAHI_BROWSER_FAILURE:
-		DEBUG("Avahi Browser : FAILURE\n");
+		IIO_DEBUG("Avahi Browser : FAILURE\n");
 		avahi_simple_poll_quit(ddata->poll);
 		break;
 	case AVAHI_BROWSER_CACHE_EXHAUSTED:
-		DEBUG("Avahi Browser : CACHE_EXHAUSTED\n");
+		IIO_DEBUG("Avahi Browser : CACHE_EXHAUSTED\n");
 		break;
 	}
 }
@@ -220,7 +220,7 @@ int dnssd_find_hosts(struct dns_sd_discovery_data **ddata)
 	client = avahi_client_new(avahi_simple_poll_get(d->poll),
 			0, NULL, NULL, &ret);
 	if (!client) {
-		ERROR("Unable to create Avahi DNS-SD client :%s\n",
+		IIO_ERROR("Unable to create Avahi DNS-SD client :%s\n",
 				avahi_strerror(ret));
 		goto err_free_poll;
 	}
@@ -230,12 +230,12 @@ int dnssd_find_hosts(struct dns_sd_discovery_data **ddata)
 			"_iio._tcp", NULL, 0, __avahi_browser_cb, d);
 	if (!browser) {
 		ret = avahi_client_errno(client);
-		ERROR("Unable to create Avahi DNS-SD browser: %s\n",
+		IIO_ERROR("Unable to create Avahi DNS-SD browser: %s\n",
 				avahi_strerror(ret));
 		goto err_free_client;
 	}
 
-	DEBUG("Trying to discover host\n");
+	IIO_DEBUG("Trying to discover host\n");
 	avahi_simple_poll_loop(d->poll);
 
 	if (d->resolved) {

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -44,7 +44,7 @@ static ssize_t iiod_client_read_integer(struct iiod_client *client,
 		ret = client->ops->read_line(client->pdata,
 				desc, buf, sizeof(buf));
 		if (ret < 0) {
-			ERROR("READ LINE: %zd\n", ret);
+			IIO_ERROR("READ LINE: %zd\n", ret);
 			return ret;
 		}
 
@@ -571,18 +571,18 @@ static int iiod_client_read_mask(struct iiod_client *client,
 
 	ret = iiod_client_read_all(client, desc, buf, words * 8 + 1);
 	if (ret < 0) {
-		ERROR("READ ALL: %zd\n", ret);
+		IIO_ERROR("READ ALL: %zd\n", ret);
 		goto out_buf_free;
 	} else
 		ret = 0;
 
 	buf[words*8] = '\0';
 
-	DEBUG("Reading mask\n");
+	IIO_DEBUG("Reading mask\n");
 
 	for (i = words, ptr = buf; i > 0; i--) {
 		sscanf(ptr, "%08" PRIx32, &mask[i - 1]);
-		DEBUG("mask[%lu] = 0x%08" PRIx32 "\n",
+		IIO_DEBUG("mask[%lu] = 0x%08" PRIx32 "\n",
 				(unsigned long)(i - 1), mask[i - 1]);
 
 		ptr = (char *) ((uintptr_t) ptr + 8);
@@ -610,7 +610,7 @@ ssize_t iiod_client_read_unlocked(struct iiod_client *client, void *desc,
 
 	ret = iiod_client_write_all(client, desc, buf, strlen(buf));
 	if (ret < 0) {
-		ERROR("WRITE ALL: %zd\n", ret);
+		IIO_ERROR("WRITE ALL: %zd\n", ret);
 		return ret;
 	}
 
@@ -619,7 +619,7 @@ ssize_t iiod_client_read_unlocked(struct iiod_client *client, void *desc,
 
 		ret = iiod_client_read_integer(client, desc, &to_read);
 		if (ret < 0) {
-			ERROR("READ INTEGER: %zd\n", ret);
+			IIO_ERROR("READ INTEGER: %zd\n", ret);
 			return ret;
 		}
 		if (to_read < 0)
@@ -630,7 +630,7 @@ ssize_t iiod_client_read_unlocked(struct iiod_client *client, void *desc,
 		if (mask) {
 			ret = iiod_client_read_mask(client, desc, mask, words);
 			if (ret < 0) {
-				ERROR("READ ALL: %zd\n", ret);
+				IIO_ERROR("READ ALL: %zd\n", ret);
 				return ret;
 			}
 

--- a/iiod/parser.y
+++ b/iiod/parser.y
@@ -95,7 +95,7 @@ ssize_t yy_input(yyscan_t scanner, char *buf, size_t max_size);
 %token <chn> CHANNEL
 %token <value> VALUE;
 
-%destructor { DEBUG("Freeing token \"%s\"\n", $$); free($$); } <word>
+%destructor { IIO_DEBUG("Freeing token \"%s\"\n", $$); free($$); } <word>
 
 %start Line
 %%

--- a/iiod/usbd.c
+++ b/iiod/usbd.c
@@ -204,13 +204,13 @@ static void usbd_main(struct thread_pool *pool, void *d)
 
 		ret = read(pdata->ep0_fd, &event, sizeof(event));
 		if (ret != sizeof(event)) {
-			WARNING("Short read!\n");
+			IIO_WARNING("Short read!\n");
 			continue;
 		}
 
 		ret = handle_event(pdata, &event);
 		if (ret) {
-			ERROR("Unable to handle event: %i\n", ret);
+			IIO_ERROR("Unable to handle event: %i\n", ret);
 			break;
 		}
 

--- a/local.c
+++ b/local.c
@@ -224,7 +224,7 @@ static int set_channel_name(struct iio_channel *chn)
 			return -ENOMEM;
 		strncpy(name, attr0, prefix_len - 1);
 		name[prefix_len - 1] = '\0';
-		DEBUG("Setting name of channel %s to %s\n", chn->id, name);
+		IIO_DEBUG("Setting name of channel %s to %s\n", chn->id, name);
 		chn->name = name;
 
 		/* Shrink the attribute name */
@@ -475,7 +475,7 @@ static ssize_t local_get_buffer(const struct iio_device *dev,
 		if (ret) {
 			ret = (ssize_t) -errno;
 			iio_strerror(errno, err_str, sizeof(err_str));
-			ERROR("Unable to enqueue block: %s\n", err_str);
+			IIO_ERROR("Unable to enqueue block: %s\n", err_str);
 			return ret;
 		}
 
@@ -503,7 +503,7 @@ static ssize_t local_get_buffer(const struct iio_device *dev,
 		if ((!pdata->blocking && ret != -EAGAIN) ||
 				(pdata->blocking && ret != -ETIMEDOUT)) {
 			iio_strerror(errno, err_str, sizeof(err_str));
-			ERROR("Unable to dequeue block: %s\n", err_str);
+			IIO_ERROR("Unable to dequeue block: %s\n", err_str);
 		}
 		return ret;
 	}
@@ -800,7 +800,7 @@ static int channel_write_state(const struct iio_channel *chn, bool en)
 	ssize_t ret;
 
 	if (!chn->pdata->enable_fn) {
-		ERROR("Libiio bug: No \"en\" attribute parsed\n");
+		IIO_ERROR("Libiio bug: No \"en\" attribute parsed\n");
 		return -EINVAL;
 	}
 
@@ -832,10 +832,10 @@ static int enable_high_speed(const struct iio_device *dev)
 
 	if (pdata->cyclic) {
 		nb_blocks = 1;
-		DEBUG("Enabling cyclic mode\n");
+		IIO_DEBUG("Enabling cyclic mode\n");
 	} else {
 		nb_blocks = pdata->max_nb_blocks;
-		DEBUG("Cyclic mode not enabled\n");
+		IIO_DEBUG("Cyclic mode not enabled\n");
 	}
 
 	pdata->blocks = calloc(nb_blocks, sizeof(*pdata->blocks));
@@ -974,7 +974,7 @@ static int local_open(const struct iio_device *dev,
 
 	if (!pdata->is_high_speed) {
 		unsigned long size = samples_count * pdata->max_nb_blocks;
-		WARNING("High-speed mode not enabled\n");
+		IIO_WARNING("High-speed mode not enabled\n");
 
 		/* Cyclic mode is only supported in high-speed mode */
 		if (cyclic) {
@@ -1208,7 +1208,7 @@ static int add_attr_to_device(struct iio_device *dev, const char *attr)
 
 	attrs[dev->nb_attrs++] = name;
 	dev->attrs = attrs;
-	DEBUG("Added attr \'%s\' to device \'%s\'\n", attr, dev->id);
+	IIO_DEBUG("Added attr \'%s\' to device \'%s\'\n", attr, dev->id);
 	return 0;
 }
 
@@ -1248,7 +1248,7 @@ static int handle_protected_scan_element_attr(struct iio_channel *chn,
 
 	} else if (!strcmp(name, "en")) {
 		if (chn->pdata->enable_fn) {
-			ERROR("Libiio bug: \"en\" attribute already parsed for channel %s!\n",
+			IIO_ERROR("Libiio bug: \"en\" attribute already parsed for channel %s!\n",
 					chn->id);
 			return -EINVAL;
 		}
@@ -1294,7 +1294,7 @@ static int add_protected_attr(struct iio_channel *chn, char *name, char *fn)
 	attrs[pdata->nb_protected_attrs++].filename = fn;
 	pdata->protected_attrs = attrs;
 
-	DEBUG("Add protected attr \'%s\' to channel \'%s\'\n", name, chn->id);
+	IIO_DEBUG("Add protected attr \'%s\' to channel \'%s\'\n", name, chn->id);
 	return 0;
 }
 
@@ -1342,7 +1342,7 @@ static int add_attr_to_channel(struct iio_channel *chn,
 	attrs[chn->nb_attrs].filename = fn;
 	attrs[chn->nb_attrs++].name = name;
 	chn->attrs = attrs;
-	DEBUG("Added attr \'%s\' to channel \'%s\'\n", name, chn->id);
+	IIO_DEBUG("Added attr \'%s\' to channel \'%s\'\n", name, chn->id);
 	return 0;
 
 err_free_fn:
@@ -1362,7 +1362,7 @@ static int add_channel_to_device(struct iio_device *dev,
 
 	channels[dev->nb_channels++] = chn;
 	dev->channels = channels;
-	DEBUG("Added %s channel \'%s\' to device \'%s\'\n",
+	IIO_DEBUG("Added %s channel \'%s\' to device \'%s\'\n",
 		chn->is_output ? "output" : "input", chn->id, dev->id);
 
 	return 0;
@@ -1378,7 +1378,7 @@ static int add_device_to_context(struct iio_context *ctx,
 
 	devices[ctx->nb_devices++] = dev;
 	ctx->devices = devices;
-	DEBUG("Added device \'%s\' to context \'%s\'\n", dev->id, ctx->name);
+	IIO_DEBUG("Added device \'%s\' to context \'%s\'\n", dev->id, ctx->name);
 	return 0;
 }
 
@@ -1498,7 +1498,7 @@ static unsigned int is_global_attr(struct iio_channel *chn, const char *attr)
 	if (strncmp(chn->id, attr, len))
 		return 0;
 
-	DEBUG("Found match: %s and %s\n", chn->id, attr);
+	IIO_DEBUG("Found match: %s and %s\n", chn->id, attr);
 	if (chn->id[len] >= '0' && chn->id[len] <= '9') {
 		if (chn->name) {
 			size_t name_len = strlen(chn->name);
@@ -1618,7 +1618,7 @@ static int add_buffer_attr(void *d, const char *path)
 
 	attrs[dev->nb_buffer_attrs++] = attr;
 	dev->buffer_attrs = attrs;
-	DEBUG("Added buffer attr \'%s\' to device \'%s\'\n", attr, dev->id);
+	IIO_DEBUG("Added buffer attr \'%s\' to device \'%s\'\n", attr, dev->id);
 	return 0;
 }
 
@@ -1673,7 +1673,7 @@ static int foreach_in_dir(void *d, const char *path, bool is_dir,
 
 			ret = -errno;
 			iio_strerror(errno, buf, sizeof(buf));
-			ERROR("Unable to open directory %s: %s\n", path, buf);
+			IIO_ERROR("Unable to open directory %s: %s\n", path, buf);
 			goto out_close_dir;
 		}
 
@@ -1681,7 +1681,7 @@ static int foreach_in_dir(void *d, const char *path, bool is_dir,
 		if (stat(buf, &st) < 0) {
 			ret = -errno;
 			iio_strerror(errno, buf, sizeof(buf));
-			ERROR("Unable to stat file: %s\n", buf);
+			IIO_ERROR("Unable to stat file: %s\n", buf);
 			goto out_close_dir;
 		}
 
@@ -1840,7 +1840,7 @@ static int add_debug_attr(void *d, const char *path)
 
 	attrs[dev->nb_debug_attrs++] = name;
 	dev->debug_attrs = attrs;
-	DEBUG("Added debug attr \'%s\' to device \'%s\'\n", name, dev->id);
+	IIO_DEBUG("Added debug attr \'%s\' to device \'%s\'\n", name, dev->id);
 	return 0;
 }
 
@@ -1872,7 +1872,7 @@ static void local_cancel(const struct iio_device *dev)
 		/* If this happens something went very seriously wrong */
 		char err_str[1024];
 		iio_strerror(errno, err_str, sizeof(err_str));
-		ERROR("Unable to signal cancellation event: %s\n", err_str);
+		IIO_ERROR("Unable to signal cancellation event: %s\n", err_str);
 	}
 }
 

--- a/serial.c
+++ b/serial.c
@@ -194,7 +194,7 @@ static ssize_t serial_write_data(struct iio_context_pdata *pdata,
 	ssize_t ret = (ssize_t) libserialport_to_errno(sp_blocking_write(
 				pdata->port, data, len, pdata->timeout_ms));
 
-	DEBUG("Write returned %li: %s\n", (long) ret, data);
+	IIO_DEBUG("Write returned %li: %s\n", (long) ret, data);
 	return ret;
 }
 
@@ -204,7 +204,7 @@ static ssize_t serial_read_data(struct iio_context_pdata *pdata,
 	ssize_t ret = (ssize_t) libserialport_to_errno(sp_blocking_read_next(
 				pdata->port, buf, len, pdata->timeout_ms));
 
-	DEBUG("Read returned %li: %.*s\n", (long) ret, (int) ret, buf);
+	IIO_DEBUG("Read returned %li: %.*s\n", (long) ret, (int) ret, buf);
 	return ret;
 }
 
@@ -215,18 +215,18 @@ static ssize_t serial_read_line(struct iio_context_pdata *pdata,
 	bool found = false;
 	int ret;
 
-	DEBUG("Readline size 0x%lx\n", (unsigned long) len);
+	IIO_DEBUG("Readline size 0x%lx\n", (unsigned long) len);
 
 	for (i = 0; i < len - 1; i++) {
 		ret = libserialport_to_errno(sp_blocking_read_next(
 					pdata->port, &buf[i], 1,
 					pdata->timeout_ms));
 		if (ret < 0) {
-			ERROR("sp_blocking_read_next returned %i\n", ret);
+			IIO_ERROR("sp_blocking_read_next returned %i\n", ret);
 			return (ssize_t) ret;
 		}
 
-		DEBUG("Character: %c\n", buf[i]);
+		IIO_DEBUG("Character: %c\n", buf[i]);
 
 		if (buf[i] != '\n')
 			found = true;
@@ -529,7 +529,7 @@ struct iio_context * serial_create_context_from_uri(const char *uri)
 err_free_dup:
 	free(uri_dup);
 err_bad_uri:
-	ERROR("Bad URI: \'%s\'\n", uri);
+	IIO_ERROR("Bad URI: \'%s\'\n", uri);
 	errno = EINVAL;
 	return NULL;
 }

--- a/xml.c
+++ b/xml.c
@@ -35,13 +35,13 @@ static int add_attr_to_channel(struct iio_channel *chn, xmlNode *n)
 		} else if (!strcmp((char *) attr->name, "filename")) {
 			filename = iio_strdup((char *) attr->children->content);
 		} else {
-			WARNING("Unknown field \'%s\' in channel %s\n",
+			IIO_WARNING("Unknown field \'%s\' in channel %s\n",
 					attr->name, chn->id);
 		}
 	}
 
 	if (!name) {
-		ERROR("Incomplete attribute in channel %s\n", chn->id);
+		IIO_ERROR("Incomplete attribute in channel %s\n", chn->id);
 		goto err_free;
 	}
 
@@ -78,13 +78,13 @@ static int add_attr_to_device(struct iio_device *dev, xmlNode *n, enum iio_attr_
 		if (!strcmp((char *) attr->name, "name")) {
 			name = iio_strdup((char *) attr->children->content);
 		} else {
-			WARNING("Unknown field \'%s\' in device %s\n",
+			IIO_WARNING("Unknown field \'%s\' in device %s\n",
 					attr->name, dev->id);
 		}
 	}
 
 	if (!name) {
-		ERROR("Incomplete attribute in device %s\n", dev->id);
+		IIO_ERROR("Incomplete attribute in device %s\n", dev->id);
 		goto err_free;
 	}
 
@@ -163,7 +163,7 @@ static void setup_scan_element(struct iio_channel *chn, xmlNode *n)
 			chn->format.with_scale = true;
 			chn->format.scale = atof(content);
 		} else {
-			WARNING("Unknown attribute \'%s\' in <scan-element>\n",
+			IIO_WARNING("Unknown attribute \'%s\' in <scan-element>\n",
 					name);
 		}
 	}
@@ -192,15 +192,15 @@ static struct iio_channel * create_channel(struct iio_device *dev, xmlNode *n)
 			if (!strcmp(content, "output"))
 				chn->is_output = true;
 			else if (strcmp(content, "input"))
-				WARNING("Unknown channel type %s\n", content);
+				IIO_WARNING("Unknown channel type %s\n", content);
 		} else {
-			WARNING("Unknown attribute \'%s\' in <channel>\n",
+			IIO_WARNING("Unknown attribute \'%s\' in <channel>\n",
 					name);
 		}
 	}
 
 	if (!chn->id) {
-		ERROR("Incomplete <attribute>\n");
+		IIO_ERROR("Incomplete <attribute>\n");
 		goto err_free_channel;
 	}
 
@@ -212,7 +212,7 @@ static struct iio_channel * create_channel(struct iio_device *dev, xmlNode *n)
 			chn->is_scan_element = true;
 			setup_scan_element(chn, n);
 		} else if (strcmp((char *) n->name, "text")) {
-			WARNING("Unknown children \'%s\' in <channel>\n",
+			IIO_WARNING("Unknown children \'%s\' in <channel>\n",
 					n->name);
 			continue;
 		}
@@ -243,13 +243,13 @@ static struct iio_device * create_device(struct iio_context *ctx, xmlNode *n)
 		} else if (!strcmp((char *) attr->name, "id")) {
 			dev->id = iio_strdup((char *) attr->children->content);
 		} else {
-			WARNING("Unknown attribute \'%s\' in <device>\n",
+			IIO_WARNING("Unknown attribute \'%s\' in <device>\n",
 					attr->name);
 		}
 	}
 
 	if (!dev->id) {
-		ERROR("Unable to read device ID\n");
+		IIO_ERROR("Unable to read device ID\n");
 		goto err_free_device;
 	}
 
@@ -258,14 +258,14 @@ static struct iio_device * create_device(struct iio_context *ctx, xmlNode *n)
 			struct iio_channel **chns,
 					   *chn = create_channel(dev, n);
 			if (!chn) {
-				ERROR("Unable to create channel\n");
+				IIO_ERROR("Unable to create channel\n");
 				goto err_free_device;
 			}
 
 			chns = realloc(dev->channels, (1 + dev->nb_channels) *
 					sizeof(struct iio_channel *));
 			if (!chns) {
-				ERROR("Unable to allocate memory\n");
+				IIO_ERROR("Unable to allocate memory\n");
 				free(chn);
 				goto err_free_device;
 			}
@@ -282,7 +282,7 @@ static struct iio_device * create_device(struct iio_context *ctx, xmlNode *n)
 			if (add_attr_to_device(dev, n, IIO_ATTR_TYPE_BUFFER) < 0)
 				goto err_free_device;
 		} else if (strcmp((char *) n->name, "text")) {
-			WARNING("Unknown children \'%s\' in <device>\n",
+			IIO_WARNING("Unknown children \'%s\' in <device>\n",
 					n->name);
 			continue;
 		}
@@ -347,7 +347,7 @@ static struct iio_context * iio_create_xml_context_helper(xmlDoc *doc)
 
 	root = xmlDocGetRootElement(doc);
 	if (strcmp((char *) root->name, "context")) {
-		ERROR("Unrecognized XML file\n");
+		IIO_ERROR("Unrecognized XML file\n");
 		err = -EINVAL;
 		goto err_free_ctx;
 	}
@@ -357,7 +357,7 @@ static struct iio_context * iio_create_xml_context_helper(xmlDoc *doc)
 			ctx->description = iio_strdup(
 					(char *) attr->children->content);
 		else if (strcmp((char *) attr->name, "name"))
-			WARNING("Unknown parameter \'%s\' in <context>\n",
+			IIO_WARNING("Unknown parameter \'%s\' in <context>\n",
 					(char *) attr->children->content);
 	}
 
@@ -372,21 +372,21 @@ static struct iio_context * iio_create_xml_context_helper(xmlDoc *doc)
 				continue;
 		} else if (strcmp((char *) n->name, "device")) {
 			if (strcmp((char *) n->name, "text"))
-				WARNING("Unknown children \'%s\' in "
+				IIO_WARNING("Unknown children \'%s\' in "
 						"<context>\n", n->name);
 			continue;
 		}
 
 		dev = create_device(ctx, n);
 		if (!dev) {
-			ERROR("Unable to create device\n");
+			IIO_ERROR("Unable to create device\n");
 			goto err_free_devices;
 		}
 
 		devs = realloc(ctx->devices, (1 + ctx->nb_devices) *
 				sizeof(struct iio_device *));
 		if (!devs) {
-			ERROR("Unable to allocate memory\n");
+			IIO_ERROR("Unable to allocate memory\n");
 			free(dev);
 			goto err_free_devices;
 		}
@@ -428,7 +428,7 @@ struct iio_context * xml_create_context(const char *xml_file)
 
 	doc = xmlReadFile(xml_file, NULL, XML_PARSE_DTDVALID);
 	if (!doc) {
-		ERROR("Unable to parse XML file\n");
+		IIO_ERROR("Unable to parse XML file\n");
 		errno = EINVAL;
 		return NULL;
 	}
@@ -447,7 +447,7 @@ struct iio_context * xml_create_context_mem(const char *xml, size_t len)
 
 	doc = xmlReadMemory(xml, (int) len, NULL, NULL, XML_PARSE_DTDVALID);
 	if (!doc) {
-		ERROR("Unable to parse XML file\n");
+		IIO_ERROR("Unable to parse XML file\n");
 		errno = EINVAL;
 		return NULL;
 	}


### PR DESCRIPTION
this namespacing will help avoid collisions like #425 on Windows
and other platforms, that libiio is compiled on.

Signed-off-by: Robin Getz <robin.getz@analog.com>