### PR TITLE
cmake: Avoid path construction in pkg-config file

### DIFF
--- a/libiio.pc.cmakein
+++ b/libiio.pc.cmakein
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: libiio
 Description: Library for interfacing IIO devices


### PR DESCRIPTION
Alternative fix for: https://github.com/analogdevicesinc/libiio/pull/563

It is [not generally true](https://github.com/jtojnar/cmake-snips#concatenating-paths-when-building-pkg-config-files) that `CMAKE_INSTALL_<dir>` variables are relative paths. Absolute paths will cause things like this to appear:

    includedir=${prefix}//nix/store/87zhscw1p08nqm73ls2sd82zmr1a8rni-libiio-0.21-dev/include

It would be best if the paths were relative to `${prefix}` pkg-config variable so that they could be [overridden](https://www.bassi.io/articles/2018/03/15/pkg-config-and-paths/) but since that is not easy to do in CMake, we will just use absolute paths.

libiio does not expect other project to install artefacts to its installation paths so non-overriddable paths should no do much harm.
