### PR TITLE
python: point to the new README.md

### DIFF
--- a/bindings/python/setup.py.cmakein
+++ b/bindings/python/setup.py.cmakein
@@ -29,7 +29,7 @@ else:
 description = "Library for interfacing with Linux IIO devices"
 
 try:
-    with open("${CMAKE_SOURCE_DIR}/README.md", "r") as fh:
+    with open("${CMAKE_CURRENT_SOURCE_DIR}/README.md", "r") as fh:
         long_description = fh.read()
 except:
     long_description = description


### PR DESCRIPTION
This should fix #497 by setting up the python specific README.md

Signed-off-by: Robin Getz <robin.getz@analog.com>