### PR TITLE
tests: add a common function to parse and create iio_contexts

### DIFF
--- a/tests/iio_common.h
+++ b/tests/iio_common.h
@@ -45,7 +45,14 @@ char *cmn_strndup(const char *str, size_t n);
 struct iio_context * autodetect_context(bool rtn, bool gen_code, const char *name);
 unsigned long int sanitize_clamp(const char *name, const char *argv,
 	uint64_t min, uint64_t max);
+
+#define COMMON_OPTIONS "hn:x:u:aS"
+struct iio_context * handle_common_opts(char * name, int argc, char * const argv[],
+	const struct option *options, const char *options_descriptions[]);
 void usage(char *name, const struct option *options, const char *options_descriptions[]);
+
+char ** dup_argv(int argc, char * argv[]);
+void free_argw(int argc, char * argw[]);
 
 /* https://pubs.opengroup.org/onlinepubs/009695399/basedefs/limits.h.html
  * {NAME_MAX} : Maximum number of bytes in a filename

--- a/tests/iio_reg.c
+++ b/tests/iio_reg.c
@@ -23,27 +23,23 @@
 #include <iio.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <getopt.h>
 
 #include "iio_common.h"
 
-static int write_reg(const char *name, uint32_t addr, uint32_t val)
+#define MY_NAME "iio_reg"
+
+static const struct option options[] = {
+	{0, 0, 0, 0},
+};
+
+static const char *options_descriptions[] = {
+	"<device> <register> [<value>]\n"
+};
+
+static int write_reg(struct iio_device *dev, uint32_t addr, uint32_t val)
 {
-	struct iio_device *dev;
-	struct iio_context *ctx;
 	int ret;
-
-	ctx = iio_create_default_context();
-	if (!ctx) {
-		perror("Unable to create context");
-		return EXIT_FAILURE;
-	}
-
-	dev = iio_context_find_device(ctx, name);
-	if (!dev) {
-		errno = ENODEV;
-		perror("Unable to find device");
-		goto err_destroy_context;
-	}
 
 	ret = iio_device_reg_write(dev, addr, val);
 	if (ret < 0) {
@@ -52,33 +48,16 @@ static int write_reg(const char *name, uint32_t addr, uint32_t val)
 		goto err_destroy_context;
 	}
 
-	iio_context_destroy(ctx);
 	return EXIT_SUCCESS;
 
 err_destroy_context:
-	iio_context_destroy(ctx);
 	return EXIT_FAILURE;
 }
 
-static int read_reg(const char *name, unsigned long addr)
+static int read_reg(struct iio_device *dev, unsigned long addr)
 {
-	struct iio_device *dev;
-	struct iio_context *ctx;
 	uint32_t val;
 	int ret;
-
-	ctx = iio_create_default_context();
-	if (!ctx) {
-		perror("Unable to create context");
-		return EXIT_FAILURE;
-	}
-
-	dev = iio_context_find_device(ctx, name);
-	if (!dev) {
-		errno = ENODEV;
-		perror("Unable to find device");
-		goto err_destroy_context;
-	}
 
 	ret = iio_device_reg_read(dev, addr, &val);
 	if (ret < 0) {
@@ -88,29 +67,66 @@ static int read_reg(const char *name, unsigned long addr)
 	}
 
 	printf("0x%x\n", val);
-	iio_context_destroy(ctx);
 	return EXIT_SUCCESS;
 
 err_destroy_context:
-	iio_context_destroy(ctx);
 	return EXIT_FAILURE;
 }
 
 int main(int argc, char **argv)
 {
+	char **argw;
 	unsigned long addr;
+	struct iio_context *ctx;
+	struct iio_device *dev;
+	int c, option_index = 0;
+	char * name;
 
-	if (argc < 3 || argc > 4) {
-		printf("Usage:\n\niio_reg <device> <register> [<value>]\n");
-		return 0;
+	argw = dup_argv(argc, argv);
+
+	ctx = handle_common_opts(MY_NAME, argc, argw, options, options_descriptions);
+
+	while ((c = getopt_long(argc, argw, "+" COMMON_OPTIONS, /* Flawfinder: ignore */
+			options, &option_index)) != -1) {
+		switch (c) {
+		/* All these are handled in the common */
+		case 'h':
+		case 'n':
+		case 'x':
+		case 'S':
+		case 'u':
+		case 'a':
+			break;
+		case '?':
+			printf("Unknown argument '%c'\n", c);
+			return EXIT_FAILURE;
+		}
 	}
 
-	addr = sanitize_clamp("register address", argv[2], 0, UINT32_MAX);
+	if ((argc - optind) < 2 || (argc - optind) > 3) {
+		usage(MY_NAME, options, options_descriptions);
+		return EXIT_SUCCESS;
+	}
 
-	if (argc == 3) {
-		return read_reg(argv[1], addr);
+	name = cmn_strndup(argw[optind], NAME_MAX);
+	dev = iio_context_find_device(ctx, name);
+	if (!dev) {
+		perror("Unable to find device");
+		goto err_destroy_context;
+	}
+
+	addr = sanitize_clamp("register address", argw[optind + 1], 0, UINT32_MAX);
+
+	if ((argc - optind) == 2) {
+		return read_reg(dev, addr);
 	} else {
-		uint32_t val = sanitize_clamp("register value", argv[3], 0, UINT32_MAX);
-		return write_reg(argv[1], addr, val);
+		uint32_t val = sanitize_clamp("register value", argw[optind + 2], 0, UINT32_MAX);
+		return write_reg(dev, addr, val);
 	}
+
+err_destroy_context:
+	free(name);
+	iio_context_destroy(ctx);
+	free_argw(argc, argw);
+	return EXIT_SUCCESS;
 }

--- a/tests/iio_writedev.c
+++ b/tests/iio_writedev.c
@@ -44,9 +44,6 @@
 #define DEFAULT_FREQ_HZ  100
 
 static const struct option options[] = {
-	  {"help", no_argument, 0, 'h'},
-	  {"network", required_argument, 0, 'n'},
-	  {"uri", required_argument, 0, 'u'},
 	  {"trigger", required_argument, 0, 't'},
 	  {"buffer-size", required_argument, 0, 'b'},
 	  {"samples", required_argument, 0, 's' },
@@ -57,12 +54,9 @@ static const struct option options[] = {
 };
 
 static const char *options_descriptions[] = {
-	"[-n <hostname>] [-t <trigger>] "
+	"[-t <trigger>] "
 		"[-T <timeout-ms>] [-b <buffer-size>] [-s <samples>] "
 		"<iio_device> [<channel> ...]",
-	"Show this help and quit.",
-	"Use the network backend with the provided hostname.",
-	"Use the context with the provided URI.",
 	"Use the specified trigger.",
 	"Size of the transmit buffer. Default is 256.",
 	"Number of samples to write, 0 = infinite. Default is 0.",
@@ -206,33 +200,31 @@ static ssize_t read_sample(const struct iio_channel *chn,
 
 int main(int argc, char **argv)
 {
+	char **argw;
 	unsigned int i, nb_channels;
 	unsigned int nb_active_channels = 0;
 	unsigned int buffer_size = SAMPLES_PER_READ;
-	const char *arg_uri = NULL;
-	const char *arg_ip = NULL;
 	int c, option_index = 0;
 	struct iio_device *dev;
 	ssize_t sample_size;
 	int timeout = -1;
-	bool scan_for_context = false;
 	bool cyclic_buffer = false;
 	ssize_t ret;
 
-	while ((c = getopt_long(argc, argv, "+hn:u:t:b:s:T:ac",
+	argw = dup_argv(argc, argv);
+
+	ctx = handle_common_opts(MY_NAME, argc, argw, options, options_descriptions);
+
+	while ((c = getopt_long(argc, argw, "+" COMMON_OPTIONS "t:b:s:T:ac",  /* Flawfinder: ignore */
 					options, &option_index)) != -1) {
 		switch (c) {
+		/* All these are handled in the common */
 		case 'h':
-			usage(MY_NAME, options, options_descriptions);
-			return EXIT_SUCCESS;
 		case 'n':
-			arg_ip = optarg;
-			break;
+		case 'x':
+		case 'S':
 		case 'u':
-			arg_uri = optarg;
-			break;
 		case 'a':
-			scan_for_context = true;
 			break;
 		case 't':
 			trigger_name = optarg;
@@ -250,6 +242,7 @@ int main(int argc, char **argv)
 			cyclic_buffer = true;
 			break;
 		case '?':
+			printf("Unknown argument '%c'\n", c);
 			return EXIT_FAILURE;
 		}
 	}
@@ -260,21 +253,10 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	setup_sig_handler();
-
-	if (scan_for_context)
-		ctx = autodetect_context(true, false, MY_NAME);
-	else if (arg_uri)
-		ctx = iio_create_context_from_uri(arg_uri);
-	else if (arg_ip)
-		ctx = iio_create_network_context(arg_ip);
-	else
-		ctx = iio_create_default_context();
-
-	if (!ctx) {
-		fprintf(stderr, "Unable to create IIO context\n");
+	if (!ctx)
 		return EXIT_FAILURE;
-	}
+
+	setup_sig_handler();
 
 	if (timeout >= 0) {
 		ret = iio_context_set_timeout(ctx, timeout);
@@ -286,9 +268,9 @@ int main(int argc, char **argv)
 		}
 	}
 
-	dev = iio_context_find_device(ctx, argv[optind]);
+	dev = iio_context_find_device(ctx, argw[optind]);
 	if (!dev) {
-		fprintf(stderr, "Device %s not found\n", argv[optind]);
+		fprintf(stderr, "Device %s not found\n", argw[optind]);
 		iio_context_destroy(ctx);
 		return EXIT_FAILURE;
 	}
@@ -350,8 +332,8 @@ int main(int argc, char **argv)
 			struct iio_channel *ch = iio_device_get_channel(dev, i);
 			for (j = optind + 1; j < (unsigned int) argc; j++) {
 				const char *n = iio_channel_get_name(ch);
-				if ((!strcmp(argv[j], iio_channel_get_id(ch)) ||
-						(n && !strcmp(n, argv[j]))) &&
+				if ((!strcmp(argw[j], iio_channel_get_id(ch)) ||
+						(n && !strcmp(n, argw[j]))) &&
 						iio_channel_is_output(ch)) {
 					iio_channel_enable(ch);
 					nb_active_channels++;
@@ -449,5 +431,6 @@ int main(int argc, char **argv)
 err_destroy_buffer:
 	iio_buffer_destroy(buffer);
 	iio_context_destroy(ctx);
+	free_argw(argc, argw);
 	return exit_code;
 }


### PR DESCRIPTION
Some (older) implementations of getopt_long) do not protect against internal
buffer overflows, so copy argv to a temp str array, and parse most in a
common function. (-u -h -x -n, and -S).
  -h, --help Show this help and quit.
  -x, --xml  Use the XML backend with the provided XML file.
  -u, --uri  Use the context at the provided URI.
  -S, --scan Scan for available backends.
  -a, --auto Scan for available contexts and if only one is available use it.

The "default" for scan is "S", since "s" is used for many apps as sample
size. This means that iio_info now takes -s and -S as scan.

This also fixes both CWE-120 and CWE-20
https://cwe.mitre.org/data/definitions/120.html
https://cwe.mitre.org/data/definitions/20.html
and almost is a net decrease (348 insertions, 345 deletions over 9
files).

Signed-off-by: Robin Getz <robin.getz@analog.com>