### PR TITLE
appveyor.yml: Fix MSYS2 pacman install. Don't use the latest version.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,8 +38,9 @@ build_script:
     - C:\msys64\usr\bin\bash -lc "pwd"
     - mkdir C:\projects\libiio\build-mingw-win32\"%configuration%"& cd C:\projects\libiio\build-mingw-win32\"%configuration%"
     - C:\msys64\usr\bin\bash -lc "pwd"
-    - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy pacman"
-    - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Su"
+    # TODO: Check when the latest pacman version is fixed and revert this commit.
+    - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz"
+    - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syu"
     - C:\msys64\usr\bin\bash -lc "pacman -Rs --noconfirm mingw-w64-i686-gcc-ada mingw-w64-i686-gcc-fortran mingw-w64-i686-gcc-libgfortran mingw-w64-i686-gcc-objc"
     - C:\msys64\usr\bin\bash -lc "rm /mingw32/etc/gdbinit"
     - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Sy  mingw-w64-i686-gcc mingw-w64-i686-libusb mingw-w64-i686-curl mingw-w64-i686-cmake mingw-w64-i686-libxml2 mingw-w64-i686-pkg-config mingw-w64-i686-libzip"


### PR DESCRIPTION
Issue: https://github.com/msys2/MSYS2-packages/issues/1967

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>