### PR TITLE
ci,azure-pipelines: add initial yaml file

### DIFF
--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -69,7 +69,7 @@ handle_centos() {
 	if is_centos_at_least_ver "8" ; then
 		# On CentOS 8, avahi-devel & doxygen are in this repo; enable it
 		yum -y install yum-utils
-		yum config-manager --set-enabled PowerTools
+		yum config-manager --set-enabled powertools
 		# On CentOS 6 & 7, have issues building or packaging doc
 		yum -y install python3 doxygen man2html
 		install_sphinx
@@ -115,6 +115,6 @@ handle_default() {
 	fi
 }
 
-OS_TYPE=${1:-default}
+OS_TYPE=${OS_TYPE:-default}
 
 handle_${OS_TYPE}

--- a/CI/travis/inside_docker.sh
+++ b/CI/travis/inside_docker.sh
@@ -1,30 +1,30 @@
 #!/bin/sh -e
 
-LIBNAME="$1"
-OS_TYPE="$2"
-
 export INSIDE_DOCKER="1"
-export TRAVIS_BUILD_DIR="/$LIBNAME"
 
-cd "/$LIBNAME"
+INSIDE_DOCKER_BUILD_DIR=/docker_build_dir
 
-if [ -d "/$LIBNAME/CI" ] ; then
-	CI="/$LIBNAME/CI"
-elif [ -d "/$LIBNAME/ci" ] ; then
-	CI="/$LIBNAME/ci"
+export TRAVIS_BUILD_DIR="$INSIDE_DOCKER_BUILD_DIR"
+
+cd "$INSIDE_DOCKER_BUILD_DIR"
+
+if [ -d "/$INSIDE_DOCKER_BUILD_DIR/CI" ] ; then
+	CI="/$INSIDE_DOCKER_BUILD_DIR/CI"
+elif [ -d "/$INSIDE_DOCKER_BUILD_DIR/ci" ] ; then
+	CI="/$INSIDE_DOCKER_BUILD_DIR/ci"
 else
 	echo "No CI/ci directory present"
 	exit 1
 fi
 
-if [ -f "/$LIBNAME/inside-travis-ci-docker-env" ] ; then
-	. "/$LIBNAME/inside-travis-ci-docker-env"
+if [ -f "$INSIDE_DOCKER_BUILD_DIR/inside-travis-ci-docker-env" ] ; then
+	. "$INSIDE_DOCKER_BUILD_DIR/inside-travis-ci-docker-env"
 fi
 
-"$CI/travis/before_install_linux" "$OS_TYPE"
+"$CI/travis/before_install_linux"
 
-"$CI/travis/make_linux" "$OS_TYPE"
+"$CI/travis/make_linux"
 
 # need to find this out inside the container
 . "$CI/travis/lib.sh"
-echo "$(get_ldist)" > "/${LIBNAME}/build/.LDIST"
+echo "$(get_ldist)" > "${INSIDE_DOCKER_BUILD_DIR}/build/.LDIST"

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -452,16 +452,22 @@ run_docker_script() {
 ensure_command_exists() {
 	local cmd="$1"
 	local package="$2"
+	local yes_confirm
 	[ -n "$cmd" ] || return 1
 	[ -n "$package" ] || package="$cmd"
 	! command_exists "$cmd" || return 0
 	# go through known package managers
 	for pacman in apt-get brew yum ; do
 		command_exists $pacman || continue
-		"$pacman" install -y "$package" || {
+		if [ "$pacman" = "brew" ] ; then
+			yes_confirm=
+		else
+			yes_confirm="-y"
+		fi
+		"$pacman" install $yes_confirm "$package" || {
 			# Try an update if install doesn't work the first time
-			"$pacman" -y update && \
-				"$pacman" install -y "$package"
+			"$pacman" $yes_confirm update && \
+				"$pacman" install $yes_confirm "$package"
 		}
 		return $?
 	done

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -10,6 +10,10 @@ LOCAL_BUILD_DIR=${LOCAL_BUILD_DIR:-build}
 HOMEBREW_NO_INSTALL_CLEANUP=1
 export HOMEBREW_NO_INSTALL_CLEANUP
 
+# This needs to be duplicated inside 'inside_docker.sh'
+# It's the common convention between host & container
+INSIDE_DOCKER_BUILD_DIR=/docker_build_dir
+
 # Add here all the common env-vars that should be propagated
 # to the docker image, simply by referencing the env-var name.
 # The values will be evaluated.
@@ -19,7 +23,7 @@ export HOMEBREW_NO_INSTALL_CLEANUP
 #
 # If these nothing should be passed, then clear or
 #'unset INSIDE_DOCKER_TRAVIS_CI_ENV' after this script is included
-INSIDE_DOCKER_TRAVIS_CI_ENV="TRAVIS TRAVIS_COMMIT TRAVIS_PULL_REQUEST OS_VERSION"
+INSIDE_DOCKER_TRAVIS_CI_ENV="TRAVIS TRAVIS_COMMIT TRAVIS_PULL_REQUEST OS_TYPE OS_VERSION"
 
 COMMON_SCRIPTS="inside_docker.sh"
 
@@ -439,9 +443,9 @@ run_docker_script() {
 	local DOCKER_SCRIPT="$(get_script_path $1)"
 	local DOCKER_IMAGE="$2"
 	local OS_TYPE="$3"
-	local MOUNTPOINT="${4:-docker_build_dir}"
+	local MOUNTPOINT="${4:-${INSIDE_DOCKER_BUILD_DIR}}"
 
-	__save_env_for_docker "${TRAVIS_BUILD_DIR}"
+	__save_env_for_docker "$(pwd)"
 
 	sudo docker run --rm=true \
 		-v "$(pwd):/${MOUNTPOINT}:rw" \

--- a/CI/travis/make_darwin
+++ b/CI/travis/make_darwin
@@ -15,10 +15,15 @@ build_osx() {
 	ls
 }
 
-cd $TRAVIS_BUILD_DIR/build
+mkdir -p build
+
+cd build
 build_osx "-DOSX_PACKAGE=ON -DPYTHON_BINDINGS=ON -DWITH_EXAMPLES=ON"
 
-cd $TRAVIS_BUILD_DIR/build_tar
+cd ..
+
+mkdir -p build_tar
+cd build_tar
 build_osx "-DOSX_PACKAGE=OFF -DENABLE_PACKAGING=ON -DPYTHON_BINDINGS=ON"
 echo "### make package"
 make package

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -112,8 +112,7 @@ handle_ubuntu_docker() {
 		"ubuntu:${OS_VERSION}"
 }
 
-LIBNAME="$1"
-OS_TYPE=${2:-default}
+OS_TYPE=${OS_TYPE:-default}
 
 handle_${OS_TYPE}
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,102 @@
+trigger:
+- main
+- master
+- staging/*
+- 20*
+
+pr:
+- main
+- master
+- 20*
+
+jobs:
+- job: centos_7_x86_64
+  pool:
+    vmImage: 'ubuntu-latest'
+  variables:
+    OS_TYPE: centos_docker
+    OS_VERSION: 7
+  steps:
+  - checkout: self
+    fetchDepth: 1
+    clean: true
+  - script: ./CI/travis/before_install_linux
+  - script: ./CI/travis/make_linux
+
+- job: centos_8_x86_64
+  pool:
+    vmImage: 'ubuntu-latest'
+  variables:
+    OS_TYPE: centos_docker
+    OS_VERSION: 8
+  steps:
+  - checkout: self
+    fetchDepth: 1
+    clean: true
+  - script: ./CI/travis/before_install_linux
+  - script: ./CI/travis/make_linux
+
+- job: ubuntu_16_04_x86_64
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - checkout: self
+    fetchDepth: 1
+    clean: true
+  - script: ./CI/travis/before_install_linux
+  - script: ./CI/travis/make_linux
+
+- job: ubuntu_18_04_x86_64
+  pool:
+    vmImage: 'ubuntu-18.04'
+  steps:
+  - checkout: self
+    fetchDepth: 1
+    clean: true
+  - script: ./CI/travis/before_install_linux
+  - script: ./CI/travis/make_linux
+
+- job: ubuntu_20_04_x86_64
+  pool:
+    vmImage: 'ubuntu-20.04'
+  steps:
+  - checkout: self
+    fetchDepth: 1
+    clean: true
+  - script: ./CI/travis/before_install_linux
+  - script: ./CI/travis/make_linux
+
+- job: macos_10_14
+  pool:
+    vmImage: 'macos-10.14'
+  steps:
+  - checkout: self
+    fetchDepth: 1
+    clean: true
+  - script: ./CI/travis/before_install_darwin
+  - script: ./CI/travis/make_darwin
+
+- job: macos_10_15
+  pool:
+    vmImage: 'macos-10.15'
+  steps:
+  - checkout: self
+    fetchDepth: 1
+    clean: true
+  - script: ./CI/travis/before_install_darwin
+  - script: ./CI/travis/make_darwin
+
+# FIXME: uncomment after this is resolved:
+#        https://github.com/actions/virtual-environments/issues/2072
+# Mac OS X 11.0 is definitely a big thing (with their switch to ARM,
+# so we should be quick to have it)
+#
+# - job: macos_11_0
+#  pool:
+#    vmImage: 'macos-11.0'
+#  steps:
+#  - checkout: self
+#    fetchDepth: 1
+#    clean: true
+#  - script: ./CI/travis/before_install_darwin
+#  - script: ./CI/travis/make_darwin


### PR DESCRIPTION
Currently just does a build, an only on PRs to save time/resources.
Deployments will be re-added in the next commit series.

On push events only staging/* branches are built.
This is an opt-in mechanism, since we may not want to build everything,
which is a waste of resources.

Dropped CentOS 6 builds during migration; we can re-add it; but it's old
enough.
The supported MacOS X images are version 10.14, 10.15 and 11.0.

Suffixed builds with CPU architecture `_x86_64`. We may want to add `_arm`
or `_arm64` later.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>