### PR TITLE
dnssd: Use lower case when including Windows headers

### DIFF
--- a/mdns.h
+++ b/mdns.h
@@ -22,8 +22,8 @@
 
 #include <fcntl.h>
 #ifdef _WIN32
-#include <Winsock2.h>
-#include <Ws2tcpip.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
 #define strncasecmp _strnicmp
 #else
 #include <unistd.h>


### PR DESCRIPTION
This would help the cross compile process where these headers are not
found because their filenames are lowercase. This happens if the host
where the cross compiling is done is case sensitive when it comes to
file paths.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>