### PR TITLE
tests: Support context timeout in common manner

### DIFF
--- a/tests/iio_adi_xflow_check.c
+++ b/tests/iio_adi_xflow_check.c
@@ -185,6 +185,7 @@ int main(int argc, char **argv)
 		case 'n':
 		case 'x':
 		case 'u':
+		case 'T':
 			break;
 		case 'S':
 		case 'a':

--- a/tests/iio_attr.c
+++ b/tests/iio_attr.c
@@ -385,6 +385,7 @@ int main(int argc, char **argv)
 		case 'n':
 		case 'x':
 		case 'u':
+		case 'T':
 			break;
 		case 'S':
 			context_scan = true;

--- a/tests/iio_common.h
+++ b/tests/iio_common.h
@@ -51,7 +51,7 @@ unsigned long int sanitize_clamp(const char *name, const char *argv,
  * If such a character is followed by a colon, the option  requires  an  argument.
  * Two colons mean an option takes an optional argument.
  */
-#define COMMON_OPTIONS "hn:x:u:a::S::"
+#define COMMON_OPTIONS "hn:x:u:a::S::T:"
 
 struct iio_context * handle_common_opts(char * name, int argc,
 	char * const argv[], const char *optstring,

--- a/tests/iio_genxml.c
+++ b/tests/iio_genxml.c
@@ -63,6 +63,7 @@ int main(int argc, char **argv)
 		case 'n':
 		case 'x':
 		case 'u':
+		case 'T':
 			break;
 		case 'S':
 		case 'a':

--- a/tests/iio_info.c
+++ b/tests/iio_info.c
@@ -95,6 +95,7 @@ int main(int argc, char **argv)
 		case 'n':
 		case 'x':
 		case 'u':
+		case 'T':
 			break;
 		case 'S':
 		case 'a':

--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -38,18 +38,16 @@ static const struct option options[] = {
 	  {"trigger", required_argument, 0, 't'},
 	  {"buffer-size", required_argument, 0, 'b'},
 	  {"samples", required_argument, 0, 's' },
-	  {"timeout", required_argument, 0, 'T'},
 	  {"auto", no_argument, 0, 'a'},
 	  {0, 0, 0, 0},
 };
 
 static const char *options_descriptions[] = {
-	"[-t <trigger>] [-T <timeout-ms>] [-b <buffer-size>]"
+	"[-t <trigger>] [-b <buffer-size>]"
 		"[-s <samples>] <iio_device> [<channel> ...]",
 	"Use the specified trigger.",
 	"Size of the capture buffer. Default is 256.",
 	"Number of samples to capture, 0 = infinite. Default is 0.",
-	"Buffer timeout in milliseconds. 0 = no timeout",
 	"Scan for available contexts and if only one is available use it.",
 };
 
@@ -198,7 +196,6 @@ int main(int argc, char **argv)
 	int c;
 	struct iio_device *dev;
 	ssize_t sample_size;
-	int timeout = -1;
 	ssize_t ret;
 	struct option *opts;
 
@@ -219,6 +216,7 @@ int main(int argc, char **argv)
 		case 'n':
 		case 'x':
 		case 'u':
+		case 'T':
 			break;
 		case 'S':
 		case 'a':
@@ -247,13 +245,6 @@ int main(int argc, char **argv)
 			}
 			num_samples = sanitize_clamp("number of samples", optarg, 0, SIZE_MAX);
 			break;
-		case 'T':
-			if (!optarg) {
-				fprintf(stderr, "Timeout requires an argument\n");
-				return EXIT_FAILURE;
-			}
-			timeout = sanitize_clamp("timeout", optarg, 0, INT_MAX);
-			break;
 		case '?':
 			printf("Unknown argument '%c'\n", c);
 			return EXIT_FAILURE;
@@ -271,16 +262,6 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 
 	setup_sig_handler();
-
-	if (timeout >= 0) {
-		ret = iio_context_set_timeout(ctx, timeout);
-		if (ret < 0) {
-			char err_str[1024];
-			iio_strerror(-(int)ret, err_str, sizeof(err_str));
-			fprintf(stderr, "IIO contexts set timeout failed : %s (%zd)\n",
-					err_str, ret);
-		}
-	}
 
 	dev = iio_context_find_device(ctx, argw[optind]);
 	if (!dev) {

--- a/tests/iio_reg.c
+++ b/tests/iio_reg.c
@@ -99,6 +99,7 @@ int main(int argc, char **argv)
 		case 'n':
 		case 'x':
 		case 'u':
+		case 'T':
 			break;
 		case 'S':
 		case 'a':

--- a/tests/iio_stresstest.c
+++ b/tests/iio_stresstest.c
@@ -106,8 +106,8 @@ static const struct option options[] = {
 	{"uri", required_argument, 0, 'u'},
 	{"buffer-size", required_argument, 0, 'b'},
 	{"samples", required_argument, 0, 's' },
-	{"timeout", required_argument, 0, 't'},
-	{"Threads", required_argument, 0, 'T'},
+	{"Timeout", required_argument, 0, 'T'},
+	{"threads", required_argument, 0, 't'},
 	{"verbose", no_argument, 0, 'v'},
 	{0, 0, 0, 0},
 };
@@ -430,13 +430,13 @@ int main(int argc, char **argv)
 			info.buffer_size = sanitize_clamp("buffersize", info.argv[info.arg_index],
 					min_samples, 1024 * 1024 * 4);
 			break;
-		case 't':
+		case 'T':
 			info.arg_index +=2;
 			/* ensure between least once a day and never (0) */
 			info.timeout = 1000 * sanitize_clamp("timeout", info.argv[info.arg_index],
 					0, 60 * 60 * 24);
 			break;
-		case 'T':
+		case 't':
 			info.arg_index +=2;
 			/* Max number threads 1024, min 1 */
 			info.num_threads = sanitize_clamp("threads", info.argv[info.arg_index],


### PR DESCRIPTION
and add it to the utils that did not support it before.

Signed-off-by: Robin Getz <robin.getz@analog.com>
Inspired-by:  Michael Hennerich's #565 