### PR TITLE
make doc errs fail on ci

### DIFF
--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -37,6 +37,25 @@ handle_default() {
 		cmake ${FLAGS} ..
 		echo "### make"
 		make
+		# check the error output if either file isn't empty
+		if [ -s ./Dox_output_libiio -o -s ./Dox_output_csharp -o -s ./Spx_output_python ] ; then
+			if [ -s ./Dox_output_libiio ] ; then
+				echo "### ERRORs in Dox_output_libiio"
+				cat ./Dox_output_libiio
+			fi
+			if [ -s ./Dox_output_csharp ] ; then
+				echo "### ERRORs in Dox_output_csharp"
+				cat ./Dox_output_csharp
+			fi
+			if [ -s ./Spx_output_python ] ; then
+				echo "### ERRRORs in Spx_output_python"
+				cat ./Spx_output_python
+			fi
+			exit 1
+		else
+			echo "### No errors in Doc"
+			ls -l Dox_output_csharp Dox_output_libiio Spx_output_python
+		fi
 	fi
 	echo "### make package"
 	make package

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -45,8 +45,10 @@ if(WITH_DOC)
 	add_custom_command(TARGET libiio-py POST_BUILD
 		COMMAND ${SPHINX_EXECUTABLE}
 			-b html
+			-n
 			-c ${CMAKE_CURRENT_SOURCE_DIR}/doc
 			-d ${CMAKE_CURRENT_BINARY_DIR}/doctrees
+			-w ${CMAKE_BINARY_DIR}/Spx_output_python
 			${CMAKE_CURRENT_SOURCE_DIR}/doc
 			${CMAKE_HTML_DEST_DIR}/python
 		COMMENT "Generating Python binding documentation with Sphinx" VERBATIM

--- a/iio.h
+++ b/iio.h
@@ -267,7 +267,7 @@ __api struct iio_scan_block * iio_create_scan_block(
 
 
 /** @brief Destroy the given scan block
- * @param ctx A pointer to an iio_scan_block structure
+ * @param blk A pointer to an iio_scan_block structure
  *
  * <b>NOTE:</b> After that function, the iio_scan_block pointer shall be invalid.
  *


### PR DESCRIPTION
Now that docs are building on CI, check for warnings/errors, and fail on CI if necessary. 

