### PR TITLE
tests/iio_common: Fix HEX value parsing in sanitize_clamp()

### DIFF
--- a/tests/iio_common.c
+++ b/tests/iio_common.c
@@ -137,7 +137,7 @@ unsigned long int sanitize_clamp(const char *name, const char *argv,
 		/* sanitized buffer by taking first 20 (or less) char */
 		iio_snprintf(buf, sizeof(buf), "%s", argv);
 		errno = 0;
-		val = strtoul(buf, &end, 10);
+		val = strtoul(buf, &end, 0);
 		if (buf == end || errno == ERANGE)
 			val = 0;
 	}


### PR DESCRIPTION
Right now iio_reg and possibly other tools are broken.
Registers and values are typically provided in hex values.
strtoul() with base 10 returns error when hex values are parsed.
So iio_reg will always clear register 0 which in most cases will
reset the device.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>