### PR TITLE
appveyor.yml: Update the MSYS build keyring manually.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,8 +38,13 @@ build_script:
     - C:\msys64\usr\bin\bash -lc "pwd"
     - mkdir C:\projects\libiio\build-mingw-win32\"%configuration%"& cd C:\projects\libiio\build-mingw-win32\"%configuration%"
     - C:\msys64\usr\bin\bash -lc "pwd"
-    # TODO: Check when the latest pacman version is fixed and revert this commit.
-    - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/msys/x86_64/pacman-5.2.1-6-x86_64.pkg.tar.xz"
+    # TODO: Revert this after appveyor supports the latest installer.
+    - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/msys/x86_64/pacman-5.2.2-1-x86_64.pkg.tar.xz"
+    - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+    - C:\msys64\usr\bin\bash -lc "curl -O http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz.sig"
+    - C:\msys64\usr\bin\bash -lc "pacman-key --verify msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz{.sig,}"
+    - C:\msys64\usr\bin\bash -lc "pacman-key --populate"
+    - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
     - C:\msys64\usr\bin\bash -lc "pacman --noconfirm -Syu"
     - C:\msys64\usr\bin\bash -lc "pacman -Rs --noconfirm mingw-w64-i686-gcc-ada mingw-w64-i686-gcc-fortran mingw-w64-i686-gcc-libgfortran mingw-w64-i686-gcc-objc"
     - C:\msys64\usr\bin\bash -lc "rm /mingw32/etc/gdbinit"


### PR DESCRIPTION
We can revert this commit once appveyor updates the installer for MSYS.
https://www.msys2.org/news/#2020-06-29-new-packagers

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>