### PR TITLE
local: add omitted return value read from close() in local_close()

### DIFF
--- a/local.c
+++ b/local.c
@@ -1038,7 +1038,7 @@ static int local_close(const struct iio_device *dev)
 	pdata->fd = -1;
 
 	if (pdata->cancel_fd > -1) {
-		close(pdata->cancel_fd);
+		ret1 = close(pdata->cancel_fd);
 		pdata->cancel_fd = -1;
 
 		if (ret1) {


### PR DESCRIPTION
Patch 4b0a7a26182d86 ("local: handle error codes in local_close()") omitted
one return value read for close().
Coverity caught that. This patch reads the return value for
'close(pdata->cancel_fd);'

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>