### PR TITLE
utilities: Fix getenv function

### DIFF
--- a/utilities.c
+++ b/utilities.c
@@ -301,7 +301,7 @@ char * iio_getenv (char * envvar)
 	len = strnlen(hostname, tmp);
 
 	/* Should be smaller than max length */
-	if (len <= tmp)
+	if (len == tmp)
 		goto wrong_str;
 
 	/* should be more than "usb:" or "ip:" */


### PR DESCRIPTION
This patch fixes a wrong comparison leading to a false failure. We want to
return error if the env var size is bigger than max size and not the other
way around.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>