### PR TITLE
Cmake/Coverity: Force coverity to check _everything_

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
         - COVERITY_SCAN_PROJECT_NAME="$TRAVIS_REPO_SLUG"
         - COVERITY_SCAN_BRANCH_PATTERN="master"
         - COVERITY_SCAN_NOTIFICATION_EMAIL="robin.getz@analog.com"
-        - COVERITY_SCAN_BUILD_COMMAND_PREPEND="mkdir build && cd build && cmake -DWITH_EXAMPLES=ON .."
+        - COVERITY_SCAN_BUILD_COMMAND_PREPEND="mkdir build && cd build && cmake -DCOVERITY_BUILD=ON -DWITH_EXAMPLES=ON .."
         - COVERITY_SCAN_BUILD_COMMAND="make"
         # The COVERITY_SCAN_TOKEN
         - secure: "QQt2l9IVo0xXWLx7Xqgz/4Iezj7YroY3MKfmG+OhtzkMRx4prhx32/07JMNAcYx6mQrccyZkBNzpYuXlfIZjFL3xDxDj5+iKv5XXpJbRFQGhc5xZtAlzOIqHNMcFc0Aj8J2mZwKfSaDnBdf+nMgKcmn46pYbpJOmPe9iEfeLvvg="

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,6 +352,34 @@ if (WIN32)
 	configure_file(properties.rc.cmakein ${LIBIIO_RC} @ONLY)
 endif()
 
+option(COVERITY_BUILD "Turn on things for Coverity Builds" OFF)
+if (COVERITY_BUILD)
+	# Make sure everything gets turned on
+	list(APPEND LIBIIO_CFILES local.c
+		./libini/libini.c
+		usb.c
+		serial.c
+		network.c
+		dns_sd_avahi.c
+		dns_sd.c
+		xml.c
+		lock.c
+		iiod-client.c
+	)
+	# turn on optional code paths
+	set(WITH_USB_BACKEND ON)
+	set(WITH_NETWORK_BACKEND ON)
+	set(WITH_LOCAL_BACKEND ON)
+	set(WITH_SERIAL_BACKEND ON)
+	set(WITH_XML_BACKEND ON)
+	set(WITH_IIOD ON)
+	set(SKIP_INSTALL_ALL ON)
+	set(ENABLE_IPV6 ON)
+	set(WITH_LOCAL_CONFIG ON)
+	# in case something was already turned on, remove it
+	list(REMOVE_DUPLICATES LIBIIO_CFILES)
+endif()
+
 add_library(iio ${LIBIIO_CFILES} ${LIBIIO_HEADERS} ${LIBIIO_EXTRA_HEADERS} ${LIBIIO_RC})
 set_target_properties(iio PROPERTIES
 	VERSION ${VERSION}


### PR DESCRIPTION
The current Cmake logic is set so that if things (like avahi) are not
installed, it doesn't build or link against it. On normal systems this
make sense.

I recently noticed that coverity builds (which happen on the coverity
servers, not on the Travis-CI servers), don't have external libraries
installed, and then a few options don't get configured/added, and
therefore, don't get checked.

Add an option to the Cmake which blindly adds things (which is fine,
since coverity doesn't actually compile/link things); so all backends
and options get checked.

Signed-off-by: Robin Getz <robin.getz@analog.com>