### PR TITLE
iio: context: start hiding the iio_context object inside context.c

### DIFF
--- a/context.c
+++ b/context.c
@@ -443,6 +443,22 @@ const char * iio_context_get_attr_value(
 	return NULL;
 }
 
+int iio_context_add_device(struct iio_context *ctx, struct iio_device *dev)
+{
+	struct iio_device **devices = realloc(ctx->devices,
+			(ctx->nb_devices + 1) * sizeof(struct iio_device *));
+
+	if (!devices) {
+		IIO_ERROR("Unable to allocate memory\n");
+		return -ENOMEM;
+	}
+
+	devices[ctx->nb_devices++] = dev;
+	ctx->devices = devices;
+	IIO_DEBUG("Added device \'%s\' to context \'%s\'\n", dev->id, ctx->name);
+	return 0;
+}
+
 int iio_context_add_attr(struct iio_context *ctx,
 		const char *key, const char *value)
 {

--- a/dns_sd.c
+++ b/dns_sd.c
@@ -99,15 +99,17 @@ static int dnssd_fill_context_info(struct iio_context_info *info,
 		iio_snprintf(description, sizeof(description), "%s %s", addr_str, hw_model);
 	} else if (serial) {
 		iio_snprintf(description, sizeof(description), "%s %s", addr_str, serial);
-	} else if (ctx->nb_devices == 0) {
+	} else if (iio_context_get_devices_count(ctx) == 0) {
 		iio_snprintf(description, sizeof(description), "%s", ctx->description);
 	} else {
 		iio_snprintf(description, sizeof(description), "%s (", addr_str);
 		p = description + strlen(description);
-		for (i = 0; i < ctx->nb_devices - 1; i++) {
-			if (ctx->devices[i]->name) {
+		for (i = 0; i < iio_context_get_devices_count(ctx) - 1; i++) {
+			const struct iio_device *dev = iio_context_get_device(ctx, i);
+			const char *name = iio_device_get_name(dev);
+			if (name) {
 				iio_snprintf(p, sizeof(description) - strlen(description) -1,
-						"%s,",  ctx->devices[i]->name);
+						"%s,",  name);
 				p += strlen(p);
 			}
 		}

--- a/iio-private.h
+++ b/iio-private.h
@@ -315,6 +315,8 @@ char *iio_strdup(const char *str);
 size_t iio_strlcpy(char * __restrict dst, const char * __restrict src, size_t dsize);
 char * iio_getenv (char * envvar);
 
+int iio_context_add_device(struct iio_context *ctx, struct iio_device *dev);
+
 int iio_context_add_attr(struct iio_context *ctx,
 		const char *key, const char *value);
 

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -1422,8 +1422,8 @@ void interpreter(struct iio_context *ctx, int fd_in, int fd_out, bool verbose,
 	yylex_destroy(scanner);
 
 	/* Close all opened devices */
-	for (i = 0; i < ctx->nb_devices; i++)
-		close_dev_helper(&pdata, ctx->devices[i]);
+	for (i = 0; i < iio_context_get_devices_count(ctx); i++)
+		close_dev_helper(&pdata, iio_context_get_device(ctx, i));
 
 #if WITH_AIO
 	if (use_aio) {

--- a/local.c
+++ b/local.c
@@ -1421,20 +1421,6 @@ static int add_channel_to_device(struct iio_device *dev,
 	return 0;
 }
 
-static int add_device_to_context(struct iio_context *ctx,
-		struct iio_device *dev)
-{
-	struct iio_device **devices = realloc(ctx->devices,
-			(ctx->nb_devices + 1) * sizeof(struct iio_device *));
-	if (!devices)
-		return -ENOMEM;
-
-	devices[ctx->nb_devices++] = dev;
-	ctx->devices = devices;
-	IIO_DEBUG("Added device \'%s\' to context \'%s\'\n", dev->id, ctx->name);
-	return 0;
-}
-
 static struct iio_channel *create_channel(struct iio_device *dev,
 		char *id, const char *attr, const char *path,
 		bool is_scan_element)
@@ -1863,7 +1849,7 @@ static int create_device(void *d, const char *path)
 
 	dev->mask = mask;
 
-	ret = add_device_to_context(ctx, dev);
+	ret = iio_context_add_device(ctx, dev);
 	if (!ret)
 		return 0;
 

--- a/local.c
+++ b/local.c
@@ -156,8 +156,8 @@ static void local_shutdown(struct iio_context *ctx)
 	/* Free the backend data stored in every device structure */
 	unsigned int i;
 
-	for (i = 0; i < ctx->nb_devices; i++) {
-		struct iio_device *dev = ctx->devices[i];
+	for (i = 0; i < iio_context_get_devices_count(ctx); i++) {
+		struct iio_device *dev = iio_context_get_device(ctx, i);
 
 		iio_device_close(dev);
 		local_free_pdata(dev);
@@ -1119,9 +1119,9 @@ static int local_get_trigger(const struct iio_device *dev,
 		return 0;
 	}
 
-	nb = dev->ctx->nb_devices;
+	nb = iio_context_get_devices_count(dev->ctx);
 	for (i = 0; i < (size_t) nb; i++) {
-		const struct iio_device *cur = dev->ctx->devices[i];
+		const struct iio_device *cur = iio_context_get_device(dev->ctx, i);
 		if (cur->name && !strcmp(cur->name, buf)) {
 			*trigger = cur;
 			return 0;
@@ -1980,8 +1980,8 @@ static void init_scan_elements(struct iio_context *ctx)
 {
 	unsigned int i, j;
 
-	for (i = 0; i < ctx->nb_devices; i++) {
-		struct iio_device *dev = ctx->devices[i];
+	for (i = 0; i < iio_context_get_devices_count(ctx); i++) {
+		struct iio_device *dev = iio_context_get_device(ctx, i);
 
 		for (j = 0; j < dev->nb_channels; j++)
 			init_data_scale(dev->channels[j]);

--- a/network.c
+++ b/network.c
@@ -1085,8 +1085,8 @@ static void network_shutdown(struct iio_context *ctx)
 	close(pdata->io_ctx.fd);
 	iio_mutex_unlock(pdata->lock);
 
-	for (i = 0; i < ctx->nb_devices; i++) {
-		struct iio_device *dev = ctx->devices[i];
+	for (i = 0; i < iio_context_get_devices_count(ctx); i++) {
+		struct iio_device *dev = iio_context_get_device(ctx, i);
 		struct iio_device_pdata *dpdata = dev->pdata;
 
 		if (dpdata) {
@@ -1462,8 +1462,8 @@ struct iio_context * network_create_context(const char *host)
 	if (ret < 0)
 		goto err_free_description;
 
-	for (i = 0; i < ctx->nb_devices; i++) {
-		struct iio_device *dev = ctx->devices[i];
+	for (i = 0; i < iio_context_get_devices_count(ctx); i++) {
+		struct iio_device *dev = iio_context_get_device(ctx, i);
 
 		dev->pdata = zalloc(sizeof(*dev->pdata));
 		if (!dev->pdata) {

--- a/usb.c
+++ b/usb.c
@@ -449,12 +449,13 @@ static int usb_set_trigger(const struct iio_device *dev,
 
 static void usb_shutdown(struct iio_context *ctx)
 {
+	unsigned int nb_devices = iio_context_get_devices_count(ctx);
 	unsigned int i;
 
 	usb_io_context_exit(&ctx->pdata->io_ctx);
 
-	for (i = 0; i < ctx->nb_devices; i++)
-		usb_close(ctx->devices[i]);
+	for (i = 0; i < nb_devices; i++)
+		usb_close(iio_context_get_device(ctx, i));
 
 	iio_mutex_destroy(ctx->pdata->lock);
 	iio_mutex_destroy(ctx->pdata->ep_lock);
@@ -465,8 +466,8 @@ static void usb_shutdown(struct iio_context *ctx)
 	if (ctx->pdata->io_endpoints)
 		free(ctx->pdata->io_endpoints);
 
-	for (i = 0; i < ctx->nb_devices; i++) {
-		struct iio_device *dev = ctx->devices[i];
+	for (i = 0; i < nb_devices; i++) {
+		struct iio_device *dev = iio_context_get_device(ctx, i);
 
 		usb_io_context_exit(&dev->pdata->io_ctx);
 		free(dev->pdata);
@@ -1015,8 +1016,8 @@ struct iio_context * usb_create_context(unsigned int bus,
 	ctx->ops = &usb_ops;
 	ctx->pdata = pdata;
 
-	for (i = 0; i < ctx->nb_devices; i++) {
-		struct iio_device *dev = ctx->devices[i];
+	for (i = 0; i < iio_context_get_devices_count(ctx); i++) {
+		struct iio_device *dev = iio_context_get_device(ctx, i);
 
 		dev->pdata = zalloc(sizeof(*dev->pdata));
 		if (!dev->pdata) {

--- a/xml.c
+++ b/xml.c
@@ -400,7 +400,7 @@ static struct iio_context * iio_create_xml_context_helper(xmlDoc *doc)
 	}
 
 	for (n = root->children; n; n = n->next) {
-		struct iio_device **devs, *dev;
+		struct iio_device *dev;
 
 		if (!strcmp((char *) n->name, "context-attribute")) {
 			err = parse_context_attr(ctx, n);
@@ -421,16 +421,11 @@ static struct iio_context * iio_create_xml_context_helper(xmlDoc *doc)
 			goto err_context_destroy;
 		}
 
-		devs = realloc(ctx->devices, (1 + ctx->nb_devices) *
-				sizeof(struct iio_device *));
-		if (!devs) {
-			IIO_ERROR("Unable to allocate memory\n");
+		err = iio_context_add_device(ctx, dev);
+		if (err) {
 			free(dev);
 			goto err_context_destroy;
 		}
-
-		devs[ctx->nb_devices++] = dev;
-		ctx->devices = devs;
 	}
 
 	err = iio_context_init(ctx);


### PR DESCRIPTION
This PR is trying to reboot this PR https://github.com/analogdevicesinc/libiio/pull/9
Which is essentially a modularization of libiio to be able to add more backends in a more dynamic fashion.

The intent is to be able to add more backends (like GPIO, HWmon, and other stuff).
But to get there, ideally we'd need to make libiio a bit more modular, and first convert all current backends to be made modular (independent of internal structures like iio_context, iio_device, etc).
We don't need to split libiio.so in smaller libs [if we don't want to]; we can implement this option to allow libiio to be built as a single library or as a smaller set of libraries, one being libiio-core.so and the others being libiio-<backend>.so (which would be loaded by libiio-core.so).
But if adding more backends, at least the internal structures/types need to be made completely opaque to the IIO backends, to make the scaling less error-prone.

We've seen various attempts in Linux at squeezing stuff in the IIO kernel framework. 
The gatekeeper there is upstream, so it takes a while to be able to do these things.
The reason seems to be network communication aspect, which other libraries don't seem to have (hwmon has lm-sensors, libiio has some libgpio, [all] with no network support).
In libiio we have way more flexibility to start integrating various backends.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>