### PR TITLE
coverity: fix Argument cannot be negative in libini

### DIFF
--- a/libini/libini.c
+++ b/libini/libini.c
@@ -61,13 +61,14 @@ struct INI *ini_open(const char *file)
 	}
 
 	fseek(f, 0, SEEK_END);
-	len = ftell(f);
+	ret = ftell(f);
 
-	if (!len) {
+	if (ret <= 0) {
 		ret = -EINVAL;
 		goto error_fclose;
 	}
 
+	len = (size_t) ret;
 	buf = malloc(len);
 	if (!buf) {
 		ret = -ENOMEM;


### PR DESCRIPTION
ftell can return -1 on error, and we were not looking
for that before using that with malloc().

Check for the negative return value.

Signed-off-by: Robin Getz <robin.getz@analog.com>