### PR TITLE
Fix Python bindings bugs relating to Triggers

### DIFF
--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -462,7 +462,7 @@ _d_get_trigger = _lib.iio_device_get_trigger
 _d_get_trigger.restype = c_int
 _d_get_trigger.argtypes = (
     _DevicePtr,
-    _DevicePtr,
+    _POINTER(_DevicePtr),
 )
 _d_get_trigger.errcheck = _check_negative
 
@@ -1272,10 +1272,10 @@ class Trigger(_DeviceOrTrigger):
         super(Trigger, self).__init__(_device)
 
     def _get_rate(self):
-        return int(self._attrs["frequency"].value)
+        return int(self._attrs["sampling_frequency"].value)
 
     def _set_rate(self, value):
-        self._attrs["frequency"].value = str(value)
+        self._attrs["sampling_frequency"].value = str(value)
 
     frequency = property(
         _get_rate,
@@ -1307,11 +1307,12 @@ class Device(_DeviceOrTrigger):
         _d_set_trigger(self._device, trigger._device if trigger else None)
 
     def _get_trigger(self):
-        value = _Device()
+        value = _DevicePtr()
         _d_get_trigger(self._device, _byref(value))
+        trig = Trigger(value.contents)
 
         for dev in self.ctx()._devices:
-            if value == dev._device:
+            if trig.id == dev.id:
                 return dev
         return None
 


### PR DESCRIPTION
## Background

The libiio python bindings currently have two bugs that I've come across, relating to triggers.
1. `<Trigger>.frequency` - throws an error, since it uses the `frequency` attribute instead of correct attribute name, `sampling_frequency`
2. `<Device>.trigger` - always returns `None`, even when the device has a trigger. This seems to be because the function is comparing two python `_Device` objects for equality, instead of comparing their values.

## Changes

1. `frequency` is replaced by `sampling_frequency`, so that calling `<Trigger>.frequency` does not throw an error and instead returns the integer frequency of the trigger.
2. `<Device>.trigger` - has an updated function signature to reflect the c function's arguments (second argument should be a double pointer) and compares the `id` (which are unique) of triggers to determine whether the triggers match. 

## Testing

I have tested on an `iio` configuration with device `iio:device0` having trigger `trigger0` (an hrtimer trigger).

The following test was run:
```python3
>>> import iio
>>> ctx=iio.LocalContext()
>>> dev0=ctx.devices[0]
>>> trig0=ctx.devices[4]
>>> dev0.id
'iio:device0'
>>> trig0.id
'trigger0'

# Check that dev0.trigger returns the trigger device
>>> trig0
<iio.Trigger object at 0xffffb42f4850>
>>> dev0.trigger
<iio.Trigger object at 0xffffb42f4850>

# Check that the trigger frequency can be read/modified
>>> trig0.frequency
10000
>>> dev0.trigger.frequency
10000
>>> trig0.frequency=5000
>>> trig0.frequency
5000
>>> dev0.trigger.frequency
5000
```



Signed-off-by: Kathy Camenzind <kathy.camenzind@tulip.co>