### PR TITLE
iio.h: add some doc about iio_context_clone not working on usb

### DIFF
--- a/iio.h
+++ b/iio.h
@@ -435,7 +435,11 @@ __api __check_ret struct iio_context * iio_create_context_from_uri(const char *u
 /** @brief Duplicate a pre-existing IIO context
  * @param ctx A pointer to an iio_context structure
  * @return On success, A pointer to an iio_context structure
- * @return On failure, NULL is returned and errno is set appropriately */
+ * @return On failure, NULL is returned and errno is set appropriately
+ *
+ * <b>NOTE:</b> This function is not supported on 'usb:' contexts, since libusb
+ * can only claim the interface once. "Function not implemented" is the expected errno.
+ * Any context which is cloned, must be destroyed via calling iio_context_destroy() */
 __api __check_ret struct iio_context * iio_context_clone(const struct iio_context *ctx);
 
 


### PR DESCRIPTION
Which (as of today) is expected, but not documented.

Signed-off-by: Robin Getz <robin.getz@analog.com>