### PR TITLE
cmake: man: Avoid installing empty directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -414,7 +414,7 @@ if(WITH_DOC)
 		COMMENT "Generating C# documentation with Doxygen" VERBATIM)
 
 	if(NOT SKIP_INSTALL_ALL)
-		install(DIRECTORY ${HTML_DEST_DIR}
+		install(DIRECTORY ${CMAKE_HTML_DEST_DIR}
 			DESTINATION ${CMAKE_INSTALL_DOCDIR})
 	endif()
 endif()

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -9,7 +9,7 @@ if (WITH_MAN)
 		)
 	configure_file(
 		${CMAKE_BINARY_DIR}/libiio.3.in
-		${CMAKE_BINARY_DIR}/man/libiio.3 @ONLY)
+		${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_MANDIR}/libiio.3 @ONLY)
 
 	if (WITH_DOC)
 		find_program(MAN2HTML man2html)
@@ -20,7 +20,7 @@ if (WITH_MAN)
 		file(MAKE_DIRECTORY ${CMAKE_HTML_DEST_DIR}/man3)
 		execute_process(
 			COMMAND ${MAN2HTML} -r
-			INPUT_FILE ${CMAKE_BINARY_DIR}/man/libiio.3
+			INPUT_FILE ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_MANDIR}/libiio.3
 			OUTPUT_FILE ${CMAKE_HTML_DEST_DIR}/man3/libiio.3.html
 		)
 	endif()
@@ -28,14 +28,14 @@ if (WITH_MAN)
 		list(APPEND MAN1 iio_attr.1 iio_info.1 iio_readdev.1 iio_reg.1 iio_writedev.1)
 		foreach(_page ${MAN1})
 			configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/${_page}.in
-				${CMAKE_BINARY_DIR}/man/${_page} @ONLY)
+				${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_MANDIR}/${_page} @ONLY)
 		endforeach()
 		if (WITH_DOC)
 			file(MAKE_DIRECTORY ${CMAKE_HTML_DEST_DIR}/man1)
 			foreach(_page ${MAN1})
 				execute_process(
 					COMMAND ${MAN2HTML} -r
-					INPUT_FILE ${CMAKE_BINARY_DIR}/man/${_page}
+					INPUT_FILE ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_MANDIR}/${_page}
 					OUTPUT_FILE ${CMAKE_HTML_DEST_DIR}/man1/${_page}.html
 				)
 			endforeach()
@@ -43,11 +43,11 @@ if (WITH_MAN)
 	endif()
 	# install man files into the BINARY directories,
 	# section 3 = library functions
-	install(DIRECTORY ${CMAKE_BINARY_DIR}/man/
+	install(DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_MANDIR}
 		DESTINATION ${CMAKE_INSTALL_MANDIR}/man3
 		COMPONENT doc FILES_MATCHING PATTERN "*.3*")
 	# section 1 = user commands
-	install(DIRECTORY ${CMAKE_BINARY_DIR}/man/
+	install(DIRECTORY ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_MANDIR}
 		DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
 		COMPONENT doc FILES_MATCHING PATTERN "*.1*")
 


### PR DESCRIPTION
I noticed that empty `CMakeFiles` directories are installed into the man page directories:
```
$ DESTDIR=/tmp/libiio/ ninja -j1 install
[snip]
-- Installing: /tmp/libiio/usr/share/man/man3
-- Installing: /tmp/libiio/usr/share/man/man3/libiio.3
**-- Installing: /tmp/libiio/usr/share/man/man3/CMakeFiles**
-- Installing: /tmp/libiio/usr/share/man/man1
-- Installing: /tmp/libiio/usr/share/man/man1/iio_attr.1
-- Installing: /tmp/libiio/usr/share/man/man1/iio_writedev.1
**-- Installing: /tmp/libiio/usr/share/man/man1/CMakeFiles**
-- Installing: /tmp/libiio/usr/share/man/man1/iio_readdev.1
-- Installing: /tmp/libiio/usr/share/man/man1/iio_info.1
-- Installing: /tmp/libiio/usr/share/man/man1/iio_reg.1
[snip]
```
First patch is a non-functional change to simplify the cmake file by using `foreach`, the second fixes the problem by using a non-cmake directory in which man-pages are created 