### PR TITLE
add uri context attribute

### DIFF
--- a/context.c
+++ b/context.c
@@ -414,6 +414,18 @@ int iio_context_add_attr(struct iio_context *ctx,
 		const char *key, const char *value)
 {
 	char **attrs, **values, *new_key, *new_val;
+	unsigned int i;
+
+	for (i = 0; i < ctx->nb_attrs; i++) {
+		if(!strcmp(ctx->attrs[i], key)) {
+			new_val = iio_strdup(value);
+			if (!new_val)
+				return -ENOMEM;
+			free(ctx->values[i]);
+			ctx->values[i] = new_val;
+			return 0;
+		}
+	}
 
 	attrs = realloc(ctx->attrs,
 			(ctx->nb_attrs + 1) * sizeof(*ctx->attrs));

--- a/local.c
+++ b/local.c
@@ -2063,6 +2063,10 @@ struct iio_context * local_create_context(void)
 	if (ret < 0)
 		goto err_context_destroy;
 
+	ret = iio_context_add_attr(ctx, "uri", "local:");
+	if (ret < 0)
+		goto err_context_destroy;
+
 	ret = iio_context_init(ctx);
 	if (ret < 0)
 		goto err_context_destroy;

--- a/usb.c
+++ b/usb.c
@@ -744,6 +744,7 @@ static int usb_populate_context_attrs(struct iio_context *ctx,
 	char buffer[64];
 	unsigned int i;
 	int ret;
+	char uri[sizeof("usb:127.255.255")];
 
 	struct {
 		const char *attr;
@@ -758,6 +759,13 @@ static int usb_populate_context_attrs(struct iio_context *ctx,
 	attrs[1].idx = dev_desc.iProduct;
 	attrs[2].attr = "usb,serial";
 	attrs[2].idx = dev_desc.iSerialNumber;
+
+	iio_snprintf(uri, sizeof(uri), "usb:%d.%d.%u",
+		libusb_get_bus_number(dev), libusb_get_device_address(dev),
+		(uint8_t)ctx->pdata->interface);
+	ret = iio_context_add_attr(ctx, "uri", uri);
+	if (ret < 0)
+		return ret;
 
 	iio_snprintf(buffer, sizeof(buffer), "%04hx", dev_desc.idVendor);
 	ret = iio_context_add_attr(ctx, "usb,idVendor", buffer);


### PR DESCRIPTION
The uri context attribute is added as "local:" (which is what is in iiod), and as this is passed to various remote devices, it will be overwritten by the remote method (usb, ip or serial).

-Robin