### PR TITLE
pylint: turn off some checks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -71,7 +71,9 @@ disable=import-error,
         deprecated-pragma,
         no-absolute-import,
         useless-object-inheritance,
-        line-too-long
+        line-too-long,
+        too-many-instance-attributes,
+        too-few-public-methods
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option


### PR DESCRIPTION
too-many-instance-attributes (R0902):
Too many instance attributes (7) Used when class has too many instance
attributes, try to reduce this to get a simpler (and so easier to use) class.

Many of our functions have 8 or more, so turn this off.

too-few-public-methods (R0903)
Too few public methods (%s/%s) Used when class has too few public methods,
so be sure it's really worth it.

Many of our classes have 0 public methods due to the way that our C is
imported.

Signed-off-by: Robin Getz <robin.getz@analog.com>