### PR TITLE
iiod-client: move context lock inside the iiod_client object

### DIFF
--- a/iiod-client.h
+++ b/iiod-client.h
@@ -34,8 +34,11 @@ struct iiod_client_ops {
 			void *desc, char *dst, size_t len);
 };
 
+void iiod_client_mutex_lock(struct iiod_client *client);
+void iiod_client_mutex_unlock(struct iiod_client *client);
+
 struct iiod_client * iiod_client_new(struct iio_context_pdata *pdata,
-		struct iio_mutex *lock, const struct iiod_client_ops *ops);
+				     const struct iiod_client_ops *ops);
 void iiod_client_destroy(struct iiod_client *client);
 
 int iiod_client_get_version(struct iiod_client *client, void *desc,


### PR DESCRIPTION
All the iiod-client (type) backends create a context lock and pass it to
the iio_client object via iiod_client_new().

This looks wonky, since the iio_client routines do a lot of things with
that lock.

The serial backend uses it quite extensively. The USB doesn't (explicitly
lock it at all), and the network backend only uses it during
network_close() (which may be un-required).

For the cases where this lock is still used, a iiod_client_mutex_{un}lock()
function pair is created to access the lock. We may find that we can hide
the lock entirely, but until then this change shouldn't change any current
behavior.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>