### PR TITLE
appveyor.yml: Upgrade packages and pacman before trying to install any dependencies.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,10 +38,10 @@ build_script:
     - C:\msys64\usr\bin\bash -lc "pwd"
     - mkdir C:\projects\libiio\build-mingw-win32\"%configuration%"& cd C:\projects\libiio\build-mingw-win32\"%configuration%"
     - C:\msys64\usr\bin\bash -lc "pwd"
+    - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syu"
     - C:\msys64\usr\bin\bash -lc "pacman -Rs --noconfirm mingw-w64-i686-gcc-ada mingw-w64-i686-gcc-fortran mingw-w64-i686-gcc-libgfortran mingw-w64-i686-gcc-objc"
     - C:\msys64\usr\bin\bash -lc "rm /mingw32/etc/gdbinit"
     - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy  mingw-w64-i686-gcc mingw-w64-i686-libusb mingw-w64-i686-curl mingw-w64-i686-cmake mingw-w64-i686-libxml2 mingw-w64-i686-pkg-config mingw-w64-i686-libzip"
-    - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syu"
     # Newer llvm breaks doxygen, use old version for now
     - C:\msys64\usr\bin\bash -lc "pacman -U --noconfirm http://repo.msys2.org/mingw/i686/mingw-w64-i686-llvm-5.0.0-3-any.pkg.tar.xz http://repo.msys2.org/mingw/i686/mingw-w64-i686-clang-5.0.0-3-any.pkg.tar.xz"
     # set the specific version of doxygen (06-Jun-2018), need to look at this later.


### PR DESCRIPTION
Otherwise it might fail because pacman can't unzip .zst files or because local packages are outdated.

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>