### PR TITLE
Coverity: Fix potential divide by zero in iio_readdev

### DIFF
--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -203,7 +203,7 @@ int main(int argc, char **argv)
 	const char *arg_ip = NULL;
 	int c, option_index = 0;
 	struct iio_device *dev;
-	size_t sample_size;
+	ssize_t sample_size;
 	int timeout = -1;
 	bool scan_for_context = false;
 	ssize_t ret;
@@ -352,6 +352,18 @@ int main(int argc, char **argv)
 	}
 
 	sample_size = iio_device_get_sample_size(dev);
+	/* Zero isn't normally an error code, but in this case it is an error */
+	if (sample_size == 0) {
+		fprintf(stderr, "Unable to get sample size, returned 0\n");
+		iio_context_destroy(ctx);
+		return EXIT_FAILURE;
+	} else if (sample_size < 0) {
+		char buf[256];
+		iio_strerror(errno, buf, sizeof(buf));
+		fprintf(stderr, "Unable to get sample size : %s\n", buf);
+		iio_context_destroy(ctx);
+		return EXIT_FAILURE;
+	}
 
 	buffer = iio_device_create_buffer(dev, buffer_size, false);
 	if (!buffer) {


### PR DESCRIPTION
in iio_readdev:

206    size_t sample_size;
...
354    sample_size = iio_device_get_sample_size(dev);
...
404    num_samples -= read_len / sample_size;

There are two issues:

iio_device_get_sample_size can return negative error codes,
and we would miss these. Fix that by making it a signed number.

this could potentially cause an error if sample_size is zero.
Catch that fault and error out. While we are here, check
for negative error codes, and also error out.

Reported by Coverity.

Signed-off-by: Robin Getz <robin.getz@analog.com>