### PR TITLE
network: Add consume to client ops

### DIFF
--- a/iiod-client.c
+++ b/iiod-client.c
@@ -75,6 +75,12 @@ static int iiod_client_exec_command(struct iiod_client *client,
 	int resp;
 	ssize_t ret;
 
+	if (client->ops->consume) {
+		ret = client->ops->consume(client->pdata);
+		if (ret)
+			return (int) ret;
+	}
+
 	ret = client->ops->write(client->pdata, desc, cmd, strlen(cmd));
 	if (ret < 0)
 		return (int) ret;

--- a/iiod-client.h
+++ b/iiod-client.h
@@ -32,6 +32,7 @@ struct iiod_client_ops {
 			void *desc, char *dst, size_t len);
 	ssize_t (*read_line)(struct iio_context_pdata *pdata,
 			void *desc, char *dst, size_t len);
+	int (*consume)(struct iio_context_pdata *pdata);
 };
 
 struct iiod_client * iiod_client_new(struct iio_context_pdata *pdata,


### PR DESCRIPTION
The goal of this new callback is to consume all the __possible__ stalled data in the buffers before doing a new transaction. The problem can occur if a remote device is occupied doing something when a new transaction is started (eg: read an attribute). In this case, most likely, our read will timeout and, due to the nature of stream sockets, the next attribute we try to read will get the stalled value from the previous, failed, transaction.

The problem came up when using the adrv9002 plugin. Doing a manually update of the device profile while having an osc session opened lead to the plugin starting to display wrong values... And while this is a very specific error and is totally acceptable for the first timeout error, that should not mean that the following operations should get invalid data.

Although the solution has windows in mind it was not tested under it (but confirmed that it is also an issue there). It would be nice if someone that can easily build libiio and osc for windows could try this...