### PR TITLE
Dev/enhance network context creation

### DIFF
--- a/dns_sd.h
+++ b/dns_sd.h
@@ -81,4 +81,7 @@ void remove_dup_discovery_data(struct dns_sd_discovery_data **ddata);
 /* port knocks  */
 void port_knock_discovery_data(struct dns_sd_discovery_data **ddata);
 
+/* Use dnssd to resolve a given hostname */
+int dnssd_resolve_host(const char *hostname, char *ip_addr, const int addr_len);
+
 #endif /* __IIO_DNS_SD_H */

--- a/dns_sd_avahi.c
+++ b/dns_sd_avahi.c
@@ -211,6 +211,7 @@ int dnssd_find_hosts(struct dns_sd_discovery_data **ddata)
 
 	d->poll = avahi_simple_poll_new();
 	if (!d->poll) {
+		iio_mutex_destroy(d->lock);
 		dnssd_free_all_discovery_data(d);
 		return -ENOMEM;
 	}

--- a/dns_sd_bonjour.c
+++ b/dns_sd_bonjour.c
@@ -240,3 +240,8 @@ exit:
 	iio_mutex_destroy(d->lock);
 	return ret;
 }
+
+int dnssd_resolve_host(const char *hostname, char *ip_addr, const int addr_len)
+{
+	return -ENOENT;
+}

--- a/dns_sd_windows.c
+++ b/dns_sd_windows.c
@@ -254,3 +254,8 @@ int dnssd_find_hosts(struct dns_sd_discovery_data** ddata)
 
 	return 0;
 }
+
+int dnssd_resolve_host(const char *hostname, char *ip_addr, const int addr_len)
+{
+	return -ENOENT;
+}


### PR DESCRIPTION
The first patch is a simple leak fix on the iio mutex. The second patch improves the network context creation by adding a fallback mechanism to resolve a hostname. Basically, if the given hostname is an avahi typical one (eg: analog.local), `getaddrinfo()` will only work if `nss-mdns` is installed on the host and `/etc/nsswitch.conf` is correctly configured. While that might be true for most linux distros, it is still something that we should not rely on. Hence, with this patch, if `getaddrinfo()` fails, we still try to resolve the host by directly using libavahi.

I was actually caught by this issue when trying to use pyadi-iio in my archlinux machine.

Also note that this is only targeting builds with `HAVE_AVAHI` since I have no idea if this is actually an issue on Windows or Mac (most likely it isn't)