### PR TITLE
iio: backend: add get_description() backend op & hook it into backends

### DIFF
--- a/iio-backend.h
+++ b/iio-backend.h
@@ -70,6 +70,8 @@ struct iio_backend_ops {
 
 	void (*shutdown)(struct iio_context *ctx);
 
+	char * (*get_description)(const struct iio_context *ctx);
+
 	int (*get_version)(const struct iio_context *ctx, unsigned int *major,
 			unsigned int *minor, char git_tag[8]);
 

--- a/serial.c
+++ b/serial.c
@@ -115,7 +115,7 @@ static int serial_get_version(const struct iio_context *ctx,
 			major, minor, git_tag);
 }
 
-static char * serial_get_description(struct sp_port *port)
+static char * __serial_get_description(struct sp_port *port)
 {
 	char *description, *name, *desc;
 	size_t desc_len;
@@ -133,6 +133,13 @@ static char * serial_get_description(struct sp_port *port)
 	iio_snprintf(description, desc_len, "%s: %s", name, desc);
 
 	return description;
+}
+
+static char * serial_get_description(const struct iio_context *ctx)
+{
+	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
+
+	return __serial_get_description(pdata->port);
 }
 
 static int serial_open(const struct iio_device *dev,
@@ -347,6 +354,7 @@ static const struct iio_backend_ops serial_ops = {
 	.write_channel_attr = serial_write_chn_attr,
 	.set_kernel_buffers_count = serial_set_kernel_buffers_count,
 	.shutdown = serial_shutdown,
+	.get_description = serial_get_description,
 	.set_timeout = serial_set_timeout,
 };
 
@@ -422,7 +430,7 @@ static struct iio_context * serial_create_context(const char *port_name,
 	/* Empty the buffers */
 	sp_flush(port, SP_BUF_BOTH);
 
-	description = serial_get_description(port);
+	description = __serial_get_description(port);
 	if (!description)
 		goto err_close_port;
 


### PR DESCRIPTION
This doesn't get rid of the 'ctx->description' object; that will still be
around and cache the description.

The get_description() splits the creation logic of the description into a
backend op. That way, we can think of splitting the creation of an IIO
context into an 'alloc()' and 'init()' part where:
* an IIO context is allocated first in libiio core
* it's backend init() routine is called
* it's backend get_description() routine is called

The idea of the 'get_description()' op is to return a pointer, that libiio
core will manage/free. Hence the return is 'char *' vs 'const char *'.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>