### PR TITLE
Codacy (shellcheck): Double quote to prevent globbing and word splitt…

### DIFF
--- a/CI/travis/check_kernel.sh
+++ b/CI/travis/check_kernel.sh
@@ -50,7 +50,7 @@ while IFS="" read -r p ; do
 	key=$(echo ${p//[[:space:],]/})
 	count=$(grep "\[$key\]" /tmp/libiio_iio_chan_type_name_spec | wc -l)
 	if [ "$count" -eq "0" ] ; then
-		echo $key missing from channel.c iio_chan_type_name_spec
+		echo "$key missing from channel.c iio_chan_type_name_spec"
 		ret=1
 	fi
 done < /tmp/libiio_iio_chan_type
@@ -59,10 +59,10 @@ echo
 sed -i '/IIO_NO_MOD/d' /tmp/libiio_iio_modifier
 
 while IFS="" read -r p ; do
-	key=$(echo ${p//[[:space:],]/})
+	key=$(echo "${p//[[:space:],]/}")
 	count=$(grep "\[$key\]" /tmp/libiio_modifier_names | wc -l)
 	if [ "$count" -eq "0" ] ; then
-		echo $key missing from channel.c modifier_names
+		echo "$key missing from channel.c modifier_names"
 		ret=1
 	fi
 done < /tmp/libiio_iio_modifier

--- a/CI/travis/generateDocumentationAndDeploy.sh.in
+++ b/CI/travis/generateDocumentationAndDeploy.sh.in
@@ -25,13 +25,13 @@ set -x
 
 ##### Setup this script and get the current gh-pages branch.
 echo 'Setting up the script...'
-GH_REPO_NAME=$(echo $TRAVIS_REPO_SLUG | awk -F/ '{print $2}')
+GH_REPO_NAME=$(echo "$TRAVIS_REPO_SLUG" | awk -F/ '{print $2}')
 
 # Exit with nonzero exit code if anything fails
 set -e
 
 # by the time this script is run, we should have already made the docs
-cd $TRAVIS_BUILD_DIR/build
+cd "$TRAVIS_BUILD_DIR/build"
 #docs should be in the $TRAVIS_BUILD_DIR/build/html directory
 if [ ! -d "html" ] || [ ! -f "./html/v@LIBIIO_VERSION_MAJOR@.@LIBIIO_VERSION_MINOR@/@PROJECT_NAME@/index.html" ]; then
 	echo '' >&2
@@ -48,7 +48,7 @@ fi
 
 # Get the current gh-pages branch
 git clone -b gh-pages https://git@github.com/$TRAVIS_REPO_SLUG
-cd $GH_REPO_NAME
+cd "$GH_REPO_NAME"
 
 # Remove everything currently in the gh-pages branch.
 # GitHub is smart enough to know which files have changed and which files have

--- a/CI/travis/inside_docker.sh
+++ b/CI/travis/inside_docker.sh
@@ -6,7 +6,7 @@ OS_TYPE="$2"
 export INSIDE_DOCKER="1"
 export TRAVIS_BUILD_DIR="/$LIBNAME"
 
-cd /$LIBNAME
+cd "/$LIBNAME"
 
 if [ -d "/$LIBNAME/CI" ] ; then
 	CI="/$LIBNAME/CI"
@@ -18,13 +18,13 @@ else
 fi
 
 if [ -f "/$LIBNAME/inside-travis-ci-docker-env" ] ; then
-	. /$LIBNAME/inside-travis-ci-docker-env
+	. "/$LIBNAME/inside-travis-ci-docker-env"
 fi
 
-$CI/travis/before_install_linux "$OS_TYPE"
+"$CI/travis/before_install_linux" "$OS_TYPE"
 
-$CI/travis/make_linux "$OS_TYPE"
+"$CI/travis/make_linux" "$OS_TYPE"
 
 # need to find this out inside the container
-. $CI/travis/lib.sh
-echo "$(get_ldist)" > /${LIBNAME}/build/.LDIST
+. "$CI/travis/lib.sh"
+echo "$(get_ldist)" > "/${LIBNAME}/build/.LDIST"

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -103,7 +103,7 @@ trigger_build() {
 		-H "Travis-API-Version: 3" \
 		-H "Authorization: token $TRAVIS_API_TOKEN" \
 		-d "$body" \
-		https://api.travis-ci.org/repo/$repo_slug/requests
+		"https://api.travis-ci.org/repo/$repo_slug/requests"
 }
 
 trigger_adi_build() {
@@ -155,9 +155,9 @@ get_ldist() {
 }
 
 __brew_install_or_upgrade() {
-	brew install $1 || \
-		brew upgrade $1 || \
-		brew ls --versions $1
+	brew install "$1" || \
+		brew upgrade "$1" || \
+		brew ls --versions "$1"
 }
 
 brew_install_or_upgrade() {
@@ -168,8 +168,8 @@ brew_install_or_upgrade() {
 }
 
 __brew_install_if_not_exists() {
-	brew ls --versions $1 || \
-		brew install $1
+	brew ls --versions "$1" || \
+		brew install "$1"
 }
 
 brew_install_if_not_exists() {
@@ -180,7 +180,7 @@ brew_install_if_not_exists() {
 }
 
 sftp_cmd_pipe() {
-	sftp ${EXTRA_SSH} ${SSHUSER}@${SSHHOST}
+	sftp "${EXTRA_SSH}" "${SSHUSER}@${SSHHOST}"
 }
 
 sftp_rm_artifact() {
@@ -241,12 +241,12 @@ upload_file_to_swdownloads() {
 	local LATE=${branch}_latest_${LIBNAME}${LDIST}${EXT}
 	local GLOB=${DEPLOY_TO}/${branch}_${LIBNAME}-*
 
-	echo attemting to deploy $FROM to $TO
-	echo and ${branch}_${LIBNAME}${LDIST}${EXT}
+	echo attemting to deploy "$FROM" to "$TO"
+	echo and "${branch}_${LIBNAME}${LDIST}${EXT}"
 	ssh -V
 
 	for rmf in ${TO} ${LATE} ; do
-		sftp_rm_artifact ${rmf} || \
+		sftp_rm_artifact "${rmf}" || \
 			echo_blue "Could not delete ${rmf}"
 	done
 
@@ -257,10 +257,10 @@ upload_file_to_swdownloads() {
 
 	# limit things to a few files, so things don't grow forever
 	if [ "${EXT}" = ".deb" ] ; then
-		for files in $(ssh ${EXTRA_SSH} ${SSHUSER}@${SSHHOST} \
+		for files in $(ssh "${EXTRA_SSH}" "${SSHUSER}@${SSHHOST}" \
 			"ls -lt ${GLOB}" | tail -n +100 | awk '{print $NF}')
 		do
-			ssh ${EXTRA_SSH} ${SSHUSER}@${SSHHOST} \
+			ssh "${EXTRA_SSH}" "${SSHUSER}@${SSHHOST}" \
 				"rm ${DEPLOY_TO}/${files}" || \
 				return 1
 		done
@@ -297,7 +297,7 @@ run_docker_script() {
 
 	sudo docker run --rm=true \
 		-v "$(pwd):/${MOUNTPOINT}:rw" \
-		$DOCKER_IMAGE \
+		"$DOCKER_IMAGE" \
 		/bin/bash -e "/${MOUNTPOINT}/${DOCKER_SCRIPT}" "${MOUNTPOINT}" "${OS_TYPE}"
 }
 
@@ -310,10 +310,10 @@ ensure_command_exists() {
 	# go through known package managers
 	for pacman in apt-get brew yum ; do
 		command_exists $pacman || continue
-		$pacman install -y $package || {
+		"$pacman" install -y "$package" || {
 			# Try an update if install doesn't work the first time
-			$pacman -y update && \
-				$pacman install -y $package
+			"$pacman" -y update && \
+				"$pacman" install -y "$package"
 		}
 		return $?
 	done
@@ -367,9 +367,9 @@ for script in $COMMON_SCRIPTS ; do
 	[ ! -f "CI/travis/$script" ] || continue
 	[ ! -f "ci/travis/$script" ] || continue
 	[ ! -f "${LOCAL_BUILD_DIR}/$script" ] || continue
-	mkdir -p ${LOCAL_BUILD_DIR}
+	mkdir -p "${LOCAL_BUILD_DIR}"
 	wget https://raw.githubusercontent.com/analogdevicesinc/libiio/master/CI/travis/$script \
-		-O $LOCAL_BUILD_DIR/$script
+		-O "$LOCAL_BUILD_DIR/$script"
 done
 
 print_github_api_rate_limits

--- a/CI/travis/setup_qemu_for_arm.sh
+++ b/CI/travis/setup_qemu_for_arm.sh
@@ -15,7 +15,7 @@ CHROOT_DIR=/tmp/arm-chroot
 MIRROR=http://archive.raspbian.org/raspbian
 # wheezy = 7 (2013-05-04); jessie = 8 (2015-04-26); stretch = 9 (2017-06-17); buster = 10 (2019-03-12)
 VERSION=$1
-echo building for ${VERSION}
+echo building for "${VERSION}"
 CHROOT_ARCH=armhf
 
 # Host dependencies
@@ -24,7 +24,7 @@ sudo apt-get install -qq -y qemu-user-static binfmt-support sbuild wget debian-a
 # need a newer version of qemu :(
 QEMU_DIR=/tmp/qemu
 sudo mkdir -p ${QEMU_DIR}
-sudo chown ${USER} /tmp/qemu
+sudo chown "${USER}" /tmp/qemu
 cd ${QEMU_DIR}
 wget https://download.qemu.org/qemu-3.1.0.tar.xz
 tar xf qemu-3.1.0.tar.xz
@@ -52,11 +52,11 @@ fi
 
 # Create chrooted environment
 sudo mkdir ${CHROOT_DIR}
-sudo debootstrap --foreign --no-check-gpg --include=fakeroot,build-essential --arch=${CHROOT_ARCH} ${VERSION} ${CHROOT_DIR} ${MIRROR}
+sudo debootstrap --foreign --no-check-gpg --include=fakeroot,build-essential --arch="${CHROOT_ARCH}" "${VERSION}" "${CHROOT_DIR}" "${MIRROR}"
 sudo cp ${QEMU_DIR}/install/bin/qemu-arm ${CHROOT_DIR}/usr/bin/qemu-arm-static
 ${CHROOT_DIR}/usr/bin/qemu-arm-static -version
 sudo chroot ${CHROOT_DIR} ./debootstrap/debootstrap --second-stage
-sudo sbuild-createchroot --arch=${CHROOT_ARCH} --foreign --setup-only ${VERSION} ${CHROOT_DIR} ${MIRROR}
+sudo sbuild-createchroot --arch="${CHROOT_ARCH}" --foreign --setup-only "${VERSION}" "${CHROOT_DIR}" "${MIRROR}"
 
 # Create file with environment variables which will be used inside chrooted
 # environment
@@ -76,8 +76,8 @@ sudo chroot ${CHROOT_DIR} locale-gen
 sudo chroot ${CHROOT_DIR} apt-get --allow-unauthenticated install -qq -y build-essential git m4 sudo python cmake
 
 # Create build dir and copy travis build files to our chroot environment
-sudo mkdir -p ${CHROOT_DIR}/${TRAVIS_BUILD_DIR}
-sudo rsync -av ${TRAVIS_BUILD_DIR}/ ${CHROOT_DIR}/${TRAVIS_BUILD_DIR}/
+sudo mkdir -p "${CHROOT_DIR}/${TRAVIS_BUILD_DIR}"
+sudo rsync -av "${TRAVIS_BUILD_DIR}/" "${CHROOT_DIR}/${TRAVIS_BUILD_DIR}/"
 
 # Indicate chroot environment has been set up
 sudo touch ${CHROOT_DIR}/.chroot_is_done

--- a/man/make_man.sh
+++ b/man/make_man.sh
@@ -87,7 +87,7 @@ Windows, and mbed (via tiny-iiod). The main C structures are:
 .in +.5i
 EOF
 
-tmp=$(grep @struct ${header} | sed 's:^[[:space:]]*\*[[:space:]]*@::g' | awk '{print length($0)}' | sort -n | tail -1)
+tmp=$(grep @struct "${header}" | sed 's:^[[:space:]]*\*[[:space:]]*@::g' | awk '{print length($0)}' | sort -n | tail -1)
 echo  .TP $((tmp - 5))
 
 grep @struct ../iio.h -A 1 | \
@@ -111,24 +111,24 @@ long=0
 longest=""
 
 #go over things by groups
-for i in $(grep -e defgroup ${header} |sed 's|\/\*\*[[:space:]]*||')
+for i in $(grep -e defgroup "${header}" |sed 's|\/\*\*[[:space:]]*||')
 do
 	echo .sp
 	echo "${i//@defgroup /}"
 
-	n=$(grep -e defgroup ${header} | grep -A 1 $i | tail -1 | sed 's|\/\*\*[[:space:]]*||')
-	f=$(awk "/${i}/{f=1;next} /${n}/{f=0} f" ${header} | grep __api | \
+	n=$(grep -e defgroup "${header}" | grep -A 1 "$i" | tail -1 | sed 's|\/\*\*[[:space:]]*||')
+	f=$(awk "/${i}/{f=1;next} /${n}/{f=0} f" "${header}" | grep __api | \
 		awk 'split(substr($0, match($0, /iio[a-z_]*\(/)), a, " ") {print a[1]}' | \
 		sed 's/(.*$//' | grep -ve "^#undef")
 	for func in ${f}
 	do
-		if [ $(echo $func | wc -c) -gt $long ] ; then
-			long=$(echo $func | wc -c)
+		if [ $(echo "$func" | wc -c) -gt "$long" ] ; then
+			long=$(echo "$func" | wc -c)
 			longest=$func
 		fi
 	done
 	echo .in +.5i
-	echo .TP $(echo ${longest} | wc -c)
+	echo .TP $(echo "${longest}" | wc -c)
 	echo .TP
 	echo "\fIFunction\fP"
 	echo "\fIDescription\fP"
@@ -136,12 +136,12 @@ do
 	for func in ${f}
 	do
 		echo -e ".TP\n.B ${func}"
-		l=$(grep -B 40 ${func} ${header} | \
+		l=$(grep -B 40 "${func}" "${header}" | \
 			grep @brief | \
 			tail -1 | \
 			awk '{$1=$2=""; print $0}'| \
 			sed -e 's:^[[:space:]]*::' -e 's:(.*<.*)::')
-		echo ${l}
+		echo "${l}"
 	done
 	echo .LP
 


### PR DESCRIPTION
…ing.

Many places in the CI infrastructure, we do things like:

echo $1

rather than:

echo "$1"

bash will actually:
  - Split the first argument by IFS (spaces, tabs and line feeds).
  - Expand each of them as if it was a glob.
  - Join all the resulting strings and filenames with spaces.
  - then finally print the result.

Quoting variables prevents word splitting and glob expansion, and prevents
scripts from breaking when input contains spaces.

So do that.

Signed-off-by: Robin Getz <robin.getz@analog.com>