### PR TITLE
flawfinder : sprintf doesn't check for buffer overflows.

### DIFF
--- a/dns_sd.c
+++ b/dns_sd.c
@@ -71,7 +71,7 @@ static int dnssd_fill_context_info(struct iio_context_info *info,
 		char *hostname, char *addr_str, int port)
 {
 	struct iio_context *ctx;
-	char uri[MAXHOSTNAMELEN + 3];
+	char uri[sizeof("ip:") + MAXHOSTNAMELEN + sizeof (":65535") + 1];
 	char description[255], *p;
 	const char *hw_model, *serial;
 	int i;
@@ -83,28 +83,28 @@ static int dnssd_fill_context_info(struct iio_context_info *info,
 	}
 
 	if (port == IIOD_PORT)
-		sprintf(uri, "ip:%s", hostname);
+		iio_snprintf(uri, sizeof(uri), "ip:%s", hostname);
 	else
-		sprintf(uri, "ip:%s:%d", hostname, port);
+		iio_snprintf(uri, sizeof(uri), "ip:%s:%d", hostname, port);
 
 	hw_model = iio_context_get_attr_value(ctx, "hw_model");
 	serial = iio_context_get_attr_value(ctx, "hw_serial");
 
 	if (hw_model && serial) {
-		snprintf(description, sizeof(description), "%s (%s), serial=%s",
+		iio_snprintf(description, sizeof(description), "%s (%s), serial=%s",
 				addr_str, hw_model, serial);
 	} else if (hw_model) {
-		snprintf(description, sizeof(description), "%s %s", addr_str, hw_model);
+		iio_snprintf(description, sizeof(description), "%s %s", addr_str, hw_model);
 	} else if (serial) {
-		snprintf(description, sizeof(description), "%s %s", addr_str, serial);
+		iio_snprintf(description, sizeof(description), "%s %s", addr_str, serial);
 	} else if (ctx->nb_devices == 0) {
-		snprintf(description, sizeof(description), "%s", ctx->description);
+		iio_snprintf(description, sizeof(description), "%s", ctx->description);
 	} else {
-		snprintf(description, sizeof(description), "%s (", addr_str);
+		iio_snprintf(description, sizeof(description), "%s (", addr_str);
 		p = description + strlen(description);
 		for (i = 0; i < ctx->nb_devices - 1; i++) {
 			if (ctx->devices[i]->name) {
-				snprintf(p, sizeof(description) - strlen(description) -1,
+				iio_snprintf(p, sizeof(description) - strlen(description) -1,
 						"%s,",  ctx->devices[i]->name);
 				p += strlen(p);
 			}

--- a/iiod/iiod.c
+++ b/iiod/iiod.c
@@ -330,9 +330,9 @@ static int start_avahi(void)
 
 	ret = gethostname(host, sizeof(host));
 	if (!ret) {
-		snprintf(label, sizeof(label), IIOD_ON "%s", host);
+		iio_snprintf(label, sizeof(label), "%s%s", IIOD_ON, host);
 	} else {
-		snprintf(label, sizeof(label), "iiod");
+		iio_snprintf(label, sizeof(label), "iiod");
 	}
 
 	avahi.name = avahi_strdup(label);

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -353,7 +353,7 @@ static void print_value(struct parser_pdata *pdata, long value)
 		output(pdata, "\n");
 	} else {
 		char buf[128];
-		sprintf(buf, "%li\n", value);
+		iio_snprintf(buf, sizeof(buf), "%li\n", value);
 		output(pdata, buf);
 	}
 }
@@ -428,14 +428,24 @@ static ssize_t send_data(struct DevEntry *dev, struct ThdEntry *thd, size_t len)
 		unsigned int i;
 		char buf[129], *ptr = buf;
 		uint32_t *mask = demux ? thd->mask : dev->mask;
-		ssize_t ret;
+		ssize_t ret, len;
 
+		len = sizeof(buf);
 		/* Send the current mask */
 		for (i = dev->nb_words; i > 0 && ptr < buf + sizeof(buf);
-				i--, ptr += 8)
-			sprintf(ptr, "%08x", mask[i - 1]);
+				i--, ptr += 8) {
+			iio_snprintf(ptr, len, "%08x", mask[i - 1]);
+			len -= 8;
+		}
 
 		*ptr = '\n';
+		len--;
+
+		if (len < 0) {
+			IIO_ERROR("send_data: string length error\n");
+			return -ENOSPC;
+		}
+
 		ret = write_all(pdata, buf, ptr + 1 - buf);
 		if (ret < 0)
 			return ret;
@@ -830,7 +840,7 @@ static uint32_t *get_mask(const char *mask, size_t *len)
 	ptr = words + nb;
 	while (*mask) {
 		char buf[9];
-		sprintf(buf, "%.*s", 8, mask);
+		iio_snprintf(buf, sizeof(buf), "%.*s", 8, mask);
 		sscanf(buf, "%08x", --ptr);
 		mask += 8;
 		IIO_DEBUG("Mask[%lu]: 0x%08x\n",


### PR DESCRIPTION
https://cwe.mitre.org/data/definitions/120.html points out that
sprintf will overflow buffers, so don't use it.

We move to the internal iio_snprintf, and move a few remaining snprintf
to the same to handle the necessary windows/Linux differences.

Signed-off-by: Robin Getz <robin.getz@analog.com>