### PR TITLE
CMake: fix build with cmake 2.8.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,13 +508,15 @@ if(OSX_PACKAGE)
 		DOC "OSX Package builder (productbuild)")
 	mark_as_advanced(PRODUCTBUILD_EXECUTABLE)
 
+	set(COPY_TOOLS_COMMAND)
 	foreach(_tool ${IIO_TESTS_TARGETS})
-		list(APPEND IIO_TESTS $<TARGET_FILE:${_tool}>)
+		list(APPEND COPY_TOOLS_COMMAND
+			COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${_tool}> ${LIBIIO_FRAMEWORK_DIR}/Tools)
 	endforeach()
 
 	add_custom_command(OUTPUT ${LIBIIO_PKG}
 		COMMAND ${CMAKE_COMMAND} -E make_directory ${LIBIIO_FRAMEWORK_DIR}/Tools
-		COMMAND ${CMAKE_COMMAND} -E copy ${IIO_TESTS} ${LIBIIO_FRAMEWORK_DIR}/Tools
+		${COPY_TOOLS_COMMAND}
 		COMMAND ${PKGBUILD_EXECUTABLE}
 			--component ${LIBIIO_FRAMEWORK_DIR}
 			--identifier com.adi.iio --version ${VERSION}


### PR DESCRIPTION
Building libiio with cmake 2.8.7(minimum version required) would fail due to cmake(2.8.7) not being able to copy a list of files separated by ";" to a destination. A solution to this problem is to create a list of commands containing a copy command for each iio test target file. With this approach the minimum required CMake version is not touched.

Tested with CMake version 2.8.7 and 3.18.2

Signed-off-by: DanielGuramulta <Daniel.Guramulta@analog.com>