### PR TITLE
cmake: Add MSVC flags for Wall, Wno-sign-compare and Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ endif()
 
 include(CheckSymbolExists)
 check_symbol_exists(strdup "string.h" HAS_STRDUP)
+check_symbol_exists(strndup "string.h" HAS_STRNDUP)
 check_symbol_exists(strerror_r "string.h" HAS_STRERROR_R)
 check_symbol_exists(newlocale "locale.h" HAS_NEWLOCALE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,16 @@ if (WITH_TESTS)
 endif()
 
 if (MSVC)
-	# Avoid annoying warnings from Visual Studio
-	add_definitions(-D_CRT_SECURE_NO_WARNINGS=1)
+	add_compile_options(/W4 /wd4018 /wd4200 /wd4127 /wd4100)
+	# C4018: signed/unsigned mismatch ; same as -Wno-sign-compare
+	# C4200: nonstandard extension used : zero-sized array in struct (usb.h)
+	# C4127: conditional expression is constant (IIO_ERROR and IIO_DEBUG macros)
+	# C4100: unreferenced parameter; same as -Wno-unused-parameter
 
+	if(DEFINED ENV{CI} AND DEFINED ENV{APPVEYOR})
+		message(STATUS "Running in an AppVeyor environment, setting -Werror")
+		add_compile_options(/WX)
+	endif()
 	set(CMAKE_FIND_LIBRARY_PREFIXES "lib" "")
 	set(CMAKE_FIND_LIBRARY_SUFFIXES ".dll.a" ".a" ".lib")
 endif()

--- a/channel.c
+++ b/channel.c
@@ -743,33 +743,33 @@ int iio_channel_attr_read_double(const struct iio_channel *chn,
 int iio_channel_attr_write_longlong(const struct iio_channel *chn,
 		const char *attr, long long val)
 {
-	ssize_t ret;
+	int ret;
 	char buf[1024];
 	iio_snprintf(buf, sizeof(buf), "%lld", val);
-	ret = iio_channel_attr_write(chn, attr, buf);
+	ret = (int) iio_channel_attr_write(chn, attr, buf);
 	return ret < 0 ? ret : 0;
 }
 
 int iio_channel_attr_write_double(const struct iio_channel *chn,
 		const char *attr, double val)
 {
-	ssize_t ret;
+	int ret;
 	char buf[1024];
 
-	ret = (ssize_t) write_double(buf, sizeof(buf), val);
+	ret = write_double(buf, sizeof(buf), val);
 	if (!ret)
-		ret = iio_channel_attr_write(chn, attr, buf);
+		ret = (int) iio_channel_attr_write(chn, attr, buf);
 	return ret < 0 ? ret : 0;
 }
 
 int iio_channel_attr_write_bool(const struct iio_channel *chn,
 		const char *attr, bool val)
 {
-	ssize_t ret;
+	int ret;
 	if (val)
-		ret = iio_channel_attr_write_raw(chn, attr, "1", 2);
+		ret = (int) iio_channel_attr_write_raw(chn, attr, "1", 2);
 	else
-		ret = iio_channel_attr_write_raw(chn, attr, "0", 2);
+		ret = (int) iio_channel_attr_write_raw(chn, attr, "0", 2);
 	return ret < 0 ? ret : 0;
 }
 

--- a/context.c
+++ b/context.c
@@ -20,7 +20,6 @@
 #include "iio-config.h"
 #include "iio-private.h"
 #include "sort.h"
-#include "network.h"
 
 #include <errno.h>
 #include <string.h>
@@ -328,22 +327,13 @@ struct iio_context * iio_create_context_from_uri(const char *uri)
 
 struct iio_context * iio_create_default_context(void)
 {
-	char *hostname = getenv("IIOD_REMOTE");
+	char *hostname = iio_getenv("IIOD_REMOTE");
+	struct iio_context * ctx;
 
 	if (hostname) {
-		if (strlen(hostname) > 2 && strlen(hostname) < MAXHOSTNAMELEN + 4) {
-			struct iio_context *ctx;
-
-			ctx = iio_create_context_from_uri(hostname);
-			if (ctx)
-				return ctx;
-		}
-#ifdef HAVE_DNS_SD
-		/* If the environment variable is an empty string, we will
-		 * discover the server using ZeroConf */
-		if (!hostname[0])
-			return iio_create_network_context(NULL);
-#endif
+		ctx = iio_create_context_from_uri(hostname);
+		free(hostname);
+		return ctx;
 	}
 
 	return iio_create_local_context();

--- a/device.c
+++ b/device.c
@@ -661,7 +661,7 @@ int iio_device_attr_write_longlong(const struct iio_device *dev,
 	iio_snprintf(buf, sizeof(buf), "%lld", val);
 	ret = iio_device_attr_write(dev, attr, buf);
 
-	return ret < 0 ? ret : 0;
+	return (int) (ret < 0 ? ret : 0);
 }
 
 int iio_device_attr_write_double(const struct iio_device *dev,
@@ -673,7 +673,7 @@ int iio_device_attr_write_double(const struct iio_device *dev,
 	ret = (ssize_t) write_double(buf, sizeof(buf), val);
 	if (!ret)
 		ret = iio_device_attr_write(dev, attr, buf);
-	return ret < 0 ? ret : 0;
+	return (int) (ret < 0 ? ret : 0);
 }
 
 int iio_device_attr_write_bool(const struct iio_device *dev,
@@ -686,7 +686,7 @@ int iio_device_attr_write_bool(const struct iio_device *dev,
 	else
 		ret = iio_device_attr_write(dev, attr, "0");
 
-	return ret < 0 ? ret : 0;
+	return (int) (ret < 0 ? ret : 0);
 }
 
 int iio_device_buffer_attr_read_longlong(const struct iio_device *dev,
@@ -737,7 +737,7 @@ int iio_device_buffer_attr_write_longlong(const struct iio_device *dev,
 	iio_snprintf(buf, sizeof(buf), "%lld", val);
 	ret = iio_device_buffer_attr_write(dev, attr, buf);
 
-	return ret < 0 ? ret : 0;
+	return (int) (ret < 0 ? ret : 0);
 }
 
 int iio_device_buffer_attr_write_double(const struct iio_device *dev,
@@ -749,7 +749,7 @@ int iio_device_buffer_attr_write_double(const struct iio_device *dev,
 	ret = (ssize_t) write_double(buf, sizeof(buf), val);
 	if (!ret)
 		ret = iio_device_buffer_attr_write(dev, attr, buf);
-	return ret < 0 ? ret : 0;
+	return (int) (ret < 0 ? ret : 0);
 }
 
 int iio_device_buffer_attr_write_bool(const struct iio_device *dev,
@@ -762,7 +762,7 @@ int iio_device_buffer_attr_write_bool(const struct iio_device *dev,
 	else
 		ret = iio_device_buffer_attr_write(dev, attr, "0");
 
-	return ret < 0 ? ret : 0;
+	return (int) (ret < 0 ? ret : 0);
 }
 
 ssize_t iio_device_debug_attr_read(const struct iio_device *dev,
@@ -853,7 +853,7 @@ int iio_device_debug_attr_write_longlong(const struct iio_device *dev,
 	iio_snprintf(buf, sizeof(buf), "%lld", val);
 	ret = iio_device_debug_attr_write(dev, attr, buf);
 
-	return ret < 0 ? ret : 0;
+	return (int) (ret < 0 ? ret : 0);
 }
 
 int iio_device_debug_attr_write_double(const struct iio_device *dev,
@@ -865,7 +865,7 @@ int iio_device_debug_attr_write_double(const struct iio_device *dev,
 	ret = (ssize_t) write_double(buf, sizeof(buf), val);
 	if (!ret)
 		ret = iio_device_debug_attr_write(dev, attr, buf);
-	return ret < 0 ? ret : 0;
+	return (int) (ret < 0 ? ret : 0);
 }
 
 int iio_device_debug_attr_write_bool(const struct iio_device *dev,
@@ -878,7 +878,7 @@ int iio_device_debug_attr_write_bool(const struct iio_device *dev,
 	else
 		ret = iio_device_debug_attr_write_raw(dev, attr, "0", 2);
 
-	return ret < 0 ? ret : 0;
+	return (int) (ret < 0 ? ret : 0);
 }
 
 int iio_device_identify_filename(const struct iio_device *dev,
@@ -930,7 +930,7 @@ int iio_device_reg_write(struct iio_device *dev,
 			address, value);
 	ret = iio_device_debug_attr_write(dev, "direct_reg_access", buf);
 
-	return ret < 0 ? ret : 0;
+	return (int) (ret < 0 ? ret : 0);
 }
 
 int iio_device_reg_read(struct iio_device *dev,

--- a/iio-config.h.cmakein
+++ b/iio-config.h.cmakein
@@ -20,6 +20,7 @@
 #cmakedefine WITH_LOCAL_CONFIG
 #cmakedefine HAS_PIPE2
 #cmakedefine HAS_STRDUP
+#cmakedefine HAS_STRNDUP
 #cmakedefine HAS_STRERROR_R
 #cmakedefine HAS_NEWLOCALE
 #cmakedefine HAS_PTHREAD_SETNAME_NP

--- a/iio-private.h
+++ b/iio-private.h
@@ -288,8 +288,8 @@ struct iio_context * local_create_context(void);
 struct iio_context * network_create_context(const char *hostname);
 struct iio_context * xml_create_context_mem(const char *xml, size_t len);
 struct iio_context * xml_create_context(const char *xml_file);
-struct iio_context * usb_create_context(unsigned int bus, unsigned int address,
-		unsigned int interface);
+struct iio_context * usb_create_context(unsigned int bus, uint16_t address,
+		uint16_t interface);
 struct iio_context * usb_create_context_from_uri(const char *uri);
 struct iio_context * serial_create_context_from_uri(const char *uri);
 

--- a/iio-private.h
+++ b/iio-private.h
@@ -314,6 +314,7 @@ unsigned int find_channel_modifier(const char *s, size_t *len_p);
 
 char *iio_strdup(const char *str);
 size_t iio_strlcpy(char * __restrict dst, const char * __restrict src, size_t dsize);
+char * iio_getenv (char * envvar);
 
 int iio_context_add_attr(struct iio_context *ctx,
 		const char *key, const char *value);

--- a/iio-private.h
+++ b/iio-private.h
@@ -29,8 +29,10 @@
 #ifdef _MSC_BUILD
 #define inline __inline
 #define iio_snprintf sprintf_s
+#define iio_sscanf sscanf_s
 #else
 #define iio_snprintf snprintf
+#define iio_sscanf sscanf
 #endif
 
 #ifdef _WIN32

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -588,7 +588,7 @@ static int iiod_client_read_mask(struct iiod_client *client,
 	IIO_DEBUG("Reading mask\n");
 
 	for (i = words, ptr = buf; i > 0; i--) {
-		sscanf(ptr, "%08" PRIx32, &mask[i - 1]);
+		iio_sscanf(ptr, "%08" PRIx32, &mask[i - 1]);
 		IIO_DEBUG("mask[%lu] = 0x%08" PRIx32 "\n",
 				(unsigned long)(i - 1), mask[i - 1]);
 

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -169,13 +169,13 @@ int iiod_client_get_version(struct iiod_client *client, void *desc,
 
 	iio_mutex_lock(client->lock);
 
-	ret = ops->write(pdata, desc, "VERSION\r\n", sizeof("VERSION\r\n") - 1);
+	ret = (int) ops->write(pdata, desc, "VERSION\r\n", sizeof("VERSION\r\n") - 1);
 	if (ret < 0) {
 		iio_mutex_unlock(client->lock);
 		return ret;
 	}
 
-	ret = ops->read_line(pdata, desc, buf, sizeof(buf));
+	ret = (int) ops->read_line(pdata, desc, buf, sizeof(buf));
 	iio_mutex_unlock(client->lock);
 
 	if (ret < 0)
@@ -325,7 +325,7 @@ static int iiod_client_discard(struct iiod_client *client, void *desc,
 
 		ret = iiod_client_read_all(client, desc, buf, read_len);
 		if (ret < 0)
-			return ret;
+			return (int) ret;
 
 		to_discard -= (size_t) ret;
 	} while (to_discard);

--- a/local.c
+++ b/local.c
@@ -1230,12 +1230,24 @@ static int handle_protected_scan_element_attr(struct iio_channel *chn,
 			char endian, sign;
 
 			if (strchr(buf, 'X')) {
-				sscanf(buf, "%ce:%c%u/%uX%u>>%u", &endian, &sign,
+				iio_sscanf(buf, "%ce:%c%u/%uX%u>>%u",
+#ifdef _MSC_BUILD
+					&endian, sizeof(endian),
+					&sign, sizeof(sign),
+#else
+					&endian, &sign,
+#endif
 					&chn->format.bits, &chn->format.length,
 					&chn->format.repeat, &chn->format.shift);
 			} else {
 				chn->format.repeat = 1;
-				sscanf(buf, "%ce:%c%u/%u>>%u", &endian, &sign,
+				iio_sscanf(buf, "%ce:%c%u/%u>>%u",
+#ifdef _MSC_BUILD
+					&endian, sizeof(endian),
+					&sign, sizeof(sign),
+#else
+					&endian, &sign,
+#endif
 					&chn->format.bits, &chn->format.length,
 					&chn->format.shift);
 			}

--- a/network.c
+++ b/network.c
@@ -771,7 +771,7 @@ static ssize_t network_read_mask(struct iio_network_io_context *io_ctx,
 			if (ret < 0)
 				return ret;
 
-			sscanf(buf, "%08x", &mask[i - 1]);
+			iio_sscanf(buf, "%08x", &mask[i - 1]);
 			IIO_DEBUG("mask[%lu] = 0x%x\n",
 					(unsigned long)(i - 1), mask[i - 1]);
 		}

--- a/network.c
+++ b/network.c
@@ -406,7 +406,7 @@ static ssize_t write_command(struct iio_network_io_context *io_ctx,
 	ret = write_all(io_ctx, cmd, strlen(cmd));
 	if (ret < 0) {
 		char buf[1024];
-		iio_strerror(-ret, buf, sizeof(buf));
+		iio_strerror(-(int) ret, buf, sizeof(buf));
 		IIO_ERROR("Unable to send command: %s\n", buf);
 	}
 	return ret;
@@ -510,8 +510,17 @@ static int do_connect(int fd, const struct addrinfo *addrinfo,
 	}
 
 #ifdef _WIN32
+#ifdef _MSC_BUILD
+	/* This is so stupid, but studio emits a signed/unsigned mismatch
+	 * on their own FD_ZERO macro, so turn the warning off/on
+	 */
+#pragma warning(disable : 4389)
+#endif
 	FD_ZERO(&set);
 	FD_SET(fd, &set);
+#ifdef _MSC_BUILD
+#pragma warning(default: 4389)
+#endif
 
 	if (timeout != 0) {
 		tv.tv_sec = timeout / 1000;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ endif()
 if (MSVC)
 	include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../deps/wingetopt/src)
 	set(GETOPT_C_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../deps/wingetopt/src/getopt.c)
+	set_source_files_properties(${GETOPT_C_FILE} PROPERTIES COMPILE_FLAGS -D_CRT_SECURE_NO_WARNINGS=1)
 endif (MSVC)
 
 if (WIN32)

--- a/tests/iio_attr.c
+++ b/tests/iio_attr.c
@@ -35,8 +35,6 @@
 
 #ifdef _WIN32
 #define snprintf sprintf_s
-#else
-#define _strdup strdup
 #endif
 
 static bool str_match(const char * haystack, char * needle, bool ignore)
@@ -55,17 +53,17 @@ static bool str_match(const char * haystack, char * needle, bool ignore)
 	if (!strcmp(".", needle) || !strcmp("*", needle))
 		return true;
 
-	ncpy = _strdup(needle);
-	hcpy = _strdup(haystack);
+	ncpy = cmn_strndup(needle, NAME_MAX);
+	hcpy = cmn_strndup(haystack, NAME_MAX);
 
 	if (!ncpy || !hcpy)
 		goto eek;
 
 	if (ignore) {
 		for (i = 0; hcpy[i]; i++)
-			hcpy[i] = tolower(hcpy[i]);
+			hcpy[i] = (char) (tolower(hcpy[i]) & 0xFF);
 		for (i = 0; ncpy[i]; i++)
-			ncpy[i] = tolower(ncpy[i]);
+			ncpy[i] = (char) (tolower(ncpy[i]) & 0xFF);
 	}
 
 	first = ncpy[0];
@@ -113,7 +111,7 @@ static void dump_device_attributes(const struct iio_device *dev,
 			else
 				printf("'%s'\n", buf);
 		} else {
-			iio_strerror(-ret, buf, BUF_SIZE);
+			iio_strerror(-(int)ret, buf, BUF_SIZE);
 			printf("ERROR: %s (%li)\n", buf, (long)ret);
 		}
 	}
@@ -124,7 +122,7 @@ static void dump_device_attributes(const struct iio_device *dev,
 			if (!quiet)
 				printf("wrote %li bytes to %s\n", (long)ret, attr);
 		} else {
-			iio_strerror(-ret, buf, BUF_SIZE);
+			iio_strerror(-(int)ret, buf, BUF_SIZE);
 			printf("ERROR: %s (%li) while writing '%s' with '%s'\n",
 					buf, (long)ret, attr, wbuf);
 		}
@@ -153,7 +151,7 @@ static void dump_buffer_attributes(const struct iio_device *dev,
 			else
 				printf("'%s'\n", buf);
 		} else {
-			iio_strerror(-ret, buf, BUF_SIZE);
+			iio_strerror(-(int)ret, buf, BUF_SIZE);
 			printf("ERROR: %s (%li)\n", buf, (long)ret);
 		}
 	}
@@ -165,7 +163,7 @@ static void dump_buffer_attributes(const struct iio_device *dev,
 			if (!quiet)
 				printf("wrote %li bytes to %s\n", (long)ret, attr);
 		} else {
-			iio_strerror(-ret, buf, BUF_SIZE);
+			iio_strerror(-(int)ret, buf, BUF_SIZE);
 			printf("ERROR: %s (%li) while writing '%s' with '%s'\n",
 					buf, (long)ret, attr, wbuf);
 		}
@@ -195,7 +193,7 @@ static void dump_debug_attributes(const struct iio_device *dev,
 			else
 				printf("'%s'\n", buf);
 		} else {
-			iio_strerror(-ret, buf, BUF_SIZE);
+			iio_strerror(-(int)ret, buf, BUF_SIZE);
 			printf("ERROR: %s (%li)\n", buf, (long)ret);
 		}
 	}
@@ -207,7 +205,7 @@ static void dump_debug_attributes(const struct iio_device *dev,
 			if (!quiet)
 				printf("wrote %li bytes to %s\n", (long)ret, attr);
 		} else {
-			iio_strerror(-ret, buf, BUF_SIZE);
+			iio_strerror(-(int)ret, buf, BUF_SIZE);
 			printf("ERROR: %s (%li) while writing '%s' with '%s'\n",
 					buf, (long)ret, attr, wbuf);
 		}
@@ -249,7 +247,7 @@ static void dump_channel_attributes(const struct iio_device *dev,
 			else
 				printf("value '%s'\n", buf);
 		} else {
-			iio_strerror(-ret, buf, BUF_SIZE);
+			iio_strerror(-(int)ret, buf, BUF_SIZE);
 			printf("ERROR: %s (%li)\n", buf, (long)ret);
 		}
 	}
@@ -260,7 +258,7 @@ static void dump_channel_attributes(const struct iio_device *dev,
 			if (!quiet)
 				printf("wrote %li bytes to %s\n", (long)ret, attr);
 		} else {
-			iio_strerror(-ret, buf, BUF_SIZE);
+			iio_strerror(-(int)ret, buf, BUF_SIZE);
 			printf("error %s (%li) while writing '%s' with '%s'\n",
 					buf, (long)ret, attr, wbuf);
 		}

--- a/tests/iio_common.h
+++ b/tests/iio_common.h
@@ -40,10 +40,22 @@ enum backend {
 };
 
 void * xmalloc(size_t n, const char *name);
+char *cmn_strndup(const char *str, size_t n);
 
 struct iio_context * autodetect_context(bool rtn, bool gen_code, const char *name);
 unsigned long int sanitize_clamp(const char *name, const char *argv,
 	uint64_t min, uint64_t max);
 void usage(char *name, const struct option *options, const char *options_descriptions[]);
+
+/* https://pubs.opengroup.org/onlinepubs/009695399/basedefs/limits.h.html
+ * {NAME_MAX} : Maximum number of bytes in a filename
+ * {PATH_MAX} : Maximum number of bytes in a pathname
+ * {PAGESIZE} : Size in bytes of a page
+ * Too bad we work on non-POSIX systems
+ */
+#ifndef NAME_MAX
+#define NAME_MAX 256
+#endif
+
 
 #endif /* IIO_TESTS_COMMON_H */

--- a/tests/iio_info.c
+++ b/tests/iio_info.c
@@ -139,12 +139,12 @@ int main(int argc, char **argv)
 	printf("\n");
 
 	if (do_scan) {
-		autodetect_context(false, NULL, MY_NAME);
+		autodetect_context(false, false, MY_NAME);
 		return EXIT_SUCCESS;
 	}
 
 	if (detect_context)
-		ctx = autodetect_context(true, NULL, MY_NAME);
+		ctx = autodetect_context(true, false, MY_NAME);
 	else if (backend == IIO_XML)
 		ctx = iio_create_xml_context(arg_xml);
 	else if (backend == IIO_NETWORK)

--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -249,7 +249,7 @@ int main(int argc, char **argv)
 	setup_sig_handler();
 
 	if (scan_for_context)
-		ctx = autodetect_context(true, NULL, MY_NAME);
+		ctx = autodetect_context(true, false, MY_NAME);
 	else if (arg_uri)
 		ctx = iio_create_context_from_uri(arg_uri);
 	else if (arg_ip)
@@ -266,7 +266,7 @@ int main(int argc, char **argv)
 		ret = iio_context_set_timeout(ctx, timeout);
 		if (ret < 0) {
 			char err_str[1024];
-			iio_strerror(-ret, err_str, sizeof(err_str));
+			iio_strerror(-(int)ret, err_str, sizeof(err_str));
 			fprintf(stderr, "IIO contexts set timeout failed : %s (%zd)\n",
 					err_str, ret);
 		}
@@ -304,7 +304,7 @@ int main(int argc, char **argv)
 				"frequency", DEFAULT_FREQ_HZ);
 			if (ret < 0) {
 				char buf[256];
-				iio_strerror(-ret, buf, sizeof(buf));
+				iio_strerror(-(int)ret, buf, sizeof(buf));
 				fprintf(stderr, "sample rate not set : %s (%zd)\n",
 						buf, ret);
 			}
@@ -313,7 +313,7 @@ int main(int argc, char **argv)
 		ret = iio_device_set_trigger(dev, trigger);
 		if (ret < 0) {
 			char buf[256];
-			iio_strerror(-ret, buf, sizeof(buf));
+			iio_strerror(-(int)ret, buf, sizeof(buf));
 			fprintf(stderr, "set triffer failed : %s (%zd)\n",
 					buf, ret);
 		}
@@ -383,11 +383,11 @@ int main(int argc, char **argv)
 #endif
 
 	while (app_running) {
-		int ret = iio_buffer_refill(buffer);
+		ssize_t ret = iio_buffer_refill(buffer);
 		if (ret < 0) {
 			if (app_running) {
 				char buf[256];
-				iio_strerror(-ret, buf, sizeof(buf));
+				iio_strerror(-(int)ret, buf, sizeof(buf));
 				fprintf(stderr, "Unable to refill buffer: %s\n", buf);
 			}
 			break;
@@ -421,8 +421,8 @@ int main(int argc, char **argv)
 			ret = iio_buffer_foreach_sample(buffer, print_sample, NULL);
 			if (ret < 0) {
 				char buf[256];
-				iio_strerror(-ret, buf, sizeof(buf));
-				fprintf(stderr, "buffer processing failed : %s (%d)\n",
+				iio_strerror(-(int)ret, buf, sizeof(buf));
+				fprintf(stderr, "buffer processing failed : %s (%zi)\n",
 						buf, ret);
 			}
 		}

--- a/tests/iio_writedev.c
+++ b/tests/iio_writedev.c
@@ -263,7 +263,7 @@ int main(int argc, char **argv)
 	setup_sig_handler();
 
 	if (scan_for_context)
-		ctx = autodetect_context(true, NULL, MY_NAME);
+		ctx = autodetect_context(true, false, MY_NAME);
 	else if (arg_uri)
 		ctx = iio_create_context_from_uri(arg_uri);
 	else if (arg_ip)
@@ -280,7 +280,7 @@ int main(int argc, char **argv)
 		ret = iio_context_set_timeout(ctx, timeout);
 		if (ret < 0) {
 			 char err_str[1024];
-			 iio_strerror(-ret, err_str, sizeof(err_str));
+			 iio_strerror(-(int)ret, err_str, sizeof(err_str));
 			 fprintf(stderr, "IIO contexts set timeout failed : %s (%zd)\n",
 					 err_str, ret);
 		}
@@ -318,7 +318,7 @@ int main(int argc, char **argv)
 				"frequency", DEFAULT_FREQ_HZ);
 			if (ret < 0) {
 				char buf[256];
-				iio_strerror(-ret, buf, sizeof(buf));
+				iio_strerror(-(int)ret, buf, sizeof(buf));
 				fprintf(stderr, "sample rate not set : %s (%zd)\n",
 						buf, ret);
 			}
@@ -327,7 +327,7 @@ int main(int argc, char **argv)
 		ret = iio_device_set_trigger(dev, trigger);
 		if (ret < 0) {
 			char buf[256];
-			iio_strerror(-ret, buf, sizeof(buf));
+			iio_strerror(-(int)ret, buf, sizeof(buf));
 			fprintf(stderr, "set triffer failed : %s (%zd)\n",
 					buf, ret);
 		}
@@ -422,16 +422,16 @@ int main(int argc, char **argv)
 			ret = iio_buffer_foreach_sample(buffer, read_sample, NULL);
 			if (ret < 0) {
 				char buf[256];
-				iio_strerror(-ret, buf, sizeof(buf));
+				iio_strerror(-(int)ret, buf, sizeof(buf));
 				fprintf(stderr, "buffer processing failed : %s (%zd)\n",
 						buf, ret);
 			}
 		}
 
-		int ret = iio_buffer_push(buffer);
+		ret = iio_buffer_push(buffer);
 		if (ret < 0) {
 			char buf[256];
-			iio_strerror(-ret, buf, sizeof(buf));
+			iio_strerror(-(int)ret, buf, sizeof(buf));
 			fprintf(stderr, "Unable to push buffer: %s\n", buf);
 			break;
 		}

--- a/utilities.c
+++ b/utilities.c
@@ -100,7 +100,7 @@ static int write_double_locale(char *buf, size_t len, double val)
 	if (!locale)
 		return -ENOMEM;
 
-	_snprintf_l(buf, len, "%f", locale, val);
+	_snprintf_s_l(buf, len, _TRUNCATE, "%f", locale, val);
 	_free_locale(locale);
 	return 0;
 }
@@ -269,7 +269,10 @@ char * iio_getenv (char * envvar)
 	if (_dupenv_s(&hostname, NULL, envvar))
 		return NULL;
 #else
-	hostname = getenv(envvar);
+	/* This is qualified below, and a copy is returned
+	 * so it's safe to use
+	 */
+	hostname = getenv(envvar); /* Flawfinder: ignore */
 #endif
 
 	if (!hostname)

--- a/xml.c
+++ b/xml.c
@@ -143,14 +143,24 @@ static void setup_scan_element(struct iio_channel *chn, xmlNode *n)
 		} else if (!strcmp(name, "format")) {
 			char e, s;
 			if (strchr(content, 'X')) {
-				sscanf(content, "%ce:%c%u/%uX%u>>%u", &e, &s,
+				iio_sscanf(content, "%ce:%c%u/%uX%u>>%u",
+#ifdef _MSC_BUILD
+					&e, sizeof(e), &s, sizeof(s),
+#else
+					&e, &s,
+#endif
 					&chn->format.bits,
 					&chn->format.length,
 					&chn->format.repeat,
 					&chn->format.shift);
 			} else {
 				chn->format.repeat = 1;
-				sscanf(content, "%ce:%c%u/%u>>%u", &e, &s,
+				iio_sscanf(content, "%ce:%c%u/%u>>%u",
+#ifdef _MSC_BUILD
+					&e, sizeof(e), &s, sizeof(s),
+#else
+					&e, &s,
+#endif
 					&chn->format.bits,
 					&chn->format.length,
 					&chn->format.shift);


### PR DESCRIPTION
to bring the Windows builds to the same as the other CI infrastructure.

Signed-off-by: Robin Getz <robin.getz@analog.com>