### PR TITLE
csharp: Control Structures should use curly braces {}

### DIFF
--- a/bindings/csharp/Attr.cs
+++ b/bindings/csharp/Attr.cs
@@ -78,9 +78,13 @@ namespace iio
         public void write(bool val)
         {
             if (val)
+            {
                 write("1");
+            }
             else
+            {
                 write("0");
+            }
         }
 
         /// <summary>Set this attribute to the value contained in the <c>long</c> argument.</summary>

--- a/bindings/csharp/Channel.cs
+++ b/bindings/csharp/Channel.cs
@@ -53,7 +53,9 @@ namespace iio
                 StringBuilder builder = new StringBuilder(1024);
                 int err = iio_channel_attr_read(chn, name, builder, (uint) builder.Capacity);
                 if (err < 0)
+                {
                     throw new Exception("Unable to read channel attribute " + err);
+                }
                 return builder.ToString();
             }
 
@@ -61,7 +63,9 @@ namespace iio
             {
                 int err = iio_channel_attr_write(chn, name, str);
                 if (err < 0)
+                {
                     throw new Exception("Unable to write channel attribute " + err);
+                }
             }
         }
 
@@ -143,13 +147,19 @@ namespace iio
             uint nb_attrs = iio_channel_get_attrs_count(chn);
 
             for (uint i = 0; i < nb_attrs; i++)
+            {
                 attrs.Add(new ChannelAttr(this.chn, Marshal.PtrToStringAnsi(iio_channel_get_attr(chn, i))));
+            }
 
             IntPtr name_ptr = iio_channel_get_name(this.chn);
             if (name_ptr == IntPtr.Zero)
+            {
                 name = "";
+            }
             else
+            {
                 name = Marshal.PtrToStringAnsi(name_ptr);
+            }
 
             id = Marshal.PtrToStringAnsi(iio_channel_get_id(this.chn));
             output = iio_channel_is_output(this.chn);
@@ -184,9 +194,13 @@ namespace iio
         public byte[] read(IOBuffer buffer, bool raw = false)
         {
             if (!is_enabled())
+            {
                 throw new Exception("Channel must be enabled before the IOBuffer is instantiated");
+            }
             if (this.output)
+            {
                 throw new Exception("Unable to read from output channel");
+            }
 
             byte[] array = new byte[(int) (buffer.samples_count * sample_size)];
             MemoryStream stream = new MemoryStream(array, true);
@@ -195,9 +209,13 @@ namespace iio
             uint count;
 
             if (raw)
+            {
                 count = iio_channel_read_raw(this.chn, buffer.buf, addr, buffer.samples_count * sample_size);
+            }
             else
+            {
                 count = iio_channel_read(this.chn, buffer.buf, addr, buffer.samples_count * sample_size);
+            }
             handle.Free();
             stream.SetLength((long) count);
             return stream.ToArray();
@@ -216,18 +234,26 @@ namespace iio
         public uint write(IOBuffer buffer, byte[] array, bool raw = false)
         {
             if (!is_enabled())
+            {
                 throw new Exception("Channel must be enabled before the IOBuffer is instantiated");
+            }
             if (!this.output)
+            {
                 throw new Exception("Unable to write to an input channel");
+            }
 
             GCHandle handle = GCHandle.Alloc(array, GCHandleType.Pinned);
             IntPtr addr = handle.AddrOfPinnedObject();
             uint count;
 
             if (raw)
+            {
                 count = iio_channel_write_raw(this.chn, buffer.buf, addr, (uint) array.Length);
+            }
             else
+            {
                 count = iio_channel_write(this.chn, buffer.buf, addr, (uint) array.Length);
+            }
             handle.Free();
 
             return count;

--- a/bindings/csharp/Context.cs
+++ b/bindings/csharp/Context.cs
@@ -129,7 +129,9 @@ namespace iio
         {
             IntPtr ptr = iio_create_context_from_uri(str);
             if (ptr == IntPtr.Zero)
+            {
                 ptr = iio_create_network_context(str);
+            }
             return ptr;
         }
 
@@ -138,7 +140,9 @@ namespace iio
             this.ctx = ctx;
 
             if (ctx == IntPtr.Zero)
+            {
                 throw new Exception("Unable to create IIO context");
+            }
 
             uint nb_devices = iio_context_get_devices_count(ctx);
 
@@ -147,9 +151,13 @@ namespace iio
             {
                 IntPtr ptr = iio_context_get_device(ctx, i);
                 if (iio_device_is_trigger(ptr))
+                {
                     devices.Add(new Trigger(this, ptr));
+                }
                 else
+                {
                     devices.Add(new Device(this, ptr));
+                }
             }
 
             xml = Marshal.PtrToStringAnsi(iio_context_get_xml(ctx));
@@ -167,14 +175,18 @@ namespace iio
             builder.Clear();
             int err = iio_context_get_version(ctx, ref major, ref minor, builder);
             if (err < 0)
+            {
                 throw new Exception("Unable to read backend version");
+            }
             backend_version = new Version(major, minor, builder.ToString());
         }
 
         ~Context()
         {
             if (ctx != IntPtr.Zero)
+            {
                 Dispose(false);
+            }
         }
 
         /// <summary>Clone this instance.</summary>
@@ -192,7 +204,9 @@ namespace iio
             foreach (Device each in devices) {
                 if (each.name.CompareTo(name) == 0 ||
                             each.id.CompareTo(name) == 0)
+                {
                     return each;
+                }
             }
 
             throw new Exception("Device " + name + " not found");
@@ -205,7 +219,9 @@ namespace iio
         {
             int ret = iio_context_set_timeout(ctx, timeout);
             if (ret < 0)
+            {
                 throw new Exception("Unable to set timeout");
+            }
         }
 
         /// <summary>Releases all resource used by the <see cref="iio.Context"/> object.</summary>
@@ -223,7 +239,9 @@ namespace iio
             if (ctx != IntPtr.Zero)
             {
                 if (clean)
+                {
                     GC.SuppressFinalize(this);
+                }
                 iio_context_destroy(ctx);
                 ctx = IntPtr.Zero;
             }

--- a/bindings/csharp/Device.cs
+++ b/bindings/csharp/Device.cs
@@ -49,7 +49,9 @@ namespace iio
                 StringBuilder builder = new StringBuilder(1024);
                 int err = iio_device_attr_read(dev, name, builder, 1024);
                 if (err < 0)
+                {
                     throw new Exception("Unable to read device attribute " + err);
+                }
                 return builder.ToString();
             }
 
@@ -57,7 +59,9 @@ namespace iio
             {
                 int err = iio_device_attr_write(dev, name, str);
                 if (err < 0)
+                {
                     throw new Exception("Unable to write device attribute " + err);
+                }
             }
         }
 
@@ -81,7 +85,9 @@ namespace iio
                 StringBuilder builder = new StringBuilder(1024);
                 int err = iio_device_debug_attr_read(dev, name, builder, 1024);
                 if (err < 0)
+                {
                     throw new Exception("Unable to read debug attribute " + err);
+                }
                 return builder.ToString();
             }
 
@@ -89,7 +95,9 @@ namespace iio
             {
                 int err = iio_device_debug_attr_write(dev, name, str);
                 if (err < 0)
+                {
                     throw new Exception("Unable to write debug attribute " + err);
+                }
             }
         }
 
@@ -165,20 +173,30 @@ namespace iio
                 nb_debug_attrs = iio_device_get_debug_attrs_count(dev);
 
             for (uint i = 0; i < nb_channels; i++)
+            {
                 channels.Add(new Channel(iio_device_get_channel(dev, i)));
+            }
 
             for (uint i = 0; i < nb_attrs; i++)
+            {
                 attrs.Add(new DeviceAttr(dev, Marshal.PtrToStringAnsi(iio_device_get_attr(dev, i))));
+            }
             for (uint i = 0; i < nb_debug_attrs; i++)
+            {
                 debug_attrs.Add(new DeviceDebugAttr(dev, Marshal.PtrToStringAnsi(iio_device_get_debug_attr(dev, i))));
+            }
 
             id = Marshal.PtrToStringAnsi(iio_device_get_id(dev));
 
             IntPtr name_ptr = iio_device_get_name(dev);
             if (name_ptr == IntPtr.Zero)
+            {
                 name = "";
+            }
             else
+            {
                 name = Marshal.PtrToStringAnsi(name_ptr);
+            }
         }
 
         /// <summary>Get the <see cref="iio.Channel"/> object of the specified name.</summary>
@@ -187,10 +205,13 @@ namespace iio
         /// name or ID could not be found in the current context.</exception>
         public Channel get_channel(string name)
         {
-            foreach (Channel each in channels) {
+            foreach (Channel each in channels)
+            {
                 if (each.name.CompareTo(name) == 0 ||
                             each.id.CompareTo(name) == 0)
+                {
                     return each;
+                }
             }
 
             throw new Exception("Channel " + name + " not found");
@@ -203,7 +224,9 @@ namespace iio
         {
             int err = iio_device_set_trigger(this.dev, trig == null ? IntPtr.Zero : trig.dev);
             if (err < 0)
+            {
                 throw new Exception("Unable to set trigger: err=" + err);
+            }
         }
 
         /// <summary>Get the current trigger affected to this device.</summary>
@@ -214,13 +237,18 @@ namespace iio
             IntPtr ptr = (IntPtr)0;
             int err = iio_device_get_trigger(this.dev, ptr);
             if (err < 0)
+            {
                 throw new Exception("Unable to get trigger: err=" + err);
+            }
 
             ptr = Marshal.ReadIntPtr(ptr);
 
-            foreach (Trigger trig in ctx.devices) {
+            foreach (Trigger trig in ctx.devices)
+            {
                 if (trig.dev == ptr)
+                {
                     return trig;
+                }
             }
 
             return null;
@@ -233,7 +261,9 @@ namespace iio
         {
             int ret = iio_device_get_sample_size(dev);
             if (ret < 0)
+            {
                 throw new Exception("Internal error. Please report any bug.");
+            }
             return (uint) ret;
         }
         /// <summary>Set a value to one register of this device.</summary>
@@ -244,7 +274,9 @@ namespace iio
         {
             int err = iio_device_reg_write(dev, addr, value);
             if (err < 0)
+            {
                 throw new Exception("Unable to write register");
+            }
         }
 
         /// <summary>Read the content of a register of this device.</summary>
@@ -255,7 +287,9 @@ namespace iio
             uint value = 0;
             int err = iio_device_reg_read(dev, addr, ref value);
             if (err < 0)
+            {
                 throw new Exception("Unable to read register");
+            }
             return value;
         }
     }

--- a/bindings/csharp/IOBuffer.cs
+++ b/bindings/csharp/IOBuffer.cs
@@ -72,13 +72,17 @@ namespace iio
 
             buf = iio_device_create_buffer(dev.dev, samples_count, circular);
             if (buf == IntPtr.Zero)
+            {
                 throw new Exception("Unable to create buffer");
+            }
         }
 
         ~IOBuffer()
         {
             if (buf != IntPtr.Zero)
+            {
                 Dispose(false);
+            }
         }
 
         /// <summary>Fetch a new set of samples from the hardware.</summary>
@@ -87,7 +91,9 @@ namespace iio
         {
             int err = iio_buffer_refill(this.buf);
             if (err < 0)
+            {
                 throw new Exception("Unable to refill buffer: err=" + err);
+            }
         }
 
         /// <summary>Submit the samples contained in this buffer to the hardware.</summary>
@@ -95,11 +101,15 @@ namespace iio
         public void push(uint samples_count)
         {
             if (circular && circular_buffer_pushed)
+            {
                 throw new Exception("Circular buffer already pushed\n");
+            }
 
             int err = iio_buffer_push_partial(this.buf, samples_count);
             if (err < 0)
+            {
                 throw new Exception("Unable to push buffer: err=" + err);
+            }
             circular_buffer_pushed = true;
         }
 
@@ -124,7 +134,9 @@ namespace iio
             if (buf != IntPtr.Zero)
             {
                 if (clean)
+                {
                     GC.SuppressFinalize(this);
+                }
                 iio_buffer_destroy(buf);
                 buf = IntPtr.Zero;
             }
@@ -137,7 +149,9 @@ namespace iio
         {
             long length = (long) iio_buffer_end(buf) - (long) iio_buffer_start(buf);
             if (length > array.Length)
+            {
                 length = array.Length;
+            }
             Marshal.Copy(array, 0, iio_buffer_start(buf), (int)length);
         }
 
@@ -147,7 +161,9 @@ namespace iio
         {
             long length = (long) iio_buffer_end(buf) - (long) iio_buffer_start(buf);
             if (length > array.Length)
+            {
                 length = array.Length;
+            }
             Marshal.Copy(iio_buffer_start(buf), array, 0, (int)length);
         }
     }

--- a/bindings/csharp/Trigger.cs
+++ b/bindings/csharp/Trigger.cs
@@ -36,11 +36,13 @@ namespace iio
         public void set_rate(ulong rate)
         {
             foreach (Attr each in attrs)
+            {
                 if (each.name.Equals("frequency"))
                 {
                     each.write((long) rate);
                     return;
                 }
+            }
             throw new Exception("Trigger has no frequency?");
         }
 
@@ -49,8 +51,12 @@ namespace iio
         public ulong get_rate()
         {
             foreach (Attr each in attrs)
+            {
                 if (each.name.Equals("frequency"))
+                {
                     return (ulong) each.read_long();
+                }
+            }
             throw new Exception("Trigger has no frequency?");
         }
 

--- a/bindings/csharp/examples/ExampleProgram.cs
+++ b/bindings/csharp/examples/ExampleProgram.cs
@@ -55,11 +55,15 @@ namespace IIOCSharp
                 {
                     string type = "input";
                     if (chn.output)
+                    {
                         type = "output";
+                    }
                     Console.WriteLine("\t\t\t" + chn.id + ": " + chn.name + " (" + type + ")");
 
                     if (chn.attrs.Count == 0)
+                    {
                         continue;
+                    }
 
                     Console.WriteLine("\t\t\t" + chn.attrs.Count + " channel-specific attributes found:");
                     foreach (Attr attr in chn.attrs)
@@ -86,11 +90,15 @@ namespace IIOCSharp
                 }
 
                 if (dev.attrs.Count == 0)
+                {
                     continue;
+                }
 
                 Console.WriteLine("\t\t" + dev.attrs.Count + " device-specific attributes found:");
                 foreach (Attr attr in dev.attrs)
+                {
                     Console.WriteLine("\t\t\t" + attr.name);
+                }
 
             }
 


### PR DESCRIPTION
According to Microsoft, and Sonar C#, all Control structures (do, for,
foreach, while, if) should use curly braces. While not technically incorrect,
the omission of curly braces can be misleading, and may lead to the
introduction of errors during maintenance.

See CERT, EXP19-C Use braces for the body of an if, for, or while statement
https://www.securecoding.cert.org/confluence/x/1QGMAg

See CERT, EXP52-J Use braces for the body of an if, for, or while statement
https://www.securecoding.cert.org/confluence/x/3wHEAw

Signed-off-by: Robin Getz <robin.getz@analog.com>