### PR TITLE
tests: iio_readdev: Set minimal buffer size to 2

### DIFF
--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -236,7 +236,7 @@ int main(int argc, char **argv)
 				fprintf(stderr, "Buffersize requires an argument\n");
 				return EXIT_FAILURE;
 			}
-			buffer_size = sanitize_clamp("buffer size", optarg, 64, 4 * 1024 * 1024);
+			buffer_size = sanitize_clamp("buffer size", optarg, 1, SIZE_MAX);
 			break;
 		case 's':
 			if (!optarg) {

--- a/tests/iio_writedev.c
+++ b/tests/iio_writedev.c
@@ -247,7 +247,7 @@ int main(int argc, char **argv)
 				fprintf(stderr, "Buffer Size requires argument\n");
 				return EXIT_FAILURE;
 			}
-			buffer_size = sanitize_clamp("buffer size", optarg, 64, 4 * 1024 * 1024);
+			buffer_size = sanitize_clamp("buffer size", optarg, 1, SIZE_MAX);
 			break;
 		case 's':
 			if (!optarg) {


### PR DESCRIPTION
Currenly set at 64, it is not optimal when a smaller number of samples
are requested. For instance, if 4 samples are requested, we still have
to wait for up to 64 samples to come in to return.

Signed-off-by: Gwendal Grignou <gwendal@chromium.org>