### PR TITLE
Coverity: 'IIO_ASSERT' falsely flags just like 'ASSERT' does. Change it.

### DIFF
--- a/examples/ad9361-iiostream.c
+++ b/examples/ad9361-iiostream.c
@@ -35,7 +35,7 @@
 #define MHZ(x) ((long long)(x*1000000.0 + .5))
 #define GHZ(x) ((long long)(x*1000000000.0 + .5))
 
-#define IIO_ASSERT(expr) { \
+#define IIO_ENSURE(expr) { \
 	if (!(expr)) { \
 		(void) fprintf(stderr, "assertion failed (%s:%d)\n", __FILE__, __LINE__); \
 		(void) abort(); \
@@ -119,7 +119,7 @@ static char* get_ch_name(const char* type, int id)
 static struct iio_device* get_ad9361_phy(struct iio_context *ctx)
 {
 	struct iio_device *dev =  iio_context_find_device(ctx, "ad9361-phy");
-	IIO_ASSERT(dev && "No ad9361-phy found");
+	IIO_ENSURE(dev && "No ad9361-phy found");
 	return dev;
 }
 
@@ -129,7 +129,7 @@ static bool get_ad9361_stream_dev(struct iio_context *ctx, enum iodev d, struct 
 	switch (d) {
 	case TX: *dev = iio_context_find_device(ctx, "cf-ad9361-dds-core-lpc"); return *dev != NULL;
 	case RX: *dev = iio_context_find_device(ctx, "cf-ad9361-lpc");  return *dev != NULL;
-	default: IIO_ASSERT(0); return false;
+	default: IIO_ENSURE(0); return false;
 	}
 }
 
@@ -148,7 +148,7 @@ static bool get_phy_chan(struct iio_context *ctx, enum iodev d, int chid, struct
 	switch (d) {
 	case RX: *chn = iio_device_find_channel(get_ad9361_phy(ctx), get_ch_name("voltage", chid), false); return *chn != NULL;
 	case TX: *chn = iio_device_find_channel(get_ad9361_phy(ctx), get_ch_name("voltage", chid), true);  return *chn != NULL;
-	default: IIO_ASSERT(0); return false;
+	default: IIO_ENSURE(0); return false;
 	}
 }
 
@@ -159,7 +159,7 @@ static bool get_lo_chan(struct iio_context *ctx, enum iodev d, struct iio_channe
 	 // LO chan is always output, i.e. true
 	case RX: *chn = iio_device_find_channel(get_ad9361_phy(ctx), get_ch_name("altvoltage", 0), true); return *chn != NULL;
 	case TX: *chn = iio_device_find_channel(get_ad9361_phy(ctx), get_ch_name("altvoltage", 1), true); return *chn != NULL;
-	default: IIO_ASSERT(0); return false;
+	default: IIO_ENSURE(0); return false;
 	}
 }
 
@@ -203,7 +203,7 @@ int main (int argc, char **argv)
 	struct stream_cfg rxcfg;
 	struct stream_cfg txcfg;
 
-	// Listen to ctrl+c and IIO_ASSERT
+	// Listen to ctrl+c and IIO_ENSURE
 	signal(SIGINT, handle_sig);
 
 	// RX stream config
@@ -220,26 +220,26 @@ int main (int argc, char **argv)
 
 	printf("* Acquiring IIO context\n");
 	if (argc == 1) {
-		IIO_ASSERT((ctx = iio_create_default_context()) && "No context");
+		IIO_ENSURE((ctx = iio_create_default_context()) && "No context");
 	}
 	else if (argc == 2) {
-		IIO_ASSERT((ctx = iio_create_context_from_uri(argv[1])) && "No context");
+		IIO_ENSURE((ctx = iio_create_context_from_uri(argv[1])) && "No context");
 	}
-	IIO_ASSERT(iio_context_get_devices_count(ctx) > 0 && "No devices");
+	IIO_ENSURE(iio_context_get_devices_count(ctx) > 0 && "No devices");
 
 	printf("* Acquiring AD9361 streaming devices\n");
-	IIO_ASSERT(get_ad9361_stream_dev(ctx, TX, &tx) && "No tx dev found");
-	IIO_ASSERT(get_ad9361_stream_dev(ctx, RX, &rx) && "No rx dev found");
+	IIO_ENSURE(get_ad9361_stream_dev(ctx, TX, &tx) && "No tx dev found");
+	IIO_ENSURE(get_ad9361_stream_dev(ctx, RX, &rx) && "No rx dev found");
 
 	printf("* Configuring AD9361 for streaming\n");
-	IIO_ASSERT(cfg_ad9361_streaming_ch(ctx, &rxcfg, RX, 0) && "RX port 0 not found");
-	IIO_ASSERT(cfg_ad9361_streaming_ch(ctx, &txcfg, TX, 0) && "TX port 0 not found");
+	IIO_ENSURE(cfg_ad9361_streaming_ch(ctx, &rxcfg, RX, 0) && "RX port 0 not found");
+	IIO_ENSURE(cfg_ad9361_streaming_ch(ctx, &txcfg, TX, 0) && "TX port 0 not found");
 
 	printf("* Initializing AD9361 IIO streaming channels\n");
-	IIO_ASSERT(get_ad9361_stream_ch(ctx, RX, rx, 0, &rx0_i) && "RX chan i not found");
-	IIO_ASSERT(get_ad9361_stream_ch(ctx, RX, rx, 1, &rx0_q) && "RX chan q not found");
-	IIO_ASSERT(get_ad9361_stream_ch(ctx, TX, tx, 0, &tx0_i) && "TX chan i not found");
-	IIO_ASSERT(get_ad9361_stream_ch(ctx, TX, tx, 1, &tx0_q) && "TX chan q not found");
+	IIO_ENSURE(get_ad9361_stream_ch(ctx, RX, rx, 0, &rx0_i) && "RX chan i not found");
+	IIO_ENSURE(get_ad9361_stream_ch(ctx, RX, rx, 1, &rx0_q) && "RX chan q not found");
+	IIO_ENSURE(get_ad9361_stream_ch(ctx, TX, tx, 0, &tx0_i) && "TX chan i not found");
+	IIO_ENSURE(get_ad9361_stream_ch(ctx, TX, tx, 1, &tx0_q) && "TX chan q not found");
 
 	printf("* Enabling IIO streaming channels\n");
 	iio_channel_enable(rx0_i);

--- a/examples/ad9371-iiostream.c
+++ b/examples/ad9371-iiostream.c
@@ -36,7 +36,7 @@
 #define MHZ(x) ((long long)(x*1000000.0 + .5))
 #define GHZ(x) ((long long)(x*1000000000.0 + .5))
 
-#define IIO_ASSERT(expr) { \
+#define IIO_ENSURE(expr) { \
 	if (!(expr)) { \
 		(void) fprintf(stderr, "assertion failed (%s:%d)\n", __FILE__, __LINE__); \
 		(void) abort(); \
@@ -137,7 +137,7 @@ static char* get_ch_name(const char* type, int id)
 static struct iio_device* get_ad9371_phy(struct iio_context *ctx)
 {
 	struct iio_device *dev =  iio_context_find_device(ctx, "ad9371-phy");
-	IIO_ASSERT(dev && "No ad9371-phy found");
+	IIO_ENSURE(dev && "No ad9371-phy found");
 	return dev;
 }
 
@@ -147,7 +147,7 @@ static bool get_ad9371_stream_dev(struct iio_context *ctx, enum iodev d, struct 
 	switch (d) {
 	case TX: *dev = iio_context_find_device(ctx, "axi-ad9371-tx-hpc"); return *dev != NULL;
 	case RX: *dev = iio_context_find_device(ctx, "axi-ad9371-rx-hpc");  return *dev != NULL;
-	default: IIO_ASSERT(0); return false;
+	default: IIO_ENSURE(0); return false;
 	}
 }
 
@@ -166,7 +166,7 @@ static bool get_phy_chan(struct iio_context *ctx, enum iodev d, int chid, struct
 	switch (d) {
 	case RX: *chn = iio_device_find_channel(get_ad9371_phy(ctx), get_ch_name("voltage", chid), false); return *chn != NULL;
 	case TX: *chn = iio_device_find_channel(get_ad9371_phy(ctx), get_ch_name("voltage", chid), true);  return *chn != NULL;
-	default: IIO_ASSERT(0); return false;
+	default: IIO_ENSURE(0); return false;
 	}
 }
 
@@ -177,7 +177,7 @@ static bool get_lo_chan(struct iio_context *ctx, enum iodev d, struct iio_channe
 	 // LO chan is always output, i.e. true
 	case RX: *chn = iio_device_find_channel(get_ad9371_phy(ctx), get_ch_name("altvoltage", 0), true); return *chn != NULL;
 	case TX: *chn = iio_device_find_channel(get_ad9371_phy(ctx), get_ch_name("altvoltage", 1), true); return *chn != NULL;
-	default: IIO_ASSERT(0); return false;
+	default: IIO_ENSURE(0); return false;
 	}
 }
 
@@ -215,7 +215,7 @@ int main (__notused int argc, __notused char **argv)
 	struct stream_cfg rxcfg;
 	struct stream_cfg txcfg;
 
-	// Listen to ctrl+c and IIO_ASSERT
+	// Listen to ctrl+c and IIO_ENSURE
 	signal(SIGINT, handle_sig);
 
 	// RX stream config
@@ -225,22 +225,22 @@ int main (__notused int argc, __notused char **argv)
 	txcfg.lo_hz = GHZ(2.5); // 2.5 GHz rf frequency
 
 	printf("* Acquiring IIO context\n");
-	IIO_ASSERT((ctx = iio_create_default_context()) && "No context");
-	IIO_ASSERT(iio_context_get_devices_count(ctx) > 0 && "No devices");
+	IIO_ENSURE((ctx = iio_create_default_context()) && "No context");
+	IIO_ENSURE(iio_context_get_devices_count(ctx) > 0 && "No devices");
 
 	printf("* Acquiring AD9371 streaming devices\n");
-	IIO_ASSERT(get_ad9371_stream_dev(ctx, TX, &tx) && "No tx dev found");
-	IIO_ASSERT(get_ad9371_stream_dev(ctx, RX, &rx) && "No rx dev found");
+	IIO_ENSURE(get_ad9371_stream_dev(ctx, TX, &tx) && "No tx dev found");
+	IIO_ENSURE(get_ad9371_stream_dev(ctx, RX, &rx) && "No rx dev found");
 
 	printf("* Configuring AD9371 for streaming\n");
-	IIO_ASSERT(cfg_ad9371_streaming_ch(ctx, &rxcfg, RX, 0) && "RX port 0 not found");
-	IIO_ASSERT(cfg_ad9371_streaming_ch(ctx, &txcfg, TX, 0) && "TX port 0 not found");
+	IIO_ENSURE(cfg_ad9371_streaming_ch(ctx, &rxcfg, RX, 0) && "RX port 0 not found");
+	IIO_ENSURE(cfg_ad9371_streaming_ch(ctx, &txcfg, TX, 0) && "TX port 0 not found");
 
 	printf("* Initializing AD9371 IIO streaming channels\n");
-	IIO_ASSERT(get_ad9371_stream_ch(ctx, RX, rx, 0, 'i', &rx0_i) && "RX chan i not found");
-	IIO_ASSERT(get_ad9371_stream_ch(ctx, RX, rx, 0, 'q', &rx0_q) && "RX chan q not found");
-	IIO_ASSERT(get_ad9371_stream_ch(ctx, TX, tx, 0, 0, &tx0_i) && "TX chan i not found");
-	IIO_ASSERT(get_ad9371_stream_ch(ctx, TX, tx, 1, 0, &tx0_q) && "TX chan q not found");
+	IIO_ENSURE(get_ad9371_stream_ch(ctx, RX, rx, 0, 'i', &rx0_i) && "RX chan i not found");
+	IIO_ENSURE(get_ad9371_stream_ch(ctx, RX, rx, 0, 'q', &rx0_q) && "RX chan q not found");
+	IIO_ENSURE(get_ad9371_stream_ch(ctx, TX, tx, 0, 0, &tx0_i) && "TX chan i not found");
+	IIO_ENSURE(get_ad9371_stream_ch(ctx, TX, tx, 1, 0, &tx0_q) && "TX chan q not found");
 
 	printf("* Enabling IIO streaming channels\n");
 	iio_channel_enable(rx0_i);

--- a/examples/adrv9009-iiostream.c
+++ b/examples/adrv9009-iiostream.c
@@ -36,7 +36,7 @@
 #define MHZ(x) ((long long)(x*1000000.0 + .5))
 #define GHZ(x) ((long long)(x*1000000000.0 + .5))
 
-#define IIO_ASSERT(expr) { \
+#define IIO_ENSURE(expr) { \
 	if (!(expr)) { \
 		(void) fprintf(stderr, "assertion failed (%s:%d)\n", __FILE__, __LINE__); \
 		(void) abort(); \
@@ -137,7 +137,7 @@ static char* get_ch_name(const char* type, int id)
 static struct iio_device* get_adrv9009_phy(struct iio_context *ctx)
 {
 	struct iio_device *dev =  iio_context_find_device(ctx, "adrv9009-phy");
-	IIO_ASSERT(dev && "No adrv9009-phy found");
+	IIO_ENSURE(dev && "No adrv9009-phy found");
 	return dev;
 }
 
@@ -147,7 +147,7 @@ static bool get_adrv9009_stream_dev(struct iio_context *ctx, enum iodev d, struc
 	switch (d) {
 	case TX: *dev = iio_context_find_device(ctx, "axi-adrv9009-tx-hpc"); return *dev != NULL;
 	case RX: *dev = iio_context_find_device(ctx, "axi-adrv9009-rx-hpc");  return *dev != NULL;
-	default: IIO_ASSERT(0); return false;
+	default: IIO_ENSURE(0); return false;
 	}
 }
 
@@ -166,7 +166,7 @@ static bool get_phy_chan(struct iio_context *ctx, enum iodev d, int chid, struct
 	switch (d) {
 	case RX: *chn = iio_device_find_channel(get_adrv9009_phy(ctx), get_ch_name("voltage", chid), false); return *chn != NULL;
 	case TX: *chn = iio_device_find_channel(get_adrv9009_phy(ctx), get_ch_name("voltage", chid), true);  return *chn != NULL;
-	default: IIO_ASSERT(0); return false;
+	default: IIO_ENSURE(0); return false;
 	}
 }
 
@@ -210,28 +210,28 @@ int main (__notused int argc, __notused char **argv)
 	// Stream configuration
 	struct stream_cfg trxcfg;
 
-	// Listen to ctrl+c and IIO_ASSERT
+	// Listen to ctrl+c and IIO_ENSURE
 	signal(SIGINT, handle_sig);
 
 	// TRX stream config
 	trxcfg.lo_hz = GHZ(2.5);
 
 	printf("* Acquiring IIO context\n");
-	IIO_ASSERT((ctx = iio_create_default_context()) && "No context");
-	IIO_ASSERT(iio_context_get_devices_count(ctx) > 0 && "No devices");
+	IIO_ENSURE((ctx = iio_create_default_context()) && "No context");
+	IIO_ENSURE(iio_context_get_devices_count(ctx) > 0 && "No devices");
 
 	printf("* Acquiring ADRV9009 streaming devices\n");
-	IIO_ASSERT(get_adrv9009_stream_dev(ctx, TX, &tx) && "No tx dev found");
-	IIO_ASSERT(get_adrv9009_stream_dev(ctx, RX, &rx) && "No rx dev found");
+	IIO_ENSURE(get_adrv9009_stream_dev(ctx, TX, &tx) && "No tx dev found");
+	IIO_ENSURE(get_adrv9009_stream_dev(ctx, RX, &rx) && "No rx dev found");
 
 	printf("* Configuring ADRV9009 for streaming\n");
-	IIO_ASSERT(cfg_adrv9009_streaming_ch(ctx, &trxcfg, 0) && "TRX device not found");
+	IIO_ENSURE(cfg_adrv9009_streaming_ch(ctx, &trxcfg, 0) && "TRX device not found");
 
 	printf("* Initializing ADRV9009 IIO streaming channels\n");
-	IIO_ASSERT(get_adrv9009_stream_ch(ctx, RX, rx, 0, 'i', &rx0_i) && "RX chan i not found");
-	IIO_ASSERT(get_adrv9009_stream_ch(ctx, RX, rx, 0, 'q', &rx0_q) && "RX chan q not found");
-	IIO_ASSERT(get_adrv9009_stream_ch(ctx, TX, tx, 0, 0, &tx0_i) && "TX chan i not found");
-	IIO_ASSERT(get_adrv9009_stream_ch(ctx, TX, tx, 1, 0, &tx0_q) && "TX chan q not found");
+	IIO_ENSURE(get_adrv9009_stream_ch(ctx, RX, rx, 0, 'i', &rx0_i) && "RX chan i not found");
+	IIO_ENSURE(get_adrv9009_stream_ch(ctx, RX, rx, 0, 'q', &rx0_q) && "RX chan q not found");
+	IIO_ENSURE(get_adrv9009_stream_ch(ctx, TX, tx, 0, 0, &tx0_i) && "TX chan i not found");
+	IIO_ENSURE(get_adrv9009_stream_ch(ctx, TX, tx, 1, 0, &tx0_q) && "TX chan q not found");
 
 	printf("* Enabling IIO streaming channels\n");
 	iio_channel_enable(rx0_i);


### PR DESCRIPTION
Since we are ensuring (to secure or guarantee:) something happens -
change the ASSERT macro to that name, so all the tools (Coverity?) that look for
ASSERTs will not flag this by accident.

Changes IIO_ASSERT to IIO_ENSURE

Signed-off-by: Robin Getz <robin.getz@analog.com>