### PR TITLE
cppcheck: fix null ptr dereference

### DIFF
--- a/tests/iio_adi_xflow_check.c
+++ b/tests/iio_adi_xflow_check.c
@@ -166,7 +166,7 @@ int main(int argc, char **argv)
 	char unit;
 	int ret;
 
-	argw = dup_argv(argc, argv);
+	argw = dup_argv(MY_NAME, argc, argv);
 
 	ctx = handle_common_opts(MY_NAME, argc, argw, options, options_descriptions);
 

--- a/tests/iio_attr.c
+++ b/tests/iio_attr.c
@@ -349,7 +349,7 @@ int main(int argc, char **argv)
 	unsigned int i;
 	char *wbuf = NULL;
 
-	argw = dup_argv(argc, argv);
+	argw = dup_argv(MY_NAME, argc, argv);
 
 	ctx = handle_common_opts(MY_NAME, argc, argw, options, options_descriptions);
 

--- a/tests/iio_common.c
+++ b/tests/iio_common.c
@@ -42,8 +42,12 @@ void * xmalloc(size_t n, const char * name)
 	void *p = malloc(n);
 
 	if (!p && n != 0) {
-		fprintf(stderr, "%s fatal error: allocating %zu bytes failed\n",
+		if (name) {
+			fprintf(stderr, "%s fatal error: allocating %zu bytes failed\n",
 				name, n);
+		} else {
+			fprintf(stderr, "Fatal error: allocating %zu bytes failed\n", n);
+		}
 		exit(EXIT_FAILURE);
 	}
 
@@ -150,10 +154,10 @@ unsigned long int sanitize_clamp(const char *name, const char *argv,
 	return (unsigned long int) val;
 }
 
-char ** dup_argv(int argc, char * argv[])
+char ** dup_argv(char * name, int argc, char * argv[])
 {
 	int i = 1;
-	char** new_argv = xmalloc((argc + 1) * sizeof(char *), NULL);
+	char** new_argv = xmalloc((argc + 1) * sizeof(char *), name);
 
 	for(int i = 0; i < argc; i++) {
 		new_argv[i] = cmn_strndup(argv[i], NAME_MAX);

--- a/tests/iio_common.h
+++ b/tests/iio_common.h
@@ -51,7 +51,7 @@ struct iio_context * handle_common_opts(char * name, int argc, char * const argv
 	const struct option *options, const char *options_descriptions[]);
 void usage(char *name, const struct option *options, const char *options_descriptions[]);
 
-char ** dup_argv(int argc, char * argv[]);
+char ** dup_argv(char * name, int argc, char * argv[]);
 void free_argw(int argc, char * argw[]);
 
 /* https://pubs.opengroup.org/onlinepubs/009695399/basedefs/limits.h.html

--- a/tests/iio_genxml.c
+++ b/tests/iio_genxml.c
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
 	int c, option_index = 0;
 	size_t xml_len;
 
-	argw = dup_argv(argc, argv);
+	argw = dup_argv(MY_NAME, argc, argv);
 	ctx = handle_common_opts(MY_NAME, argc, argw, options, options_descriptions);
 
 	while ((c = getopt_long(argc, argv, "+" COMMON_OPTIONS,  /* Flawfinder: ignore */

--- a/tests/iio_info.c
+++ b/tests/iio_info.c
@@ -68,7 +68,7 @@ int main(int argc, char **argv)
 	char git_tag[8];
 	int ret;
 
-	argw = dup_argv(argc, argv);
+	argw = dup_argv(MY_NAME, argc, argv);
 
 	iio_library_get_version(&major, &minor, git_tag);
 	printf("Library version: %u.%u (git tag: %s)\n", major, minor, git_tag);

--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -200,7 +200,7 @@ int main(int argc, char **argv)
 	int timeout = -1;
 	ssize_t ret;
 
-	argw = dup_argv(argc, argv);
+	argw = dup_argv(MY_NAME, argc, argv);
 
 	ctx = handle_common_opts(MY_NAME, argc, argw, options, options_descriptions);
 

--- a/tests/iio_reg.c
+++ b/tests/iio_reg.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv)
 	int c, option_index = 0;
 	char * name;
 
-	argw = dup_argv(argc, argv);
+	argw = dup_argv(MY_NAME, argc, argv);
 
 	ctx = handle_common_opts(MY_NAME, argc, argw, options, options_descriptions);
 

--- a/tests/iio_writedev.c
+++ b/tests/iio_writedev.c
@@ -211,7 +211,7 @@ int main(int argc, char **argv)
 	bool cyclic_buffer = false;
 	ssize_t ret;
 
-	argw = dup_argv(argc, argv);
+	argw = dup_argv(MY_NAME, argc, argv);
 
 	ctx = handle_common_opts(MY_NAME, argc, argw, options, options_descriptions);
 


### PR DESCRIPTION
Not sure why, but it looks like cppcheck doesn't run on pull requests...

When adding : 336c3c8b884d83049b589ecd8b1482076d40e6e6
I made a mistake, and called xmalloc() with a NULL name, which is
printed when malloc fails. So:
 - fix the calling functions to include a name
 - add a check to make sure name isn't touched when if it is NULL

This should resolve things.

Signed-off-by: Robin Getz <robin.getz@analog.com>