### PR TITLE
Fix E1101 and R1714 pylint warnings

### DIFF
--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -675,7 +675,7 @@ def iio_strerror(err, buf, length):
 
 
 version = _get_lib_version()
-backends = [_get_backend(x).decode("ascii") for x in range(0, _get_backends_count())]
+backends = [_get_backend(b).decode("ascii") for b in range(0, _get_backends_count())]
 
 
 class _attr(object):
@@ -688,11 +688,11 @@ class _attr(object):
         return self._name
 
     @abc.abstractmethod
-    def __read(self):
+    def _read(self):
         pass
 
     @abc.abstractmethod
-    def __write(self):
+    def _write(self, value):
         pass
 
     name = property(
@@ -705,8 +705,8 @@ class _attr(object):
         "The filename in sysfs to which this attribute is bound.\n\ttype=str",
     )
     value = property(
-        lambda self: self.__read(),
-        lambda self, x: self.__write(x),
+        lambda self: self._read(),
+        lambda self, x: self._write(x),
         None,
         "Current value of this attribute.\n\ttype=str",
     )
@@ -734,12 +734,12 @@ class ChannelAttr(_attr):
         )
         self._channel = channel
 
-    def _attr__read(self):
+    def _read(self):
         buf = create_string_buffer(1024)
         _c_read_attr(self._channel, self._name_ascii, buf, len(buf))
         return buf.value.decode("ascii")
 
-    def _attr__write(self, value):
+    def _write(self, value):
         _c_write_attr(self._channel, self._name_ascii, value.encode("ascii"))
 
 
@@ -763,12 +763,12 @@ class DeviceAttr(_attr):
         super(DeviceAttr, self).__init__(name)
         self._device = device
 
-    def _attr__read(self):
+    def _read(self):
         buf = create_string_buffer(1024)
         _d_read_attr(self._device, self._name_ascii, buf, len(buf))
         return buf.value.decode("ascii")
 
-    def _attr__write(self, value):
+    def _write(self, value):
         _d_write_attr(self._device, self._name_ascii, value.encode("ascii"))
 
 
@@ -791,12 +791,12 @@ class DeviceDebugAttr(DeviceAttr):
         """
         super(DeviceDebugAttr, self).__init__(device, name)
 
-    def _attr__read(self):
+    def _read(self):
         buf = create_string_buffer(1024)
         _d_read_debug_attr(self._device, self._name_ascii, buf, len(buf))
         return buf.value.decode("ascii")
 
-    def _attr__write(self, value):
+    def _write(self, value):
         _d_write_debug_attr(self._device, self._name_ascii, value.encode("ascii"))
 
 
@@ -818,12 +818,12 @@ class DeviceBufferAttr(DeviceAttr):
         """
         super(DeviceBufferAttr, self).__init__(device, name)
 
-    def _attr__read(self):
+    def _read(self):
         buf = create_string_buffer(1024)
         _d_read_buffer_attr(self._device, self._name_ascii, buf, len(buf))
         return buf.value.decode("ascii")
 
-    def _attr__write(self, value):
+    def _write(self, value):
         _d_write_buffer_attr(self._device, self._name_ascii, value.encode("ascii"))
 
 
@@ -1445,10 +1445,7 @@ class Context(object):
         returns: type=iio.Device or type=iio.Trigger
             The IIO Device
         """
-        return next(
-            (x for x in self.devices if name_or_id == x.name or name_or_id == x.id),
-            None,
-        )
+        return next((x for x in self.devices if name_or_id in [x.name, x.id]), None,)
 
     name = property(
         lambda self: self._name, None, None, "Name of this IIO context.\n\ttype=str"


### PR DESCRIPTION
Fix pylink warnings related to abstract methods and simpler attribute
name check.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>