### PR TITLE
Prospector: turn off pylint

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -16,6 +16,9 @@ pyroma:
 mypy:
   run: false
 
+pylint:
+  run: false
+
 pydocroma:
   run: true
 


### PR DESCRIPTION
Pylint is officially supported in Codady on its own. Since we  want better
configurability, disabling Pylint in Prospector and using the standalone
"Pylint" tool in Codacy.

Signed-off-by: Robin Getz <robin.getz@analog.com>