### PR TITLE
Flawfinder : remove atol and atof, replace with strtoll and strtof

### DIFF
--- a/xml.c
+++ b/xml.c
@@ -139,7 +139,13 @@ static void setup_scan_element(struct iio_channel *chn, xmlNode *n)
 		const char *name = (const char *) attr->name,
 		      *content = (const char *) attr->children->content;
 		if (!strcmp(name, "index")) {
-			chn->index = atol(content);
+			char *end;
+			long long value;
+
+			value = strtoll(content, &end, 0);
+			if (end == content || value < 0 || value > LONG_MAX)
+				return;
+			chn->index = (long) value;
 		} else if (!strcmp(name, "format")) {
 			char e, s;
 			if (strchr(content, 'X')) {
@@ -170,8 +176,17 @@ static void setup_scan_element(struct iio_channel *chn, xmlNode *n)
 			chn->format.is_fully_defined = (s == 'S' || s == 'U' ||
 				chn->format.bits == chn->format.length);
 		} else if (!strcmp(name, "scale")) {
+			char *end;
+			float value;
+
+			value = strtof(content, &end);
+			if (end == content) {
+				chn->format.with_scale = false;
+				return;
+			}
+
 			chn->format.with_scale = true;
-			chn->format.scale = atof(content);
+			chn->format.scale = value;
 		} else {
 			IIO_WARNING("Unknown attribute \'%s\' in <scan-element>\n",
 					name);


### PR DESCRIPTION
Flawfinder reminds us that unless checked, the resulting number can exceed
the expected range (CWE-190). If source untrusted, check both minimum and
maximum, even if the input had no minus sign (large numbers can roll over
into negative number; consider saving to an unsigned value if that is
intended).
https://cwe.mitre.org/data/definitions/190.html

replace these library calls with strtoll and strtof, and include more
error checking.

Signed-off-by: Robin Getz <robin.getz@analog.com>