### PR TITLE
prospector: add a configuration file for prospector

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -1,0 +1,34 @@
+# prospector configuration file
+
+---
+output-format: grouped
+strictness: veryhigh
+doc-warnings: true
+test-warnings: true
+member-warnings: true
+
+frosted:
+  run: false
+
+pyroma:
+  run: false
+
+mypy:
+  run: false
+
+pydocroma:
+  run: true
+
+pep8:
+  run: true
+  disable: [
+    E501,  # Line-length, already controlled by pylint
+  ]
+
+pep257:
+  run: true
+    # see http://pep257.readthedocs.io/en/latest/error_codes.html
+  disable: [
+    D203,  # 1 blank line required before class docstring
+           # conflicts with D0211, No blank lines allowed before class docstring
+  ]


### PR DESCRIPTION
In a few of the recent python commits, @cristi-iacob was running into issues about the pep257 tool complaining when lines were inserted, and then when they were not. I checked into it, and this should resolve things.

The pep257 tool (part of prospector) has two rules:
   D203: 1 blank line required before class docstring
   D211: No blank lines allowed before class docstring

Which conflict, so turn D203 off.

Signed-off-by: Robin Getz <robin.getz@analog.com>