### PR TITLE
remove strcpy

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -267,32 +267,29 @@ char * iio_channel_get_xml(const struct iio_channel *chn, size_t *length)
 	eptr = str + len;
 
 	if (len > 0) {
-		iio_snprintf(str, len, "<channel id=\"%s\"", chn->id);
-		ptr = strrchr(str, '\0');
+		ptr += iio_snprintf(str, len, "<channel id=\"%s\"", chn->id);
 		len = eptr - ptr;
 	}
 
 	if (chn->name && len > 0) {
-		iio_snprintf(ptr, len, " name=\"%s\"", chn->name);
-		ptr = strrchr(ptr, '\0');
+		ptr += iio_snprintf(ptr, len, " name=\"%s\"", chn->name);
 		len = eptr - ptr;
 	}
 
 	if (len > 0) {
-		iio_snprintf(ptr, len, " type=\"%s\" >", chn->is_output ? "output" : "input");
-		ptr = strrchr(ptr, '\0');
+		ptr += iio_snprintf(ptr, len, " type=\"%s\" >", chn->is_output ? "output" : "input");
 		len = eptr - ptr;
 	}
 
-	if (chn->is_scan_element && len > 0) {
-		iio_strlcpy(ptr, scan_element, len);
+	if (chn->is_scan_element && len > scan_element_len) {
+		memcpy(ptr, scan_element, scan_element_len); /* Flawfinder: ignore */
 		ptr += scan_element_len;
 		len -= scan_element_len;
 	}
 
 	for (i = 0; i < chn->nb_attrs; i++) {
-		if (len > 0) {
-			iio_strlcpy(ptr, attrs[i], len);
+		if (len > attrs_len[i]) {
+			memcpy(ptr, attrs[i], attrs_len[i]); /* Flawfinder: ignore */
 			ptr += attrs_len[i];
 			len -= attrs_len[i];
 		}
@@ -304,10 +301,11 @@ char * iio_channel_get_xml(const struct iio_channel *chn, size_t *length)
 	free(attrs_len);
 
 	if (len > 0) {
-		iio_strlcpy(ptr, "</channel>", len);
-		len -= sizeof("</channel>");
+		ptr += iio_strlcpy(ptr, "</channel>", len);
+		len -= sizeof("</channel>") -1;
 	}
-	*length = ptr - str + sizeof("</channel>") - 1;
+
+	*length = ptr - str;
 
 	if (len < 0) {
 		IIO_ERROR("Internal libIIO error: iio_channel_get_xml str length isssue\n");

--- a/channel.c
+++ b/channel.c
@@ -226,12 +226,15 @@ static char * get_scan_element(const struct iio_channel *chn, size_t *length)
 /* Returns a string containing the XML representation of this channel */
 char * iio_channel_get_xml(const struct iio_channel *chn, size_t *length)
 {
-	size_t len = sizeof("<channel id=\"\" name=\"\" "
-			"type=\"output\" ></channel>")
-		+ strlen(chn->id) + (chn->name ? strlen(chn->name) : 0);
-	char *ptr, *str, **attrs, *scan_element = NULL;
+	ssize_t len;
+	char *ptr, *eptr, *str, **attrs, *scan_element = NULL;
 	size_t *attrs_len, scan_element_len = 0;
 	unsigned int i;
+
+	len = sizeof("<channel id=\"\" type=\"\" ></channel>");
+	len += strnlen(chn->id, MAX_CHN_ID);
+	len += chn->is_output ? sizeof("output") : sizeof("input");
+	len += chn->name ? sizeof(" name= ") + strnlen(chn->name, MAX_CHN_NAME) : 0;
 
 	if (chn->is_scan_element) {
 		scan_element = get_scan_element(chn, &scan_element_len);
@@ -260,26 +263,32 @@ char * iio_channel_get_xml(const struct iio_channel *chn, size_t *length)
 	str = malloc(len);
 	if (!str)
 		goto err_free_attrs;
+	eptr = str + len;
 
 	iio_snprintf(str, len, "<channel id=\"%s\"", chn->id);
 	ptr = strrchr(str, '\0');
+	len = eptr - ptr;
 
 	if (chn->name) {
 		sprintf(ptr, " name=\"%s\"", chn->name);
 		ptr = strrchr(ptr, '\0');
+		len = eptr - ptr;
 	}
 
 	sprintf(ptr, " type=\"%s\" >", chn->is_output ? "output" : "input");
 	ptr = strrchr(ptr, '\0');
+	len = eptr - ptr;
 
 	if (chn->is_scan_element) {
 		strcpy(ptr, scan_element);
 		ptr += scan_element_len;
+		len -= scan_element_len;
 	}
 
 	for (i = 0; i < chn->nb_attrs; i++) {
 		strcpy(ptr, attrs[i]);
 		ptr += attrs_len[i];
+		len -= attrs_len[i];
 		free(attrs[i]);
 	}
 
@@ -289,6 +298,14 @@ char * iio_channel_get_xml(const struct iio_channel *chn, size_t *length)
 
 	strcpy(ptr, "</channel>");
 	*length = ptr - str + sizeof("</channel>") - 1;
+	len -= sizeof("</channel>");
+
+	if (len < 0) {
+		IIO_ERROR("Internal libIIO error: iio_channel_get_xml str length isssue\n");
+		free(str);
+		return NULL;
+	}
+
 	return str;
 
 err_free_attrs:

--- a/context.c
+++ b/context.c
@@ -104,14 +104,13 @@ char * iio_context_create_xml(const struct iio_context *ctx)
 
 	if (len > 0) {
 		if (ctx->description) {
-			iio_snprintf(str, len, "%s<context name=\"%s\" "
+			ptr += iio_snprintf(str, len, "%s<context name=\"%s\" "
 					"description=\"%s\" >",
 					xml_header, ctx->name, ctx->description);
 		} else {
-			iio_snprintf(str, len, "%s<context name=\"%s\" >",
+			ptr += iio_snprintf(str, len, "%s<context name=\"%s\" >",
 					xml_header, ctx->name);
 		}
-		ptr = strrchr(str, '\0');
 		len = eptr - ptr;
 	}
 
@@ -122,8 +121,8 @@ char * iio_context_create_xml(const struct iio_context *ctx)
 	}
 
 	for (i = 0; i < ctx->nb_devices; i++) {
-		if (len > 0) {
-			iio_strlcpy(ptr, devices[i], len);
+		if (len > devices_len[i]) {
+			memcpy(ptr, devices[i], devices_len[i]); /* Flawfinder: ignore */
 			ptr += devices_len[i];
 			len -= devices_len[i];
 		}
@@ -134,7 +133,7 @@ char * iio_context_create_xml(const struct iio_context *ctx)
 	free(devices_len);
 
 	if (len > 0) {
-		iio_strlcpy(ptr, "</context>", len);
+		ptr += iio_strlcpy(ptr, "</context>", len);
 		len -= sizeof("</context>") - 1;
 	}
 

--- a/device.c
+++ b/device.c
@@ -150,25 +150,32 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	if (!str)
 		goto err_free_debug_attrs;
 	eptr = str + len;
+	ptr = str;
 
-	iio_snprintf(str, len, "<device id=\"%s\"", dev->id);
-	ptr = strrchr(str, '\0');
-	len = eptr - ptr;
+	if (len > 0) {
+		iio_snprintf(str, len, "<device id=\"%s\"", dev->id);
+		ptr = strrchr(str, '\0');
+		len = eptr - ptr;
+	}
 
-	if (dev->name) {
-		sprintf(ptr, " name=\"%s\"", dev->name);
+	if (dev->name && len > 0) {
+		iio_snprintf(ptr, len, " name=\"%s\"", dev->name);
 		ptr = strrchr(ptr, '\0');
 		len = eptr - ptr;
 	}
 
-	strcpy(ptr, " >");
-	ptr += 2;
-	len -= 2;
+	if (len > 0) {
+		iio_strlcpy(ptr, " >", len);
+		ptr += 2;
+		len -= 2;
+	}
 
 	for (i = 0; i < dev->nb_channels; i++) {
-		strcpy(ptr, channels[i]);
-		ptr += channels_len[i];
-		len -= channels_len[i];
+		if (len > 0) {
+			iio_strlcpy(ptr, channels[i], len);
+			ptr += channels_len[i];
+			len -= channels_len[i];
+		}
 		free(channels[i]);
 	}
 
@@ -176,9 +183,11 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	free(channels_len);
 
 	for (i = 0; i < dev->nb_attrs; i++) {
-		strcpy(ptr, attrs[i]);
-		ptr += attrs_len[i];
-		len -= attrs_len[i];
+		if (len > 0) {
+			iio_strlcpy(ptr, attrs[i], len);
+			ptr += attrs_len[i];
+			len -= attrs_len[i];
+		}
 		free(attrs[i]);
 	}
 
@@ -186,9 +195,11 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	free(attrs_len);
 
 	for (i = 0; i < dev->nb_buffer_attrs; i++) {
-		strcpy(ptr, buffer_attrs[i]);
-		ptr += buffer_attrs_len[i];
-		len -= buffer_attrs_len[i];
+		if (len > 0) {
+			iio_strlcpy(ptr, buffer_attrs[i], len);
+			ptr += buffer_attrs_len[i];
+			len -= buffer_attrs_len[i];
+		}
 		free(buffer_attrs[i]);
 	}
 
@@ -196,17 +207,21 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	free(buffer_attrs_len);
 
 	for (i = 0; i < dev->nb_debug_attrs; i++) {
-		strcpy(ptr, debug_attrs[i]);
-		ptr += debug_attrs_len[i];
-		len -= debug_attrs_len[i];
+		if (len > 0) {
+			iio_strlcpy(ptr, debug_attrs[i], len);
+			ptr += debug_attrs_len[i];
+			len -= debug_attrs_len[i];
+		}
 		free(debug_attrs[i]);
 	}
 
 	free(debug_attrs);
 	free(debug_attrs_len);
 
-	strcpy(ptr, "</device>");
-	len -= sizeof("</device>") - 1;
+	if (len > 0) {
+		iio_strlcpy(ptr, "</device>", len);
+		len -= sizeof("</device>") - 1;
+	}
 
 	*length = ptr - str + sizeof("</device>") - 1;
 

--- a/device.c
+++ b/device.c
@@ -65,11 +65,17 @@ static char *get_attr_xml(const char *attr, size_t *length, enum iio_attr_type t
 /* Returns a string containing the XML representation of this device */
 char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 {
-	size_t len = sizeof("<device id=\"\" name=\"\" ></device>")
-		+ strlen(dev->id) + (dev->name ? strlen(dev->name) : 0);
-	char *ptr, *str, **attrs, **channels, **buffer_attrs, **debug_attrs;
+	ssize_t len;
+	char *ptr, *eptr, *str, **attrs, **channels, **buffer_attrs, **debug_attrs;
 	size_t *attrs_len, *channels_len, *buffer_attrs_len, *debug_attrs_len;
 	unsigned int i, j, k;
+
+	len = sizeof("<device id=\"\" ></device> ") - 1;
+	len += strnlen(dev->id, MAX_DEV_ID);
+	if (dev->name) {
+		len += sizeof(" name=\"\"") - 1;
+		len += strnlen(dev->name, MAX_DEV_NAME);
+	}
 
 	attrs_len = malloc(dev->nb_attrs * sizeof(*attrs_len));
 	if (!attrs_len)
@@ -143,21 +149,26 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	str = malloc(len);
 	if (!str)
 		goto err_free_debug_attrs;
+	eptr = str + len;
 
 	iio_snprintf(str, len, "<device id=\"%s\"", dev->id);
 	ptr = strrchr(str, '\0');
+	len = eptr - ptr;
 
 	if (dev->name) {
 		sprintf(ptr, " name=\"%s\"", dev->name);
 		ptr = strrchr(ptr, '\0');
+		len = eptr - ptr;
 	}
 
 	strcpy(ptr, " >");
 	ptr += 2;
+	len -= 2;
 
 	for (i = 0; i < dev->nb_channels; i++) {
 		strcpy(ptr, channels[i]);
 		ptr += channels_len[i];
+		len -= channels_len[i];
 		free(channels[i]);
 	}
 
@@ -167,6 +178,7 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	for (i = 0; i < dev->nb_attrs; i++) {
 		strcpy(ptr, attrs[i]);
 		ptr += attrs_len[i];
+		len -= attrs_len[i];
 		free(attrs[i]);
 	}
 
@@ -176,6 +188,7 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	for (i = 0; i < dev->nb_buffer_attrs; i++) {
 		strcpy(ptr, buffer_attrs[i]);
 		ptr += buffer_attrs_len[i];
+		len -= buffer_attrs_len[i];
 		free(buffer_attrs[i]);
 	}
 
@@ -185,6 +198,7 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	for (i = 0; i < dev->nb_debug_attrs; i++) {
 		strcpy(ptr, debug_attrs[i]);
 		ptr += debug_attrs_len[i];
+		len -= debug_attrs_len[i];
 		free(debug_attrs[i]);
 	}
 
@@ -192,7 +206,16 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	free(debug_attrs_len);
 
 	strcpy(ptr, "</device>");
+	len -= sizeof("</device>") - 1;
+
 	*length = ptr - str + sizeof("</device>") - 1;
+
+	if (len < 0) {
+		IIO_ERROR("Internal libIIO error: iio_device_get_xml str length isssue\n");
+		free(str);
+		return NULL;
+	}
+
 	return str;
 
 err_free_debug_attrs:

--- a/device.c
+++ b/device.c
@@ -153,26 +153,23 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	ptr = str;
 
 	if (len > 0) {
-		iio_snprintf(str, len, "<device id=\"%s\"", dev->id);
-		ptr = strrchr(str, '\0');
+		ptr += iio_snprintf(str, len, "<device id=\"%s\"", dev->id);
 		len = eptr - ptr;
 	}
 
 	if (dev->name && len > 0) {
-		iio_snprintf(ptr, len, " name=\"%s\"", dev->name);
-		ptr = strrchr(ptr, '\0');
+		ptr += iio_snprintf(ptr, len, " name=\"%s\"", dev->name);
 		len = eptr - ptr;
 	}
 
 	if (len > 0) {
-		iio_strlcpy(ptr, " >", len);
-		ptr += 2;
+		ptr += iio_strlcpy(ptr, " >", len);
 		len -= 2;
 	}
 
 	for (i = 0; i < dev->nb_channels; i++) {
-		if (len > 0) {
-			iio_strlcpy(ptr, channels[i], len);
+		if (len > channels_len[i]) {
+			memcpy(ptr, channels[i], channels_len[i]); /* Flawfinder: ignore */
 			ptr += channels_len[i];
 			len -= channels_len[i];
 		}
@@ -183,8 +180,8 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	free(channels_len);
 
 	for (i = 0; i < dev->nb_attrs; i++) {
-		if (len > 0) {
-			iio_strlcpy(ptr, attrs[i], len);
+		if (len > attrs_len[i]) {
+			memcpy(ptr, attrs[i], attrs_len[i]); /* Flawfinder: ignore */
 			ptr += attrs_len[i];
 			len -= attrs_len[i];
 		}
@@ -195,8 +192,8 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	free(attrs_len);
 
 	for (i = 0; i < dev->nb_buffer_attrs; i++) {
-		if (len > 0) {
-			iio_strlcpy(ptr, buffer_attrs[i], len);
+		if (len > buffer_attrs_len[i]) {
+			memcpy(ptr, buffer_attrs[i], buffer_attrs_len[i]); /* Flawfinder: ignore */
 			ptr += buffer_attrs_len[i];
 			len -= buffer_attrs_len[i];
 		}
@@ -207,8 +204,8 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	free(buffer_attrs_len);
 
 	for (i = 0; i < dev->nb_debug_attrs; i++) {
-		if (len > 0) {
-			iio_strlcpy(ptr, debug_attrs[i], len);
+		if (len > debug_attrs_len[i]) {
+			memcpy(ptr, debug_attrs[i], debug_attrs_len[i]); /* Flawfinder: ignore */
 			ptr += debug_attrs_len[i];
 			len -= debug_attrs_len[i];
 		}
@@ -219,11 +216,11 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	free(debug_attrs_len);
 
 	if (len > 0) {
-		iio_strlcpy(ptr, "</device>", len);
+		ptr += iio_strlcpy(ptr, "</device>", len);
 		len -= sizeof("</device>") - 1;
 	}
 
-	*length = ptr - str + sizeof("</device>") - 1;
+	*length = ptr - str;
 
 	if (len < 0) {
 		IIO_ERROR("Internal libIIO error: iio_device_get_xml str length isssue\n");

--- a/iio-private.h
+++ b/iio-private.h
@@ -298,6 +298,7 @@ void iio_channel_init_finalize(struct iio_channel *chn);
 unsigned int find_channel_modifier(const char *s, size_t *len_p);
 
 char *iio_strdup(const char *str);
+size_t iio_strlcpy(char * __restrict dst, const char * __restrict src, size_t dsize);
 
 int iio_context_add_attr(struct iio_context *ctx,
 		const char *key, const char *value);

--- a/iio-private.h
+++ b/iio-private.h
@@ -63,6 +63,8 @@
 /* 256 is the MAX_NAME (file name) on Linux, 4096 is PAGESIZE */
 #define MAX_CHN_ID 256 /* encoded in the sysfs filename */
 #define MAX_CHN_NAME 256 /* encoded in the sysfs filename */
+#define MAX_DEV_ID 256 /* encoded in the sysfs filename */
+#define MAX_DEV_NAME 256 /* encoded in the sysfs filename */
 
 /* ntohl/htonl are a nightmare to use in cross-platform applications,
  * since they are defined in different headers on different platforms.

--- a/iio-private.h
+++ b/iio-private.h
@@ -65,6 +65,10 @@
 #define MAX_CHN_NAME 256 /* encoded in the sysfs filename */
 #define MAX_DEV_ID 256 /* encoded in the sysfs filename */
 #define MAX_DEV_NAME 256 /* encoded in the sysfs filename */
+#define MAX_CTX_NAME 256    /* nominally "xml" */
+#define MAX_CTX_DESC 256    /* nominally "linux ..." */
+#define MAX_ATTR_NAME 256   /* encoded in the sysfs filename */
+#define MAX_ATTR_VALUE 4096 /* Linux page size, could be anything */
 
 /* ntohl/htonl are a nightmare to use in cross-platform applications,
  * since they are defined in different headers on different platforms.

--- a/iio-private.h
+++ b/iio-private.h
@@ -60,6 +60,9 @@
 #define CLEAR_BIT(addr, bit) \
 	*(((uint32_t *) addr) + BIT_WORD(bit)) &= ~BIT_MASK(bit)
 
+/* 256 is the MAX_NAME (file name) on Linux, 4096 is PAGESIZE */
+#define MAX_CHN_ID 256 /* encoded in the sysfs filename */
+#define MAX_CHN_NAME 256 /* encoded in the sysfs filename */
 
 /* ntohl/htonl are a nightmare to use in cross-platform applications,
  * since they are defined in different headers on different platforms.

--- a/utilities.c
+++ b/utilities.c
@@ -214,3 +214,46 @@ char *iio_strdup(const char *str)
 	return buf;
 #endif
 }
+
+/* strlcpy is designed to be safer, more consistent, and less error prone
+ * replacements for strncpy, since it guarantees to NUL-terminate the result.
+ *
+ * This function
+ * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
+ * https://github.com/freebsd/freebsd/blob/master/sys/libkern/strlcpy.c
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * Copy string src to buffer dst of size dsize.  At most dsize-1
+ * chars will be copied.  Always NUL terminates (unless dsize == 0).
+ * Returns strlen(src); if retval >= dsize, truncation occurred.
+ *
+ * src is assumed to be null terminated, if it is not, this function will
+ * dereference unknown memory beyond src.
+ */
+size_t iio_strlcpy(char * __restrict dst, const char * __restrict src, size_t dsize)
+{
+	const char *osrc = src;
+	size_t nleft = dsize;
+
+	/* Copy as many bytes as will fit. */
+	if (nleft != 0) {
+		while (--nleft != 0) {
+			if ((*dst++ = *src++) == '\0')
+				break;
+		}
+	}
+
+	/* Not enough room in dst, add NUL and traverse rest of src. */
+	if (nleft == 0) {
+		if (dsize != 0)
+			*dst = '\0';            /* NUL-terminate dst */
+
+		while (*src++)
+			;
+	}
+
+	return(src - osrc - 1); /* count does not include NUL */
+}


### PR DESCRIPTION
This is a follow on from #439 

It slowly updates some of the core files in a way that should be easier to review, and follow, and bisect. Since this effects the way that the internal xml is built up, one file at a time is changed, the downsides is there are 10 commits in the PR.

- It tracks the length of building up xml files
- adds a iio_strlcpy
- uses things, so there is no chance of undetected buffer overflow
- optimize things to use memcpy where possible.

I will apply the other changes that were in the old branch if/when this gets accepted. That would removes these: 
- 7 instances of `snprintf` (should be using `iio_snprintf`)
- 2 instances of `sprintf`(should be using `iio_snprintf`)
- 8 instances of `strncpy` (should be using `iio_strlcpy`)
- 1 instances of `strcpy` (should be using `iio_strlcpy`)