### PR TITLE
remove usleep(): usleep() is considered obsolete, move to nanosleep()

### DIFF
--- a/examples/iio-monitor.c
+++ b/examples/iio-monitor.c
@@ -162,9 +162,12 @@ static void * read_thd(void *d)
 		unsigned int i, nb_channels, nb = 0;
 		char buf[1024];
 		chtype *str;
+		struct timespec wait;
 		(void) row; /* Prevent warning */
 
-		usleep(100000);
+		wait.tv_sec = 0;
+		wait.tv_nsec = (100000 * 1000);
+		nanosleep(&wait, &wait);
 
 		if (selected < 0)
 			continue;
@@ -380,9 +383,13 @@ static void show_main_screen(struct iio_context *ctx)
 
 	while (!stop) {
 		int ret = activateCDKScroll(list, NULL);
+		struct timespec wait;
+		wait.tv_sec = 0;
+		wait.tv_nsec = (100000 * 1000);
+
 		stop = ret < 0;
 		selected = ret;
-		usleep(100000);
+		nanosleep(&wait, &wait);
 	}
 
 	pthread_join(thd, NULL);

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -951,9 +951,12 @@ retry:
 			 * This is not pretty but it works.
 			 */
 			if (cyclic_retry) {
-			       cyclic_retry--;
-			       usleep(100);
-			       goto retry;
+				struct timespec wait;
+				wait.tv_sec = 0;
+				wait.tv_nsec = (100 * 1000);
+				cyclic_retry--;
+				nanosleep(&wait, &wait);
+				goto retry;
 			}
 
 			ret = -EBUSY;

--- a/tests/iio_stresstest.c
+++ b/tests/iio_stresstest.c
@@ -318,8 +318,11 @@ static void *client_thread(void *data)
 			info->buffers[id]++;
 			buffer = iio_device_create_buffer(dev, info->buffer_size, false);
 			if (!buffer) {
+				struct timespec wait;
+				wait.tv_sec = 0;
+				wait.tv_nsec = (1 * 1000);
 				thread_err(id, errno, "iio_device_create_buffer failed");
-				usleep(1);
+				nanosleep(&wait, &wait);
 				continue;
 			}
 	
@@ -571,7 +574,10 @@ int main(int argc, char **argv)
 			if (info.timeout && duration >= info.timeout) {
 				threads_running = false;
 			} else {
-				usleep(1000);
+				struct timespec wait;
+				wait.tv_sec = 0;
+				wait.tv_nsec = (1000 * 1000);
+				nanosleep(&wait, &wait);
 			}
 		}
 


### PR DESCRIPTION
The usleep() function is considered obsolete. The interaction of this function
with SIGALRM and other timer functions such as sleep(), alarm(), setitimer(),
and nanosleep() is unspecified (CWE-676)
https://cwe.mitre.org/data/definitions/676.html

So move to nanosleep() instead.

Signed-off-by: Robin Getz <robin.getz@analog.com>