### PR TITLE
iio_writedev: fix off by one when pushing buffers bug

### DIFF
--- a/tests/iio_writedev.c
+++ b/tests/iio_writedev.c
@@ -472,11 +472,9 @@ int main(int argc, char **argv)
 
 		int ret = iio_buffer_push(buffer);
 		if (ret < 0) {
-			if (app_running) {
-				char buf[256];
-				iio_strerror(-ret, buf, sizeof(buf));
-				fprintf(stderr, "Unable to push buffer: %s\n", buf);
-			}
+			char buf[256];
+			iio_strerror(-ret, buf, sizeof(buf));
+			fprintf(stderr, "Unable to push buffer: %s\n", buf);
 			break;
 		}
 

--- a/tests/iio_writedev.c
+++ b/tests/iio_writedev.c
@@ -91,7 +91,7 @@ static void quit_all(int sig)
 {
 	exit_code = sig;
 	app_running = false;
-	if (buffer)
+	if (buffer && exit_code != EXIT_SUCCESS)
 		iio_buffer_cancel(buffer);
 }
 
@@ -457,8 +457,9 @@ int main(int argc, char **argv)
 
 			if (num_samples) {
 				num_samples -= write_len / sample_size;
-				if (!num_samples)
+				if (!num_samples && !cyclic_buffer) {
 					quit_all(EXIT_SUCCESS);
+				}
 			}
 		} else {
 			ret = iio_buffer_foreach_sample(buffer, read_sample, NULL);


### PR DESCRIPTION
The bug was described in this pull request:
https://github.com/analogdevicesinc/libiio/pull/410

As @commodo suggested, the old solution was a little confusing for future development because it forced the while loop to do an extra iteration in order to find out that all requested samples were sent.
The modifications from this pull request avoid this thing to happen. Instead of calling quit_all(), which also closes the buffer, after reading from stdin the requested number of samples, the program now only sets app_running and exit_code. Therefore the program will now push even the last buffer, which was not pushed in the previous version, and afterwards will exit the while loop.
If the cyclic mode is enabled, app_running should not be set on false in order to enter the while loop which ensures the cyclic behaviour.
Also, the `if (app_running)` statement from the push-error-handling block was hiding some errors (because app_running was set on false by quit_all()). 