### PR TITLE
usb.c : avoid using 'interface' as an identifier.

### DIFF
--- a/iio-private.h
+++ b/iio-private.h
@@ -285,7 +285,7 @@ struct iio_context * network_create_context(const char *hostname);
 struct iio_context * xml_create_context_mem(const char *xml, size_t len);
 struct iio_context * xml_create_context(const char *xml_file);
 struct iio_context * usb_create_context(unsigned int bus, uint16_t address,
-		uint16_t interface);
+		uint16_t intrfc);
 struct iio_context * usb_create_context_from_uri(const char *uri);
 struct iio_context * serial_create_context_from_uri(const char *uri);
 


### PR DESCRIPTION
per #508, a windows header (combaseapi.h) includes this:

making 'interface' a keyword, which we need to avoid using, so - avoid
using it to ensure things compile without issues.

Signed-off-by: Robin Getz <robin.getz@analog.com>