### PR TITLE
iio_utils: rework/fix command line argument parsing

### DIFF
--- a/tests/iio_attr.c
+++ b/tests/iio_attr.c
@@ -340,11 +340,12 @@ static const char *options_descriptions[] = {
 	"Read/Write debug attributes.",
 };
 
+#define MY_OPTS "CdcBDiosIqg:"
 int main(int argc, char **argv)
 {
 	char **argw;
 	struct iio_context *ctx;
-	int c, option_index = 0;
+	int c;
 	int device_index = 0, channel_index = 0, attr_index = 0;
 	const char *gen_file = NULL;
 	bool search_device = false, ignore_case = false,
@@ -356,13 +357,18 @@ int main(int argc, char **argv)
 		channel_found = false ;
 	unsigned int i;
 	char *wbuf = NULL;
+	struct option *opts;
 
 	argw = dup_argv(MY_NAME, argc, argv);
 
-	ctx = handle_common_opts(MY_NAME, argc, argw, options, options_descriptions);
-
-	while ((c = getopt_long(argc, argw, "+" COMMON_OPTIONS "g:CdcBDiosIq", /* Flawfinder: ignore */
-					options, &option_index)) != -1) {
+	ctx = handle_common_opts(MY_NAME, argc, argw, MY_OPTS, options, options_descriptions);
+	opts = add_common_options(options);
+	if (!opts) {
+		fprintf(stderr, "Failed to add common options\n");
+		return EXIT_FAILURE;
+	}
+	while ((c = getopt_long(argc, argw, "+" COMMON_OPTIONS MY_OPTS, /* Flawfinder: ignore */
+					opts, NULL)) != -1) {
 		switch (c) {
 		/* All these are handled in the common */
 		case 'h':
@@ -372,7 +378,8 @@ int main(int argc, char **argv)
 			break;
 		case 'S':
 		case 'a':
-			if (!optarg && argv[optind] != NULL && argv[optind][0] != '-')
+			if (!optarg && argc > optind && argv[optind] != NULL
+					&& argv[optind][0] != '-')
 				optind++;
 			break;
 		/* Attribute type
@@ -424,6 +431,7 @@ int main(int argc, char **argv)
 		}
 	}
 
+	free(opts);
 
 	if (!ctx)
 		return EXIT_FAILURE;

--- a/tests/iio_common.h
+++ b/tests/iio_common.h
@@ -46,9 +46,16 @@ struct iio_context * autodetect_context(bool rtn, const char *name, const char *
 unsigned long int sanitize_clamp(const char *name, const char *argv,
 	uint64_t min, uint64_t max);
 
+/* optstring is a string containing the legitimate option characters.
+ * If such a character is followed by a colon, the option  requires  an  argument.
+ * Two colons mean an option takes an optional argument.
+ */
 #define COMMON_OPTIONS "hn:x:u:a::S::"
-struct iio_context * handle_common_opts(char * name, int argc, char * const argv[],
+
+struct iio_context * handle_common_opts(char * name, int argc,
+	char * const argv[], const char *optstring,
 	const struct option *options, const char *options_descriptions[]);
+struct option * add_common_options(const struct option * longopts);
 void usage(char *name, const struct option *options, const char *options_descriptions[]);
 
 char ** dup_argv(char * name, int argc, char * argv[]);

--- a/tests/iio_genxml.c
+++ b/tests/iio_genxml.c
@@ -44,14 +44,19 @@ int main(int argc, char **argv)
 	char *xml;
 	const char *tmp;
 	struct iio_context *ctx;
-	int c, option_index = 0;
+	int c;
 	size_t xml_len;
+	struct option *opts;
 
 	argw = dup_argv(MY_NAME, argc, argv);
-	ctx = handle_common_opts(MY_NAME, argc, argw, options, options_descriptions);
-
+	ctx = handle_common_opts(MY_NAME, argc, argw, "", options, options_descriptions);
+	opts = add_common_options(options);
+	if (!opts) {
+		fprintf(stderr, "Failed to add common options\n");
+		return EXIT_FAILURE;
+	}
 	while ((c = getopt_long(argc, argv, "+" COMMON_OPTIONS,  /* Flawfinder: ignore */
-					options, &option_index)) != -1) {
+					opts, NULL)) != -1) {
 		switch (c) {
 		/* All these are handled in the common */
 		case 'h':
@@ -61,7 +66,8 @@ int main(int argc, char **argv)
 			break;
 		case 'S':
 		case 'a':
-			if (!optarg && argv[optind] != NULL && argv[optind][0] != '-')
+			if (!optarg && argc > optind && argv[optind] != NULL
+					&& argv[optind][0] != '-')
 				optind++;
 			break;
 		case '?':
@@ -69,6 +75,7 @@ int main(int argc, char **argv)
 			return EXIT_FAILURE;
 		}
 	}
+	free(opts);
 
 	if (optind != argc) {
 		fprintf(stderr, "Incorrect number of arguments.\n\n");

--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -188,24 +188,31 @@ static ssize_t print_sample(const struct iio_channel *chn,
 	return (ssize_t) len;
 }
 
+#define MY_OPTS "t:b:s:T:"
 int main(int argc, char **argv)
 {
 	char **argw;
 	unsigned int i, nb_channels;
 	unsigned int nb_active_channels = 0;
 	unsigned int buffer_size = SAMPLES_PER_READ;
-	int c, option_index = 0;
+	int c;
 	struct iio_device *dev;
 	ssize_t sample_size;
 	int timeout = -1;
 	ssize_t ret;
+	struct option *opts;
 
 	argw = dup_argv(MY_NAME, argc, argv);
 
-	ctx = handle_common_opts(MY_NAME, argc, argw, options, options_descriptions);
+	ctx = handle_common_opts(MY_NAME, argc, argw, MY_OPTS, options, options_descriptions);
+	opts = add_common_options(options);
+	if (!opts) {
+		fprintf(stderr, "Failed to add common options\n");
+		return EXIT_FAILURE;
+	}
 
-	while ((c = getopt_long(argc, argw, "+" COMMON_OPTIONS "t:b:s:T:",	/* Flawfinder: ignore */
-					options, &option_index)) != -1) {
+	while ((c = getopt_long(argc, argw, "+" COMMON_OPTIONS MY_OPTS,	/* Flawfinder: ignore */
+					opts, NULL)) != -1) {
 		switch (c) {
 		/* All these are handled in the common */
 		case 'h':
@@ -215,7 +222,8 @@ int main(int argc, char **argv)
 			break;
 		case 'S':
 		case 'a':
-			if (!optarg && argv[optind] != NULL && argv[optind][0] != '-')
+			if (!optarg && argc > optind && argv[optind] != NULL
+					&& argv[optind][0] != '-')
 				optind++;
 			break;
 		case 't':
@@ -251,6 +259,7 @@ int main(int argc, char **argv)
 			return EXIT_FAILURE;
 		}
 	}
+	free(opts);
 
 	if (argc == optind) {
 		fprintf(stderr, "Incorrect number of arguments.\n\n");

--- a/tests/iio_reg.c
+++ b/tests/iio_reg.c
@@ -79,15 +79,20 @@ int main(int argc, char **argv)
 	unsigned long addr;
 	struct iio_context *ctx;
 	struct iio_device *dev;
-	int c, option_index = 0;
+	int c;
 	char * name;
+	struct option *opts;
 
 	argw = dup_argv(MY_NAME, argc, argv);
 
-	ctx = handle_common_opts(MY_NAME, argc, argw, options, options_descriptions);
-
+	ctx = handle_common_opts(MY_NAME, argc, argw, "", options, options_descriptions);
+	opts = add_common_options(options);
+	if (!opts) {
+		fprintf(stderr, "Failed to add common options\n");
+		return EXIT_FAILURE;
+	}
 	while ((c = getopt_long(argc, argw, "+" COMMON_OPTIONS, /* Flawfinder: ignore */
-			options, &option_index)) != -1) {
+			opts, NULL)) != -1) {
 		switch (c) {
 		/* All these are handled in the common */
 		case 'h':
@@ -97,7 +102,8 @@ int main(int argc, char **argv)
 			break;
 		case 'S':
 		case 'a':
-			if (!optarg && argv[optind] != NULL && argv[optind][0] != '-')
+			if (!optarg && argc > optind && argv[optind] != NULL
+					&& argv[optind][0] != '-')
 				optind++;
 			break;
 		case '?':
@@ -105,6 +111,7 @@ int main(int argc, char **argv)
 			return EXIT_FAILURE;
 		}
 	}
+	free(opts);
 
 	if ((argc - optind) < 2 || (argc - optind) > 3) {
 		usage(MY_NAME, options, options_descriptions);


### PR DESCRIPTION
the rework and moving to common functions for argument parsing broke a
few things, since I thought that you could pass a incomplete optstring
and incomplete longopts to getopt_long(). However, this is not the case.
It broke long flags (--uri vs -u) and broke the position parsing that
happened deep inside getopt_long() somewhere.

In fact - this caused builds on MSVC to crash sometimes. The other thing
that caused MSVC to crash was if an flag that had an optional argument
was the last on on the command line (for example 'iio_info -a') we would
use a index that exceeded the actual memory allocations, so check for
that and don't do it.

Now, make sure to pass complete arguments to things, and fix the bounds
checking which seems to resolve all the issues on Linux and Windows.

Signed-off-by: Robin Getz <robin.getz@analog.com>