### PR TITLE
man: allow man pages to be built when not in a ./build dir

### DIFF
--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -4,8 +4,11 @@ if (WITH_MAN)
 	execute_process(
 		COMMAND ${DATE_EXECUTABLE} "+%d %B %Y"
 		OUTPUT_VARIABLE CMAKE_DATE OUTPUT_STRIP_TRAILING_WHITESPACE)
+	configure_file(
+		${CMAKE_CURRENT_SOURCE_DIR}/make_man.sh.in
+		${CMAKE_CURRENT_BINARY_DIR}/make_man.sh @ONLY)
 	execute_process(
-		COMMAND ${BASH_EXECUTABLE} "-c" "${CMAKE_CURRENT_SOURCE_DIR}/make_man.sh > ${CMAKE_BINARY_DIR}/libiio.3.in"
+		COMMAND ${BASH_EXECUTABLE} "-c" "${CMAKE_CURRENT_BINARY_DIR}/make_man.sh > ${CMAKE_BINARY_DIR}/libiio.3.in"
 		)
 	configure_file(
 		${CMAKE_BINARY_DIR}/libiio.3.in

--- a/man/make_man.sh.in
+++ b/man/make_man.sh.in
@@ -1,9 +1,10 @@
 #!/bin/bash -e
 
-if [ -z "$TRAVIS_BUILD_DIR" ] ; then
-	header="../iio.h"
-else
-	header="$TRAVIS_BUILD_DIR/iio.h"
+header="@CMAKE_SOURCE_DIR@/iio.h"
+
+if [ ! -f "${header}" ] ; then
+	echo "Can not find iio.h at ${header}"
+	exit
 fi
 
 cat <<EOF
@@ -90,7 +91,7 @@ EOF
 tmp=$(grep @struct "${header}" | sed 's:^[[:space:]]*\*[[:space:]]*@::g' | awk '{print length($0)}' | sort -n | tail -1)
 echo  .TP $((tmp - 5))
 
-grep @struct ../iio.h -A 1 | \
+grep @struct ${header} -A 1 | \
 	sed -e 's:^[[:space:]]*\*[[:space:]]*@::g' \
        	    -e 's:struct[[:space:]]*:.TP\n.B :' \
 	    -e 's:brief[[:space:]]*::' \


### PR DESCRIPTION
as pointed out in #555, we assumed that iio.h was always one directory
up, which is sort of bad form.

Don't make that assumption, and process things with the CMAKE system.

Signed-off-by: Robin Getz <robin.getz@analog.com>