### PR TITLE
xml: Add capability to properly encode xml entities in context attrib…

### DIFF
--- a/iio-private.h
+++ b/iio-private.h
@@ -263,6 +263,7 @@ void free_device(struct iio_device *dev);
 char *iio_channel_get_xml(const struct iio_channel *chn, size_t *len);
 char *iio_device_get_xml(const struct iio_device *dev, size_t *len);
 
+char *encode_xml_ndup(const char * input);
 char *iio_context_create_xml(const struct iio_context *ctx);
 int iio_context_init(struct iio_context *ctx);
 

--- a/xml.c
+++ b/xml.c
@@ -23,6 +23,16 @@
 #include <libxml/tree.h>
 #include <string.h>
 
+/* 'input' must be in UTF-8 encoded, null terminated */
+char * encode_xml_ndup(const char * input)
+{
+	char * out;
+
+	out = (char *)xmlEncodeEntitiesReentrant(NULL, (const xmlChar *)input);
+
+	return out;
+}
+
 static int add_attr_to_channel(struct iio_channel *chn, xmlNode *n)
 {
 	xmlAttr *attr;


### PR DESCRIPTION
…utes

Per #519, xml entities (<, >, ", ', and &) were not encoded properly, and if
used in the libiio.ini file (which was added in 77568c71ec0d7b0162f0b488f261d6d9874f2e88 )
cause the libiio library to fail.

This fixed that by adding a generic way to encode things in xml.c and uses them in context.c

Right now, we only encode context attributes. In theory this could also effect:
 - attribute name
 - buffer-attribute name
 - channel id
 - context name
 - debug-attribute name
 - device id
 - scan-element index
Since most of those are encoded in file names, we shouldn't have those chars
anyway. Now that we know the issue, and understand the fix, if anyone sees
any issues, please feel free to report.

Tested on Zed + FMCOMMS3, with both 0.19 (with fix) and old libraries without fix.
As long as the the version which is reading the file has the fix - it works with
older libraries (is backwards compatible).

Signed-off-by: Robin Getz <robin.getz@analog.com>