### PR TITLE
.travis.yml: build & deploy for Xcode12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,9 @@ matrix:
     - compiler: "gcc"
       os: osx
       osx_image: xcode11
+    - compiler: "gcc"
+      os: osx
+      osx_image: xcode12
 
     - stage: "Trigger Next In Pipeline"
       env:


### PR DESCRIPTION
Xcode 12 has been out for a while now.
This change adds a build for it so that we can start putting it through the
pipeline.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>