### PR TITLE
iio_attr: enable code gen for local contexts

### DIFF
--- a/tests/gen_code.c
+++ b/tests/gen_code.c
@@ -163,7 +163,11 @@ void gen_context (const char *uri_in)
 	if (!fd)
 		return;
 
-	uri = cmn_strndup(uri_in, NAME_MAX);
+	if (uri_in)
+		uri = cmn_strndup(uri_in, NAME_MAX);
+	else
+		uri = cmn_strndup("unknown:", NAME_MAX);
+
 	if (lang == C_LANG) {
 		fprintf(fd, "\t/* Create IIO Context */\n"
 		    "\tIIO_ASSERT(ctx = iio_create_context_from_uri(\"%s\"));\n\n", uri);
@@ -289,7 +293,7 @@ void gen_function(const char* prefix, const char* target,
 			prefix, rw, target, attr);
 		fprintf(fd, "\t *******************************************************************/\n");
 		if (wbuf) {
-			fprintf(fd, "\tprintf(\"Wrote %%li bytes\\n\", ret);\n\n");
+			fprintf(fd, "\tprintf(\"Wrote %%zi bytes\\n\", ret);\n\n");
 		} else {
 			fprintf(fd, "\tprintf(\"%s : %%s\\n\", buf);\n\n", attr);
 		}

--- a/tests/iio_attr.c
+++ b/tests/iio_attr.c
@@ -554,6 +554,7 @@ int main(int argc, char **argv)
 
 	if (gen_code) {
 		gen_start(gen_file);
+		gen_context(iio_context_get_attr_value(ctx, "uri"));
 	}
 
 	if (search_context) {

--- a/tests/iio_common.c
+++ b/tests/iio_common.c
@@ -70,9 +70,7 @@ char *cmn_strndup(const char *str, size_t n)
 #endif
 }
 
-
-
-struct iio_context * autodetect_context(bool rtn, bool gen_code, const char * name, const char * scan)
+struct iio_context * autodetect_context(bool rtn, const char * name, const char * scan)
 {
 	struct iio_scan_context *scan_ctx;
 	struct iio_context_info **info;
@@ -104,8 +102,6 @@ struct iio_context * autodetect_context(bool rtn, bool gen_code, const char * na
 		printf("Using auto-detected IIO context at URI \"%s\"\n",
 		iio_context_info_get_uri(info[0]));
 		ctx = iio_create_context_from_uri(iio_context_info_get_uri(info[0]));
-		if (gen_code)
-			gen_context(iio_context_info_get_uri(info[0]));
 	} else {
 		if (rtn) {
 			out = stderr;
@@ -285,10 +281,10 @@ struct iio_context * handle_common_opts(char * name, int argc, char * const argv
 	opterr = 1;
 
 	if (do_scan) {
-		autodetect_context(false, false, name, arg);
+		autodetect_context(false, name, arg);
 		exit(0);
 	} else if (detect_context)
-		ctx = autodetect_context(true, false, name, arg);
+		ctx = autodetect_context(true, name, arg);
 	else if (!arg && backend != IIO_LOCAL)
 		fprintf(stderr, "argument parsing error\n");
 	else if (backend == IIO_XML)

--- a/tests/iio_common.h
+++ b/tests/iio_common.h
@@ -42,7 +42,7 @@ enum backend {
 void * xmalloc(size_t n, const char *name);
 char *cmn_strndup(const char *str, size_t n);
 
-struct iio_context * autodetect_context(bool rtn, bool gen_code, const char *name, const char *scan);
+struct iio_context * autodetect_context(bool rtn, const char *name, const char *scan);
 unsigned long int sanitize_clamp(const char *name, const char *argv,
 	uint64_t min, uint64_t max);
 

--- a/tests/iio_info.c
+++ b/tests/iio_info.c
@@ -93,7 +93,7 @@ int main(int argc, char **argv)
 				optind++;
 			break;
 		case 's':
-			autodetect_context(false, false, MY_NAME, NULL);
+			autodetect_context(false, MY_NAME, NULL);
 			return EXIT_SUCCESS;
 		case '?':
 			printf("Unknown argument '%c'\n", c);


### PR DESCRIPTION
Now that we have the uri in the context, we use it, which simplifies the
codegen, and ensures that things work with both local and remote contexts.

This fixes #529

Signed-off-by: Robin Getz <robin.getz@analog.com>