### PR TITLE
ci,travis: remove lsb package requirement

### DIFF
--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -42,7 +42,7 @@ handle_centos() {
 	# FIXME: see about adding `libserialport-dev` from EPEL ; maybe libusb-1.0.0-devel...
 	yum -y groupinstall 'Development Tools'
 	yum -y install cmake libxml2-devel libusb1-devel libaio-devel \
-		bzip2 gzip rpm rpm-build redhat-lsb-core
+		bzip2 gzip rpm rpm-build
 
 	# needed for building python with pyenv
 	yum install -y  gcc gcc-c++ make git patch openssl-devel zlib-devel readline-devel sqlite-devel bzip2-devel
@@ -95,7 +95,7 @@ handle_default() {
 	sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake graphviz \
 		libaio-dev libavahi-client-dev \
 		libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar \
-		bzip2 gzip flex bison git lsb-release libncurses5-dev libcdk5-dev
+		bzip2 gzip flex bison git libncurses5-dev libcdk5-dev
 
 	# Most of these should be here, but are needed for building python by pyenv
 	sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential \

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -474,24 +474,30 @@ version_lt() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" != "$1";
 version_ge() { test "$(echo "$@" | tr " " "\n" | sort -rV | head -n 1)" = "$1"; }
 
 get_codename() {
-	lsb_release -c -s
+	local VERSION_CODENAME
+	eval $(grep -w VERSION_CODENAME /etc/os-release)
+	echo "$VERSION_CODENAME"
 }
 
 get_dist_id() {
-	lsb_release -i -s
+	local ID
+	eval $(grep -w ID /etc/os-release)
+	echo "$ID"
 }
 
 get_version() {
-	lsb_release -r -s
+	local VERSION_ID
+	eval $(grep -w VERSION_ID /etc/os-release)
+	echo "$VERSION_ID"
 }
 
 is_ubuntu_at_least_ver() {
-	[ "$(get_dist_id)" = "Ubuntu" ] || return 1
+	[ "$(get_dist_id)" = "ubuntu" ] || return 1
 	version_ge "$(get_version)" "$1"
 }
 
 is_centos_at_least_ver() {
-	[ "$(get_dist_id)" = "CentOS" ] || return 1
+	[ "$(get_dist_id)" = "centos" ] || return 1
 	version_ge "$(get_version)" "$1"
 }
 


### PR DESCRIPTION
To get the lsb_release command working some packages need to be
pre-installed.
The docker images come pretty bare, so they need to be installed before.

This can complicate things, because we need to make sure that all builds
down the pipeline install this package.

The utilities that wrap lsb_release can be re-implemented with simple shell
commands and parsing of /etc/os-release.
This change does that.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>