### PR TITLE
flawfinder: mark some ignores for CWE-134 in debug.h

### DIFF
--- a/debug.h
+++ b/debug.h
@@ -45,13 +45,20 @@
 #define COLOR_END "\e[0m"
 #endif
 
+/* Many of these debug printf include a Flawfinder: ignore, this is because,
+ * according to https://cwe.mitre.org/data/definitions/134.html which describes
+ * functions that accepts a format string as an argument, but the format
+ * string originates from an external source. All the IIO_DEBUG, IIO_INFO,
+ * IIO_WARNING, and IIO_ERRRO functions are called internally from the
+ * library, have fixed format strings and can not be modified externally.
+ */
 #if (LOG_LEVEL >= Debug_L)
 # ifdef COLOR_DEBUG
 #  define IIO_DEBUG(str, ...) \
-    fprintf(stdout, COLOR_DEBUG "DEBUG: " str COLOR_END, ##__VA_ARGS__)
+    fprintf(stdout, COLOR_DEBUG "DEBUG: " str COLOR_END, ##__VA_ARGS__) /* Flawfinder: ignore */
 # else
 #  define IIO_DEBUG(...) \
-    fprintf(stdout, "DEBUG: " __VA_ARGS__)
+    fprintf(stdout, "DEBUG: " __VA_ARGS__) /* Flawfinder: ignore */
 # endif
 #else
 #define IIO_DEBUG(...) do { } while (0)
@@ -60,10 +67,10 @@
 #if (LOG_LEVEL >= Info_L)
 # ifdef COLOR_INFO
 #  define IIO_INFO(str, ...) \
-    fprintf(stdout, COLOR_INFO str COLOR_END, ##__VA_ARGS__)
+    fprintf(stdout, COLOR_INFO str COLOR_END, ##__VA_ARGS__) /* Flawfinder: ignore */
 # else
 #  define IIO_INFO(...) \
-    fprintf(stdout, __VA_ARGS__)
+    fprintf(stdout, __VA_ARGS__) /* Flawfinder: ignore */
 # endif
 #else
 #define IIO_INFO(...) do { } while (0)
@@ -72,10 +79,10 @@
 #if (LOG_LEVEL >= Warning_L)
 # ifdef COLOR_WARNING
 #  define IIO_WARNING(str, ...) \
-    fprintf(stderr, COLOR_WARNING "WARNING: " str COLOR_END, ##__VA_ARGS__)
+    fprintf(stderr, COLOR_WARNING "WARNING: " str COLOR_END, ##__VA_ARGS__) /* Flawfinder: ignore */
 # else
 #  define IIO_WARNING(...) \
-    fprintf(stderr, "WARNING: " __VA_ARGS__)
+    fprintf(stderr, "WARNING: " __VA_ARGS__) /* Flawfinder: ignore */
 # endif
 #else
 #define IIO_WARNING(...) do { } while (0)
@@ -84,10 +91,10 @@
 #if (LOG_LEVEL >= Error_L)
 # ifdef COLOR_ERROR
 #  define IIO_ERROR(str, ...) \
-    fprintf(stderr, COLOR_ERROR "ERROR: " str COLOR_END, ##__VA_ARGS__)
+    fprintf(stderr, COLOR_ERROR "ERROR: " str COLOR_END, ##__VA_ARGS__) /* Flawfinder: ignore */
 # else
 #  define IIO_ERROR(...) \
-    fprintf(stderr, "ERROR: " __VA_ARGS__)
+    fprintf(stderr, "ERROR: " __VA_ARGS__) /* Flawfinder: ignore */
 # endif
 #else
 #define IIO_ERROR(...) do { } while (0)


### PR DESCRIPTION
According to https://cwe.mitre.org/data/definitions/134.html describes
functions that accepts a format string as an argument, but the format
string originates from an external source as dangerous.

This gets tagged on all the IIO_DEBUG, IIO_INFO, IIO_WARNING, and
IIO_ERRRO functions that are in debug.h However, they are always called
internally from the library, have fixed format strings and can not be
modified externally, so mark them as safe.

Signed-off-by: Robin Getz <robin.getz@analog.com>