### PR TITLE
Dont ignore sign differences

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,7 @@ if (NOT LOG_LEVEL)
 endif()
 
 if (MSVC)
-	add_compile_options(/W4 /wd4018 /wd4200 /wd4127 /wd4100)
-	# C4018: signed/unsigned mismatch ; same as -Wno-sign-compare
+	add_compile_options(/W4 /wd4200 /wd4127 /wd4100)
 	# C4200: nonstandard extension used : zero-sized array in struct (usb.h)
 	# C4127: conditional expression is constant (IIO_ERROR and IIO_DEBUG macros)
 	# C4100: unreferenced parameter; same as -Wno-unused-parameter
@@ -77,7 +76,7 @@ elseif (CMAKE_COMPILER_IS_GNUCC)
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
 	endif()
 
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-parameter")
 
 	include(CheckCCompilerFlag)
 	check_c_compiler_flag(-Wpedantic HAS_WPEDANTIC)
@@ -97,7 +96,7 @@ elseif (CMAKE_COMPILER_IS_GNUCC)
 	endif()
 
 elseif (CMAKE_C_COMPILER_ID STREQUAL "Clang")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic -Wno-unused-parameter -Wno-sign-compare")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -pedantic -Wno-unused-parameter")
 	if(DEFINED ENV{TRAVIS} AND DEFINED ENV{CI})
 		message(STATUS "Running in a Travis-CI environment, setting -Werror")
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")

--- a/channel.c
+++ b/channel.c
@@ -293,14 +293,14 @@ char * iio_channel_get_xml(const struct iio_channel *chn, size_t *length)
 		len = eptr - ptr;
 	}
 
-	if (chn->is_scan_element && len > scan_element_len) {
+	if (chn->is_scan_element && len > (ssize_t) scan_element_len) {
 		memcpy(ptr, scan_element, scan_element_len); /* Flawfinder: ignore */
 		ptr += scan_element_len;
 		len -= scan_element_len;
 	}
 
 	for (i = 0; i < chn->nb_attrs; i++) {
-		if (len > attrs_len[i]) {
+		if (len > (ssize_t) attrs_len[i]) {
 			memcpy(ptr, attrs[i], attrs_len[i]); /* Flawfinder: ignore */
 			ptr += attrs_len[i];
 			len -= attrs_len[i];

--- a/context.c
+++ b/context.c
@@ -116,7 +116,7 @@ char * iio_context_create_xml(const struct iio_context *ctx)
 	}
 
 	for (i = 0; i < ctx->nb_devices; i++) {
-		if (len > devices_len[i]) {
+		if (len > (ssize_t) devices_len[i]) {
 			memcpy(ptr, devices[i], devices_len[i]); /* Flawfinder: ignore */
 			ptr += devices_len[i];
 			len -= devices_len[i];

--- a/device.c
+++ b/device.c
@@ -173,7 +173,7 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	}
 
 	for (i = 0; i < dev->nb_channels; i++) {
-		if (len > channels_len[i]) {
+		if (len > (ssize_t) channels_len[i]) {
 			memcpy(ptr, channels[i], channels_len[i]); /* Flawfinder: ignore */
 			ptr += channels_len[i];
 			len -= channels_len[i];
@@ -185,7 +185,7 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	free(channels_len);
 
 	for (i = 0; i < dev->nb_attrs; i++) {
-		if (len > attrs_len[i]) {
+		if (len > (ssize_t) attrs_len[i]) {
 			memcpy(ptr, attrs[i], attrs_len[i]); /* Flawfinder: ignore */
 			ptr += attrs_len[i];
 			len -= attrs_len[i];
@@ -197,7 +197,7 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	free(attrs_len);
 
 	for (i = 0; i < dev->nb_buffer_attrs; i++) {
-		if (len > buffer_attrs_len[i]) {
+		if (len > (ssize_t) buffer_attrs_len[i]) {
 			memcpy(ptr, buffer_attrs[i], buffer_attrs_len[i]); /* Flawfinder: ignore */
 			ptr += buffer_attrs_len[i];
 			len -= buffer_attrs_len[i];
@@ -209,7 +209,7 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	free(buffer_attrs_len);
 
 	for (i = 0; i < dev->nb_debug_attrs; i++) {
-		if (len > debug_attrs_len[i]) {
+		if (len > (ssize_t) debug_attrs_len[i]) {
 			memcpy(ptr, debug_attrs[i], debug_attrs_len[i]); /* Flawfinder: ignore */
 			ptr += debug_attrs_len[i];
 			len -= debug_attrs_len[i];

--- a/dns_sd.c
+++ b/dns_sd.c
@@ -74,7 +74,7 @@ static int dnssd_fill_context_info(struct iio_context_info *info,
 	char uri[sizeof("ip:") + MAXHOSTNAMELEN + sizeof (":65535") + 1];
 	char description[255], *p;
 	const char *hw_model, *serial;
-	int i;
+	unsigned int i;
 
 	ctx = network_create_context(addr_str);
 	if (!ctx) {

--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -12,6 +12,12 @@ add_flex_bison_dependency(lexer parser)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
+if (CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_COMPILER_IS_GNUCC)
+	# flex sometimes generates code which generate sign comparison errors
+	set_source_files_properties(${FLEX_lexer_OUTPUTS} PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
+	set_source_files_properties(${BISON_parser_OUTPUTS} PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
+endif ()
+
 set(IIOD_CFILES iiod.c ops.c thread-pool.c ${BISON_parser_OUTPUTS} ${FLEX_lexer_OUTPUTS})
 
 find_library(LIBAIO_LIBRARIES aio)

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -674,7 +674,7 @@ static void rw_thd(struct thread_pool *pool, void *d)
 
 				if (ret < 0 || thd->nb < sample_size)
 					signal_thread(thd, (ret < 0) ?
-							ret : thd->nb);
+							ret : (ssize_t) thd->nb);
 			}
 
 			pthread_mutex_unlock(&entry->thdlist_lock);
@@ -820,7 +820,7 @@ static ssize_t rw_buffer(struct parser_pdata *pdata,
 		ret = thd->err;
 	pthread_mutex_unlock(&entry->thdlist_lock);
 
-	if (ret > 0 && ret < nb)
+	if (ret > 0 && ret < (ssize_t) nb)
 		print_value(thd->pdata, 0);
 
 	IIO_DEBUG("Exiting rw_buffer with code %li\n", (long) ret);

--- a/local.c
+++ b/local.c
@@ -266,7 +266,7 @@ static int get_rel_timeout_ms(struct timespec *start, unsigned int timeout_rel)
 	diff_ms = (now.tv_sec - start->tv_sec) * 1000;
 	diff_ms += (now.tv_nsec - start->tv_nsec) / 1000000;
 
-	if (diff_ms >= timeout_rel) /* Expired */
+	if (diff_ms >= (int) timeout_rel) /* Expired */
 		return 0;
 	if (diff_ms > 0) /* Should never be false, but lets be safe */
 		timeout_rel -= diff_ms;
@@ -1499,7 +1499,7 @@ static unsigned int is_global_attr(struct iio_channel *chn, const char *attr)
 		unsigned int len2 = ptr - dashptr - 1;
 		const char*  iddashptr = strchr(chn->id, '-');
 		if (iddashptr && strlen(iddashptr + 1) > len2 &&
-			iddashptr - chn->id > len1 &&
+			(unsigned int)(iddashptr - chn->id) > len1 &&
 			chn->id[len1] >= '0' && chn->id[len1] <= '9' &&
 			!strncmp(chn->id, attr, len1) &&
 			iddashptr[len2 + 1] >= '0' && iddashptr[len2 + 1] <= '9' &&
@@ -1612,7 +1612,7 @@ static int add_buffer_attr(void *d, const char *path)
 	struct iio_device *dev = (struct iio_device *) d;
 	const char *name = strrchr(path, '/') + 1;
 	char **attrs, *attr;
-	int i;
+	unsigned int i;
 
 	for (i = 0; i < ARRAY_SIZE(buffer_attrs_reserved); i++)
 		if (!strcmp(buffer_attrs_reserved[i], name))

--- a/tests/iio_stresstest.c
+++ b/tests/iio_stresstest.c
@@ -604,7 +604,7 @@ int main(int argc, char **argv)
 		}
 
 		/* Calculate some stats about the threads */
-		int a =0, b = 0;
+		unsigned int a =0, b = 0;
 		c = 0;
 		for (i = 0; i < info.num_threads; i++) {
 			a+= info.starts[i];

--- a/usb.c
+++ b/usb.c
@@ -1106,7 +1106,7 @@ struct iio_context * usb_create_context_from_uri(const char *uri)
 	if (bus < 0 || address < 0 || interface < 0)
 		goto err_bad_uri;
 
-	if (bus > UINT_MAX || address > UINT8_MAX || interface > UINT8_MAX)
+	if (bus > (long) UINT_MAX || address > UINT8_MAX || interface > UINT8_MAX)
 		goto err_bad_uri;
 
 	return usb_create_context((unsigned int) bus,


### PR DESCRIPTION
With all the coverity and codacy updates, there are very few signed/unsigned issues anymore - so fix those up, and remove the ignore flag.

This will need to be re-based on master after #466 is merged.