### PR TITLE
local.c: fix off by one introduced in 3f305ee

### DIFF
--- a/local.c
+++ b/local.c
@@ -223,7 +223,7 @@ static int set_channel_name(struct iio_channel *chn)
 		name = malloc(prefix_len);
 		if (!name)
 			return -ENOMEM;
-		iio_strlcpy(name, attr0, prefix_len - 1);
+		iio_strlcpy(name, attr0, prefix_len);
 		IIO_DEBUG("Setting name of channel %s to %s\n", chn->id, name);
 		chn->name = name;
 


### PR DESCRIPTION
when moving to iio_strlcpy in local.c during:
3f305ee3f0ada31d4d26ac97f349912869825cfe
we were off by one, so fix that.

Tested over network from FMCOMMS2/Zed Board (running Master) to Windows
(running 0.19 release).

Signed-off-by: Robin Getz <robin.getz@analog.com>