### PR TITLE
local.c: when target buffer is too small, fail

### DIFF
--- a/local.c
+++ b/local.c
@@ -706,10 +706,16 @@ static ssize_t local_read_dev_attr(const struct iio_device *dev,
 		return -errno;
 
 	ret = fread(dst, 1, len, f);
+
+	/* if we didn't read the entire file, fail */
+	if (!feof(f))
+		ret = -EFBIG;
+
 	if (ret > 0)
 		dst[ret - 1] = '\0';
 	else
 		dst[0] = '\0';
+
 	fflush(f);
 	if (ferror(f))
 		ret = -errno;


### PR DESCRIPTION
Fix #357

If a target buffer is too small, right now, we try to put a partial fill
in the buffer, and return sucess (which is wrong).

Now we will return EFBIG, and leave the target buffer empty. This will
make the local backends the same as the otherbackends.

Signed-off-by: Robin Getz <robin.getz@analog.com>