### PR TITLE
network: move free(description) under #ifdef HAVE_IPV6

### DIFF
--- a/network.c
+++ b/network.c
@@ -617,7 +617,8 @@ static char * network_get_description(struct addrinfo *res, size_t *len)
 					strlen(description) + 1);
 			if (!ptr) {
 				IIO_ERROR("Unable to lookup interface of IPv6 address\n");
-				goto err_free_description;
+				free(description);
+				return NULL;
 			}
 
 			*(ptr - 1) = '%';
@@ -635,10 +636,6 @@ static char * network_get_description(struct addrinfo *res, size_t *len)
 	}
 
 	return description;
-
-err_free_description:
-	free(description);
-	return NULL;
 }
 
 static int network_open(const struct iio_device *dev,


### PR DESCRIPTION
This was not happening on Travis-CI because it's compiling on Linux, and
HAVE_IPV6 is defined.
Under Windows/Appveyor it seems it isn't, so the 'err_free_description'
label in network_get_description() is unused.

This also seems to have happened, because Appveyor builds were failing.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>