### PR TITLE
Upgrade python setuptools for CI

### DIFF
--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -7,6 +7,7 @@ install_sphinx() {
 		python --version
 		command -v python
 		python -m pip install -U pip
+		python -m pip install -U setuptools
 		python -m pip install sphinx
 		python -m pip install sphinx-rtd-theme
 	fi


### PR DESCRIPTION
This fix will remove "UserWarning: Unknown distribution option: 'long_description_content_type'"

Signed-off-by: Travis F. Collins <travis.collins@analog.com>