### PR TITLE
add errcodes to all faults

### DIFF
--- a/examples/dummy-iiostream.c
+++ b/examples/dummy-iiostream.c
@@ -137,7 +137,7 @@ static void shutdown()
 		if (ret < 0) {
 			char buf[256];
 			iio_strerror(-ret, buf, sizeof(buf));
-			fprintf(stderr, "%s (%d) while Disassociate trigger\n", buf, ret);
+			fprintf(stderr, "%s while Disassociate trigger\n", buf);
 		}
 	}
 
@@ -355,7 +355,7 @@ int main (int argc, char **argv)
 			if (ret < 0) {
 				char buf[256];
 				iio_strerror(-ret, buf, sizeof(buf));
-				fprintf(stderr, "%s (%d) while processing buffer\n", buf, ret);
+				fprintf(stderr, "%s while processing buffer\n", buf);
 			}
 			printf("\n");
 			break;

--- a/examples/iio-monitor.c
+++ b/examples/iio-monitor.c
@@ -77,7 +77,7 @@ static void err_str(int ret)
 {
 	char buf[256];
 	iio_strerror(-ret, buf, sizeof(buf));
-	fprintf(stderr, "Error during read: %s (%d)\n", buf, ret);
+	fprintf(stderr, "Error during read: %s\n", buf);
 }
 
 static double get_channel_value(struct iio_channel *chn)

--- a/iiod/iiod.c
+++ b/iiod/iiod.c
@@ -469,7 +469,7 @@ static int main_interactive(struct iio_context *ctx, bool verbose, bool use_aio)
 			char err_str[1024];
 			iio_strerror(errno, err_str, sizeof(err_str));
 			IIO_ERROR("Could not get/set O_NONBLOCK on STDIN_FILENO"
-					" %s (%d)\n", err_str, -errno);
+					" %s\n", err_str);
 		}
 
 		flags = fcntl(STDOUT_FILENO, F_GETFL);
@@ -479,7 +479,7 @@ static int main_interactive(struct iio_context *ctx, bool verbose, bool use_aio)
 			char err_str[1024];
 			iio_strerror(errno, err_str, sizeof(err_str));
 			IIO_ERROR("Could not get/set O_NONBLOCK on STDOUT_FILENO"
-					" %s (%d)\n", err_str, -errno);
+					" %s\n", err_str);
 		}
 	}
 
@@ -517,7 +517,7 @@ static int main_server(struct iio_context *ctx, bool debug)
 	ret = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
 	if (ret < 0) {
 		iio_strerror(errno, err_str, sizeof(err_str));
-		IIO_WARNING("setsockopt SO_REUSEADDR : %s (%d)", err_str, -errno);
+		IIO_WARNING("setsockopt SO_REUSEADDR : %s\n", err_str);
 	}
 
 #ifdef HAVE_IPV6
@@ -588,30 +588,30 @@ static int main_server(struct iio_context *ctx, bool debug)
 		ret = setsockopt(new, SOL_SOCKET, SO_KEEPALIVE, &yes, sizeof(yes));
 		if (ret < 0) {
 			iio_strerror(errno, err_str, sizeof(err_str));
-			IIO_WARNING("setsockopt SO_KEEPALIVE : %s (%d)", err_str, -errno);
+			IIO_WARNING("setsockopt SO_KEEPALIVE : %s", err_str);
 		}
 		ret = setsockopt(new, IPPROTO_TCP, TCP_KEEPCNT, &keepalive_probes,
 				sizeof(keepalive_probes));
 		if (ret < 0) {
 			iio_strerror(errno, err_str, sizeof(err_str));
-			IIO_WARNING("setsockopt TCP_KEEPCNT : %s (%d)", err_str, -errno);
+			IIO_WARNING("setsockopt TCP_KEEPCNT : %s", err_str);
 		}
 		ret = setsockopt(new, IPPROTO_TCP, TCP_KEEPIDLE, &keepalive_time,
 				sizeof(keepalive_time));
 		if (ret < 0) {
 			iio_strerror(errno, err_str, sizeof(err_str));
-			IIO_WARNING("setsockopt TCP_KEEPIDLE : %s (%d)", err_str, -errno);
+			IIO_WARNING("setsockopt TCP_KEEPIDLE : %s", err_str);
 		}
 		ret = setsockopt(new, IPPROTO_TCP, TCP_KEEPINTVL, &keepalive_intvl,
 				sizeof(keepalive_intvl));
 		if (ret < 0) {
 			iio_strerror(errno, err_str, sizeof(err_str));
-			IIO_WARNING("setsockopt TCP_KEEPINTVL : %s (%d)", err_str, -errno);
+			IIO_WARNING("setsockopt TCP_KEEPINTVL : %s", err_str);
 		}
 		ret = setsockopt(new, IPPROTO_TCP, TCP_NODELAY, &yes, sizeof(yes));
 		if (ret < 0) {
 			iio_strerror(errno, err_str, sizeof(err_str));
-			IIO_WARNING("setsockopt TCP_NODELAY : %s (%d)", err_str, -errno);
+			IIO_WARNING("setsockopt TCP_NODELAY : %s", err_str);
 		}
 
 		cdata->fd = new;

--- a/tests/iio_attr.c
+++ b/tests/iio_attr.c
@@ -125,7 +125,7 @@ static int dump_device_attributes(const struct iio_device *dev,
 				printf("'%s'\n", buf);
 		} else {
 			iio_strerror(-(int)ret, buf, BUF_SIZE);
-			printf("ERROR: %s (%li)\n", buf, (long)ret);
+			printf("ERROR: %s\n", buf);
 		}
 	}
 	if (wbuf) {
@@ -137,8 +137,8 @@ static int dump_device_attributes(const struct iio_device *dev,
 			dump_device_attributes(dev, attr, NULL, quiet);
 		} else {
 			iio_strerror(-(int)ret, buf, BUF_SIZE);
-			printf("ERROR: %s (%li) while writing '%s' with '%s'\n",
-					buf, (long)ret, attr, wbuf);
+			printf("ERROR: %s while writing '%s' with '%s'\n",
+					buf, attr, wbuf);
 		}
 	}
 	free(buf);
@@ -174,7 +174,7 @@ static int dump_buffer_attributes(const struct iio_device *dev,
 				printf("'%s'\n", buf);
 		} else {
 			iio_strerror(-(int)ret, buf, BUF_SIZE);
-			printf("ERROR: %s (%li)\n", buf, (long)ret);
+			printf("ERROR: %s\n", buf);
 		}
 	}
 
@@ -187,8 +187,8 @@ static int dump_buffer_attributes(const struct iio_device *dev,
 			dump_buffer_attributes(dev, attr, NULL, quiet);
 		} else {
 			iio_strerror(-(int)ret, buf, BUF_SIZE);
-			printf("ERROR: %s (%li) while writing '%s' with '%s'\n",
-					buf, (long)ret, attr, wbuf);
+			printf("ERROR: %s while writing '%s' with '%s'\n",
+					buf, attr, wbuf);
 		}
 	}
 
@@ -225,7 +225,7 @@ static int dump_debug_attributes(const struct iio_device *dev,
 				printf("'%s'\n", buf);
 		} else {
 			iio_strerror(-(int)ret, buf, BUF_SIZE);
-			printf("ERROR: %s (%li)\n", buf, (long)ret);
+			printf("ERROR: %s\n", buf);
 		}
 	}
 
@@ -238,8 +238,8 @@ static int dump_debug_attributes(const struct iio_device *dev,
 			dump_debug_attributes(dev, attr, NULL, quiet);
 		} else {
 			iio_strerror(-(int)ret, buf, BUF_SIZE);
-			printf("ERROR: %s (%li) while writing '%s' with '%s'\n",
-					buf, (long)ret, attr, wbuf);
+			printf("ERROR: %s while writing '%s' with '%s'\n",
+					buf, attr, wbuf);
 		}
 	}
 
@@ -287,7 +287,7 @@ static int dump_channel_attributes(const struct iio_device *dev,
 				printf("value '%s'\n", buf);
 		} else {
 			iio_strerror(-(int)ret, buf, BUF_SIZE);
-			printf("ERROR: %s (%li)\n", buf, (long)ret);
+			printf("ERROR: %s\n", buf);
 		}
 	}
 	if (wbuf) {
@@ -299,8 +299,8 @@ static int dump_channel_attributes(const struct iio_device *dev,
 			dump_channel_attributes(dev, ch, attr, NULL, quiet);
 		} else {
 			iio_strerror(-(int)ret, buf, BUF_SIZE);
-			printf("error %s (%li) while writing '%s' with '%s'\n",
-					buf, (long)ret, attr, wbuf);
+			printf("error %s while writing '%s' with '%s'\n",
+					buf, attr, wbuf);
 		}
 	}
 	free(buf);
@@ -630,8 +630,8 @@ int main(int argc, char **argv)
 			} else {
 				char *buf = xmalloc(BUF_SIZE, MY_NAME);
 				iio_strerror(errno, buf, BUF_SIZE);
-				fprintf(stderr, "Unable to get context attributes: %s (%zd)\n",
-						buf, ret);
+				fprintf(stderr, "Unable to get context attributes: %s\n",
+						buf);
 				free(buf);
 			}
 		}

--- a/tests/iio_common.c
+++ b/tests/iio_common.c
@@ -388,8 +388,8 @@ struct iio_context * handle_common_opts(char * name, int argc,
 		if (ret < 0) {
 			char err_str[1024];
 			iio_strerror(-(int)ret, err_str, sizeof(err_str));
-			fprintf(stderr, "IIO contexts set timeout failed : %s (%zd)\n",
-					err_str, ret);
+			fprintf(stderr, "IIO contexts set timeout failed : %s\n",
+					err_str);
 			iio_context_destroy(ctx);
 			return NULL;
 		}

--- a/tests/iio_info.c
+++ b/tests/iio_info.c
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
 	else {
 		char err_str[1024];
 		iio_strerror(-ret, err_str, sizeof(err_str));
-		fprintf(stderr, "Unable to get backend version: %s (%i)\n", err_str, ret);
+		fprintf(stderr, "Unable to get backend version: %s\n", err_str);
 	}
 
 	printf("Backend description string: %s\n",
@@ -151,8 +151,8 @@ int main(int argc, char **argv)
 		else {
 			char err_str[1024];
 			iio_strerror(-ret, err_str, sizeof(err_str));
-			fprintf(stderr, "\tUnable to read IIO context attributes: %s (%i)\n",
-					err_str, ret);
+			fprintf(stderr, "\tUnable to read IIO context attributes: %s\n",
+					err_str);
 		}
 	}
 
@@ -233,7 +233,7 @@ int main(int argc, char **argv)
 					printf("value: %s\n", buf);
 				} else {
 					iio_strerror(-ret, buf, BUF_SIZE);
-					printf("ERROR: %s (%i)\n", buf, ret);
+					printf("ERROR: %s\n", buf);
 				}
 			}
 		}
@@ -254,7 +254,7 @@ int main(int argc, char **argv)
 					printf("value: %s\n", buf);
 				} else {
 					iio_strerror(-ret, buf, BUF_SIZE);
-					printf("ERROR: %s (%i)\n", buf, ret);
+					printf("ERROR: %s\n", buf);
 				}
 			}
 		}
@@ -275,7 +275,7 @@ int main(int argc, char **argv)
 					printf("value: %s\n", buf);
 				} else {
 					iio_strerror(-ret, buf, BUF_SIZE);
-					printf("ERROR: %s (%i)\n", buf, ret);
+					printf("ERROR: %s\n", buf);
 				}
 			}
 		}
@@ -295,7 +295,7 @@ int main(int argc, char **argv)
 					printf("value: %s\n", buf);
 				} else {
 					iio_strerror(-ret, buf, BUF_SIZE);
-					printf("ERROR: %s (%i)\n", buf, ret);
+					printf("ERROR: %s\n", buf);
 				}
 			}
 		}
@@ -315,7 +315,7 @@ int main(int argc, char **argv)
 			printf("\t\tNo trigger on this device\n");
 		} else if (ret < 0) {
 			iio_strerror(-ret, buf, BUF_SIZE);
-			printf("ERROR: checking for trigger : %s (%i)\n", buf, ret);
+			printf("ERROR: checking for trigger : %s\n", buf);
 		}
 	}
 

--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -296,8 +296,7 @@ int main(int argc, char **argv)
 			if (ret < 0) {
 				char buf[256];
 				iio_strerror(-(int)ret, buf, sizeof(buf));
-				fprintf(stderr, "sample rate not set : %s (%zd)\n",
-						buf, ret);
+				fprintf(stderr, "sample rate not set : %s\n", buf);
 			}
 		}
 
@@ -305,8 +304,7 @@ int main(int argc, char **argv)
 		if (ret < 0) {
 			char buf[256];
 			iio_strerror(-(int)ret, buf, sizeof(buf));
-			fprintf(stderr, "set triffer failed : %s (%zd)\n",
-					buf, ret);
+			fprintf(stderr, "set triffer failed : %s\n", buf);
 		}
 	}
 
@@ -413,8 +411,7 @@ int main(int argc, char **argv)
 			if (ret < 0) {
 				char buf[256];
 				iio_strerror(-(int)ret, buf, sizeof(buf));
-				fprintf(stderr, "buffer processing failed : %s (%zi)\n",
-						buf, ret);
+				fprintf(stderr, "buffer processing failed : %s\n", buf);
 			}
 		}
 	}

--- a/tests/iio_stresstest.c
+++ b/tests/iio_stresstest.c
@@ -219,7 +219,7 @@ static void thread_err(int id, ssize_t ret, char * what)
 	if (ret < 0) {
 		char err_str[1024];
 		iio_strerror(-ret, err_str, sizeof(err_str)); \
-		fprintf(stderr, "%i : IIO ERROR : %s : %s (%zd)\n", id, what, err_str, ret); \
+		fprintf(stderr, "%i : IIO ERROR : %s : %s\n", id, what, err_str); \
 	}
 }
 

--- a/tests/iio_writedev.c
+++ b/tests/iio_writedev.c
@@ -310,8 +310,7 @@ int main(int argc, char **argv)
 			if (ret < 0) {
 				char buf[256];
 				iio_strerror(-(int)ret, buf, sizeof(buf));
-				fprintf(stderr, "sample rate not set : %s (%zd)\n",
-						buf, ret);
+				fprintf(stderr, "sample rate not set : %s\n", buf);
 			}
 		}
 
@@ -319,8 +318,7 @@ int main(int argc, char **argv)
 		if (ret < 0) {
 			char buf[256];
 			iio_strerror(-(int)ret, buf, sizeof(buf));
-			fprintf(stderr, "set triffer failed : %s (%zd)\n",
-					buf, ret);
+			fprintf(stderr, "set trigger failed : %s\n", buf);
 		}
 	}
 
@@ -414,8 +412,7 @@ int main(int argc, char **argv)
 			if (ret < 0) {
 				char buf[256];
 				iio_strerror(-(int)ret, buf, sizeof(buf));
-				fprintf(stderr, "buffer processing failed : %s (%zd)\n",
-						buf, ret);
+				fprintf(stderr, "buffer processing failed : %s\n", buf);
 			}
 		}
 

--- a/usb.c
+++ b/usb.c
@@ -918,8 +918,8 @@ struct iio_context * usb_create_context(unsigned int bus,
 	if (ret) {
 		ret = -(int) libusb_to_errno(ret);
 		iio_strerror(-ret, err_str, sizeof(err_str));
-		IIO_ERROR("Unable to claim interface %u:%u:%u: %s (%i)\n",
-		      bus, address, intrfc, err_str, ret);
+		IIO_ERROR("Unable to claim interface %u:%u:%u: %s\n",
+		      bus, address, intrfc, err_str);
 		goto err_libusb_close;
 	}
 
@@ -927,8 +927,7 @@ struct iio_context * usb_create_context(unsigned int bus,
 	if (ret) {
 		ret = -(int) libusb_to_errno(ret);
 		iio_strerror(-ret, err_str, sizeof(err_str));
-		IIO_ERROR("Unable to get config descriptor: %s (%i)\n",
-				err_str, ret);
+		IIO_ERROR("Unable to get config descriptor: %s\n", err_str);
 		goto err_libusb_close;
 	}
 

--- a/utilities.c
+++ b/utilities.c
@@ -216,6 +216,10 @@ void iio_strerror(int err, char *buf, size_t len)
 #endif
 	if (ret != 0)
 		iio_snprintf(buf, len, "Unknown error %i", err);
+	else {
+		size_t i = strnlen(buf, len);
+		iio_snprintf(buf + i, len - i, " (%i)", err);
+	}
 }
 
 char *iio_strdup(const char *str)


### PR DESCRIPTION
iio_error: Always print out the error code.
    
When debugging some Windows code, there were some weird strings coming out. 

This tweak will make it easier to find things, as we now follow the rule:
 * always include the error number along with the message, as that's the unambiguous part
 
This does two things:   
* update iio_strerror to always append the error number, so coders can be more lazy.
 * be lazy, and never print out error codes in the leaf code
    
