### PR TITLE
dns_sd: qualify IIO_ERROR message before it prints out

### DIFF
--- a/dns_sd.c
+++ b/dns_sd.c
@@ -53,7 +53,8 @@ static void dnssd_remove_node(struct dns_sd_discovery_data **ddata, int n)
 			ldata = ndata;
 			i++;
 		}
-		IIO_ERROR("dnssd_remove_node call when %i exceeds list length (%i)\n", n, i);
+		if (i < n)
+			IIO_ERROR("dnssd_remove_node call when %i exceeds list length (%i)\n", n, i);
 	}
 
 	*ddata = d;


### PR DESCRIPTION
After a loop finishes (normally by a 'break;') only print out
the IIO_ERROR message if there was an error (was no 'break;').

This resolves some random message printing out:
ERROR: dnssd_remove_node call when 1 exceeds list length (1)
when doing dns-sd (iio_info -s).

Signed-off-by: Robin Getz <robin.getz@analog.com>