### PR TITLE
remove strcpy, and replace with an iio_strlcpy

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -226,12 +226,15 @@ static char * get_scan_element(const struct iio_channel *chn, size_t *length)
 /* Returns a string containing the XML representation of this channel */
 char * iio_channel_get_xml(const struct iio_channel *chn, size_t *length)
 {
-	size_t len = sizeof("<channel id=\"\" name=\"\" "
-			"type=\"output\" ></channel>")
-		+ strlen(chn->id) + (chn->name ? strlen(chn->name) : 0);
-	char *ptr, *str, **attrs, *scan_element = NULL;
+	ssize_t len;
+	char *ptr, *eptr, *str, **attrs, *scan_element = NULL;
 	size_t *attrs_len, scan_element_len = 0;
 	unsigned int i;
+
+	len = sizeof("<channel id=\"\" type=\"\" ></channel>");
+	len += strnlen(chn->id, MAX_CHN_ID);
+	len += chn->is_output ? sizeof("output") : sizeof("input");
+	len += chn->name ? sizeof(" name= ") + strnlen(chn->name, MAX_CHN_NAME) : 0;
 
 	if (chn->is_scan_element) {
 		scan_element = get_scan_element(chn, &scan_element_len);
@@ -260,26 +263,37 @@ char * iio_channel_get_xml(const struct iio_channel *chn, size_t *length)
 	str = malloc(len);
 	if (!str)
 		goto err_free_attrs;
+	eptr = str + len;
 
-	iio_snprintf(str, len, "<channel id=\"%s\"", chn->id);
+	if (len > 0)
+		iio_snprintf(str, len, "<channel id=\"%s\"", chn->id);
 	ptr = strrchr(str, '\0');
+	len = eptr - ptr;
 
 	if (chn->name) {
-		sprintf(ptr, " name=\"%s\"", chn->name);
+		if (len > 0)
+			iio_snprintf(ptr, len, " name=\"%s\"", chn->name);
 		ptr = strrchr(ptr, '\0');
+		len = eptr - ptr;
 	}
 
-	sprintf(ptr, " type=\"%s\" >", chn->is_output ? "output" : "input");
+	if (len > 0)
+		iio_snprintf(ptr, len, " type=\"%s\" >", chn->is_output ? "output" : "input");
 	ptr = strrchr(ptr, '\0');
+	len = eptr - ptr;
 
 	if (chn->is_scan_element) {
-		strcpy(ptr, scan_element);
+		if (len > 0)
+			iio_strlcpy(ptr, scan_element, len);
 		ptr += scan_element_len;
+		len -= scan_element_len;
 	}
 
 	for (i = 0; i < chn->nb_attrs; i++) {
-		strcpy(ptr, attrs[i]);
+		if (len > 0)
+			iio_strlcpy(ptr, attrs[i], len);
 		ptr += attrs_len[i];
+		len -= attrs_len[i];
 		free(attrs[i]);
 	}
 
@@ -287,8 +301,14 @@ char * iio_channel_get_xml(const struct iio_channel *chn, size_t *length)
 	free(attrs);
 	free(attrs_len);
 
-	strcpy(ptr, "</channel>");
+	if (len > 0)
+		iio_strlcpy(ptr, "</channel>", len);
 	*length = ptr - str + sizeof("</channel>") - 1;
+	len -= sizeof("</channel>");
+
+	if (len < 0)
+		IIO_ERROR("Internal libIIO error: iio_channel_get_xml str length isssue\n");
+
 	return str;
 
 err_free_attrs:

--- a/debug.h
+++ b/debug.h
@@ -45,13 +45,20 @@
 #define COLOR_END "\e[0m"
 #endif
 
+/* Many of these debug printf include a Flawfinder: ignore, this is because,
+ * according to https://cwe.mitre.org/data/definitions/134.html which describes
+ * functions that accepts a format string as an argument, but the format
+ * string originates from an external source. All the IIO_DEBUG, IIO_INFO,
+ * IIO_WARNING, and IIO_ERRRO functions are called internally from the
+ * library, have fixed format strings and can not be modified externally.
+ */
 #if (LOG_LEVEL >= Debug_L)
 # ifdef COLOR_DEBUG
 #  define IIO_DEBUG(str, ...) \
-    fprintf(stdout, COLOR_DEBUG "DEBUG: " str COLOR_END, ##__VA_ARGS__)
+    fprintf(stdout, COLOR_DEBUG "DEBUG: " str COLOR_END, ##__VA_ARGS__) /* Flawfinder: ignore */
 # else
 #  define IIO_DEBUG(...) \
-    fprintf(stdout, "DEBUG: " __VA_ARGS__)
+    fprintf(stdout, "DEBUG: " __VA_ARGS__) /* Flawfinder: ignore */
 # endif
 #else
 #define IIO_DEBUG(...) do { } while (0)
@@ -60,10 +67,10 @@
 #if (LOG_LEVEL >= Info_L)
 # ifdef COLOR_INFO
 #  define IIO_INFO(str, ...) \
-    fprintf(stdout, COLOR_INFO str COLOR_END, ##__VA_ARGS__)
+    fprintf(stdout, COLOR_INFO str COLOR_END, ##__VA_ARGS__) /* Flawfinder: ignore */
 # else
 #  define IIO_INFO(...) \
-    fprintf(stdout, __VA_ARGS__)
+    fprintf(stdout, __VA_ARGS__) /* Flawfinder: ignore */
 # endif
 #else
 #define IIO_INFO(...) do { } while (0)
@@ -72,10 +79,10 @@
 #if (LOG_LEVEL >= Warning_L)
 # ifdef COLOR_WARNING
 #  define IIO_WARNING(str, ...) \
-    fprintf(stderr, COLOR_WARNING "WARNING: " str COLOR_END, ##__VA_ARGS__)
+    fprintf(stderr, COLOR_WARNING "WARNING: " str COLOR_END, ##__VA_ARGS__) /* Flawfinder: ignore */
 # else
 #  define IIO_WARNING(...) \
-    fprintf(stderr, "WARNING: " __VA_ARGS__)
+    fprintf(stderr, "WARNING: " __VA_ARGS__) /* Flawfinder: ignore */
 # endif
 #else
 #define IIO_WARNING(...) do { } while (0)
@@ -84,10 +91,10 @@
 #if (LOG_LEVEL >= Error_L)
 # ifdef COLOR_ERROR
 #  define IIO_ERROR(str, ...) \
-    fprintf(stderr, COLOR_ERROR "ERROR: " str COLOR_END, ##__VA_ARGS__)
+    fprintf(stderr, COLOR_ERROR "ERROR: " str COLOR_END, ##__VA_ARGS__) /* Flawfinder: ignore */
 # else
 #  define IIO_ERROR(...) \
-    fprintf(stderr, "ERROR: " __VA_ARGS__)
+    fprintf(stderr, "ERROR: " __VA_ARGS__) /* Flawfinder: ignore */
 # endif
 #else
 #define IIO_ERROR(...) do { } while (0)

--- a/dns_sd.c
+++ b/dns_sd.c
@@ -290,7 +290,7 @@ int dnssd_discover_host(char *addr_str, size_t addr_len, uint16_t *port)
 
 	if (ddata) {
 		*port = ddata->port;
-		strncpy(addr_str, ddata->addr_str, addr_len);
+		iio_strlcpy(addr_str, ddata->addr_str, addr_len);
 	}
 
 host_fail:

--- a/dns_sd.c
+++ b/dns_sd.c
@@ -71,7 +71,7 @@ static int dnssd_fill_context_info(struct iio_context_info *info,
 		char *hostname, char *addr_str, int port)
 {
 	struct iio_context *ctx;
-	char uri[MAXHOSTNAMELEN + 3];
+	char uri[sizeof("ip:") + MAXHOSTNAMELEN + sizeof (":65536") + 1];
 	char description[255], *p;
 	const char *hw_model, *serial;
 	int i;
@@ -83,28 +83,28 @@ static int dnssd_fill_context_info(struct iio_context_info *info,
 	}
 
 	if (port == IIOD_PORT)
-		sprintf(uri, "ip:%s", hostname);
+		iio_snprintf(uri, sizeof(uri), "ip:%s", hostname);
 	else
-		sprintf(uri, "ip:%s:%d", hostname, port);
+		iio_snprintf(uri, sizeof(uri), "ip:%s:%d", hostname, port);
 
 	hw_model = iio_context_get_attr_value(ctx, "hw_model");
 	serial = iio_context_get_attr_value(ctx, "hw_serial");
 
 	if (hw_model && serial) {
-		snprintf(description, sizeof(description), "%s (%s), serial=%s",
+		iio_snprintf(description, sizeof(description), "%s (%s), serial=%s",
 				addr_str, hw_model, serial);
 	} else if (hw_model) {
-		snprintf(description, sizeof(description), "%s %s", addr_str, hw_model);
+		iio_snprintf(description, sizeof(description), "%s %s", addr_str, hw_model);
 	} else if (serial) {
-		snprintf(description, sizeof(description), "%s %s", addr_str, serial);
+		iio_snprintf(description, sizeof(description), "%s %s", addr_str, serial);
 	} else if (ctx->nb_devices == 0) {
-		snprintf(description, sizeof(description), "%s", ctx->description);
+		iio_snprintf(description, sizeof(description), "%s", ctx->description);
 	} else {
-		snprintf(description, sizeof(description), "%s (", addr_str);
+		iio_snprintf(description, sizeof(description), "%s (", addr_str);
 		p = description + strlen(description);
 		for (i = 0; i < ctx->nb_devices - 1; i++) {
 			if (ctx->devices[i]->name) {
-				snprintf(p, sizeof(description) - strlen(description) -1,
+				iio_snprintf(p, sizeof(description) - strlen(description) -1,
 						"%s,",  ctx->devices[i]->name);
 				p += strlen(p);
 			}

--- a/dns_sd_bonjour.c
+++ b/dns_sd_bonjour.c
@@ -144,9 +144,9 @@ static void __cfnet_browser_cb (
 	dd->port = port;
 	dd->hostname = strdup(hostname);
 	if (have_v4) {
-		strncpy(dd->addr_str, address_v4, sizeof(dd->addr_str));
+		iio_strlcpy(dd->addr_str, address_v4, sizeof(dd->addr_str));
 	} else if(have_v6) {
-		strncpy(dd->addr_str, address_v6, sizeof(dd->addr_str));
+		iio_strlcpy(dd->addr_str, address_v6, sizeof(dd->addr_str));
 	}
 
 	IIO_DEBUG("DNS SD: added %s (%s:%d)\n", hostname, dd->addr_str, port);

--- a/iio-private.h
+++ b/iio-private.h
@@ -60,6 +60,11 @@
 #define CLEAR_BIT(addr, bit) \
 	*(((uint32_t *) addr) + BIT_WORD(bit)) &= ~BIT_MASK(bit)
 
+/* 256 is the MAX_NAME (file name) on Linux, but this might evolve over time */
+#define MAX_CHN_ID  256
+#define MAX_CHN_NAME 256
+#define MAX_DEV_ID 256
+#define MAX_DEV_NAME 256
 
 /* ntohl/htonl are a nightmare to use in cross-platform applications,
  * since they are defined in different headers on different platforms.
@@ -289,6 +294,7 @@ void iio_channel_init_finalize(struct iio_channel *chn);
 unsigned int find_channel_modifier(const char *s, size_t *len_p);
 
 char *iio_strdup(const char *str);
+size_t iio_strlcpy(char * __restrict dst, const char * __restrict src, size_t dsize);
 
 int iio_context_add_attr(struct iio_context *ctx,
 		const char *key, const char *value);

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -202,7 +202,7 @@ int iiod_client_get_version(struct iiod_client *client, void *desc,
 	if (minor)
 		*minor = (unsigned int) min;
 	if (git_tag)
-		strncpy(git_tag, ptr, 8);
+		iio_strlcpy(git_tag, ptr, 8);
 	return 0;
 }
 

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -534,17 +534,21 @@ int iiod_client_open_unlocked(struct iiod_client *client, void *desc,
 {
 	char buf[1024], *ptr;
 	size_t i;
+	ssize_t len;
 
-	iio_snprintf(buf, sizeof(buf), "OPEN %s %lu ",
+	len = sizeof(buf);
+	iio_snprintf(buf, len, "OPEN %s %lu ",
 			iio_device_get_id(dev), (unsigned long) samples_count);
 	ptr = buf + strlen(buf);
+	len -= strnlen(buf, sizeof(buf));
 
 	for (i = dev->words; i > 0; i--, ptr += 8) {
-		iio_snprintf(ptr, (ptr - buf) + i * 8, "%08" PRIx32,
+		iio_snprintf(ptr, len, "%08" PRIx32,
 				dev->mask[i - 1]);
+		len -= 8; /* 8 characters */
 	}
 
-	strcpy(ptr, cyclic ? " CYCLIC\r\n" : "\r\n");
+	iio_strlcpy(ptr, cyclic ? " CYCLIC\r\n" : "\r\n", len);
 
 	return iiod_client_exec_command(client, desc, buf);
 }

--- a/iiod/iiod.c
+++ b/iiod/iiod.c
@@ -330,9 +330,9 @@ static int start_avahi(void)
 
 	ret = gethostname(host, sizeof(host));
 	if (!ret) {
-		snprintf(label, sizeof(label), IIOD_ON "%s", host);
+		iio_snprintf(label, sizeof(label), "%s%s", IIOD_ON, host);
 	} else {
-		snprintf(label, sizeof(label), "iiod");
+		iio_snprintf(label, sizeof(label), "iiod");
 	}
 
 	avahi.name = avahi_strdup(label);

--- a/network.c
+++ b/network.c
@@ -1424,7 +1424,7 @@ struct iio_context * network_create_context(const char *host)
 		inet_ntop(AF_INET, &in->sin_addr, description, INET_ADDRSTRLEN);
 #else
 		char *tmp = inet_ntoa(in->sin_addr);
-		strncpy(description, tmp, len);
+		iio_strlcpy(description, tmp, len);
 #endif
 	}
 

--- a/utilities.c
+++ b/utilities.c
@@ -214,3 +214,45 @@ char *iio_strdup(const char *str)
 	return buf;
 #endif
 }
+
+/* strlcpy is designed to be safer, more consistent, and less error prone
+ * replacements for strncpy, since it guarantees to NUL-terminate the result.
+ *
+ * This function
+ * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
+ * https://github.com/freebsd/freebsd/blob/master/sys/libkern/strlcpy.c
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * Copy string src to buffer dst of size dsize.  At most dsize-1
+ * chars will be copied.  Always NUL terminates (unless dsize == 0).
+ * Returns strlen(src); if retval >= dsize, truncation occurred.
+ */
+size_t
+iio_strlcpy(char * __restrict dst, const char * __restrict src, size_t dsize)
+{
+	const char *osrc = src;
+	size_t nleft = dsize;
+
+	/* Copy as many bytes as will fit. */
+	if (nleft != 0) {
+		while (--nleft != 0) {
+			if ((*dst++ = *src++) == '\0')
+				break;
+		}
+	}
+
+	/* Not enough room in dst, add NUL and traverse rest of src. */
+	if (nleft == 0) {
+		if (dsize != 0)
+			*dst = '\0';		/* NUL-terminate dst */
+
+		/* src must be null terminated */ 
+		while (*src++)
+			;
+	}
+
+	return(src - osrc - 1);	/* count does not include NUL */
+}

--- a/utilities.c
+++ b/utilities.c
@@ -180,7 +180,7 @@ void iio_library_get_version(unsigned int *major,
 	if (minor)
 		*minor = LIBIIO_VERSION_MINOR;
 	if (git_tag) {
-		strncpy(git_tag, LIBIIO_VERSION_GIT, 8);
+		iio_strlcpy(git_tag, LIBIIO_VERSION_GIT, 8);
 		git_tag[7] = '\0';
 	}
 }


### PR DESCRIPTION
We used strcpy a few places, which opens up classic buffer overflow
issues so check those, and fix them.

https://cwe.mitre.org/data/definitions/120.html

This adds some internal error checking, as we are building up xml
representations of things, we now keep track of the remaining space
in the buffer, and don't go over if we have no space. (which in theory
should never happen).

Tested on Pluto and M2k to see if this introduces issues, and couldn't
find anything.

Signed-off-by: Robin Getz <robin.getz@analog.com>