### PR TITLE
ci,azure-pipelines: rework to matrix strategy and publish artifacts

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,6 @@
+variables:
+  branchName: $[ variables['Build.SourceBranchName'] ]
+
 trigger:
 - main
 - master
@@ -17,16 +20,21 @@ jobs:
         imageName: 'ubuntu-latest'
         OS_TYPE: 'centos_docker'
         OS_VERSION: 7
+        artifactName: 'libiio-Linux-CentOS-7-x86_64'
       centos_8_x86_64:
         imageName: 'ubuntu-latest'
         OS_TYPE: 'centos_docker'
         OS_VERSION: 8
+        artifactName: 'libiio-Linux-CentOS-8-x86_64'
       ubuntu_16_04_x86_64:
         imageName: 'ubuntu-16.04'
+        artifactName: 'libiio-Linux-Ubuntu-16.04-x86_64'
       ubuntu_18_04_x86_64:
         imageName: 'ubuntu-18.04'
+        artifactName: 'libiio-Linux-Ubuntu-18.04-x86_64'
       ubuntu_20_04_x86_64:
         imageName: 'ubuntu-20.04'
+        artifactName: 'libiio-Linux-Ubuntu-20.04-x86_64'
   pool:
     vmImage: $(imageName)
   steps:
@@ -37,20 +45,33 @@ jobs:
     displayName: "Install Dependencies"
   - script: ./CI/travis/make_linux
     displayName: "Build"
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: '$(Agent.BuildDirectory)/s/build/'
+      contents: '$(Agent.BuildDirectory)/s/build/?(*.deb|*.rpm)'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+  - task: PublishPipelineArtifact@1
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)'
+      artifactName: '$(artifactName)-$(branchName)'
 
 - job: macOSBuilds
   strategy:
     matrix:
       macOS_10_14:
         imageName: 'macOS-10.14'
+        artifactName: 'libiio-macOS-10.14'
       macOS_10_15:
         imageName: 'macOS-10.15'
+        artifactName: 'libiio-macOS-10.15'
 # FIXME: uncomment after this is resolved:
 #        https://github.com/actions/virtual-environments/issues/2072
 # Mac OS X 11.0 is definitely a big thing (with their switch to ARM,
 # so we should be quick to have it)
 #      macOS_11_0:
 #        imageName: 'macOS-11.0'
+#        artifactName: 'libiio-macOS-11.0'
   pool:
     vmImage: $(imageName)
   steps:
@@ -61,3 +82,13 @@ jobs:
     displayName: "Install Dependencies"
   - script: ./CI/travis/make_darwin
     displayName: "Build"
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: '$(Agent.BuildDirectory)/s/build/'
+      contents: '$(Agent.BuildDirectory)/s/build/?(*.pkg)'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+  - task: PublishPipelineArtifact@1
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)'
+      artifactName: '$(artifactName)-$(branchName)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,12 +10,25 @@ pr:
 - 20*
 
 jobs:
-- job: centos_7_x86_64
+- job: LinuxBuilds
+  strategy:
+    matrix:
+      centos_7_x86_64:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'centos_docker'
+        OS_VERSION: 7
+      centos_8_x86_64:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'centos_docker'
+        OS_VERSION: 8
+      ubuntu_16_04_x86_64:
+        imageName: 'ubuntu-16.04'
+      ubuntu_18_04_x86_64:
+        imageName: 'ubuntu-18.04'
+      ubuntu_20_04_x86_64:
+        imageName: 'ubuntu-20.04'
   pool:
-    vmImage: 'ubuntu-latest'
-  variables:
-    OS_TYPE: centos_docker
-    OS_VERSION: 7
+    vmImage: $(imageName)
   steps:
   - checkout: self
     fetchDepth: 1
@@ -25,94 +38,26 @@ jobs:
   - script: ./CI/travis/make_linux
     displayName: "Build"
 
-- job: centos_8_x86_64
-  pool:
-    vmImage: 'ubuntu-latest'
-  variables:
-    OS_TYPE: centos_docker
-    OS_VERSION: 8
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - script: ./CI/travis/before_install_linux
-    displayName: "Install Dependencies"
-  - script: ./CI/travis/make_linux
-    displayName: "Build"
-
-- job: ubuntu_16_04_x86_64
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - script: ./CI/travis/before_install_linux
-    displayName: "Install Dependencies"
-  - script: ./CI/travis/make_linux
-    displayName: "Build"
-
-- job: ubuntu_18_04_x86_64
-  pool:
-    vmImage: 'ubuntu-18.04'
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - script: ./CI/travis/before_install_linux
-    displayName: "Install Dependencies"
-  - script: ./CI/travis/make_linux
-    displayName: "Build"
-
-- job: ubuntu_20_04_x86_64
-  pool:
-    vmImage: 'ubuntu-20.04'
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - script: ./CI/travis/before_install_linux
-    displayName: "Install Dependencies"
-  - script: ./CI/travis/make_linux
-    displayName: "Build"
-
-- job: macos_10_14
-  pool:
-    vmImage: 'macos-10.14'
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - script: ./CI/travis/before_install_darwin
-    displayName: "Install Dependencies"
-  - script: ./CI/travis/make_darwin
-    displayName: "Build"
-
-- job: macos_10_15
-  pool:
-    vmImage: 'macos-10.15'
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - script: ./CI/travis/before_install_darwin
-    displayName: "Install Dependencies"
-  - script: ./CI/travis/make_darwin
-    displayName: "Build"
-
+- job: macOSBuilds
+  strategy:
+    matrix:
+      macOS_10_14:
+        imageName: 'macOS-10.14'
+      macOS_10_15:
+        imageName: 'macOS-10.15'
 # FIXME: uncomment after this is resolved:
 #        https://github.com/actions/virtual-environments/issues/2072
 # Mac OS X 11.0 is definitely a big thing (with their switch to ARM,
 # so we should be quick to have it)
-#
-# - job: macos_11_0
-#  pool:
-#    vmImage: 'macos-11.0'
-#  steps:
-#  - checkout: self
-#    fetchDepth: 1
-#    clean: true
-#  - script: ./CI/travis/before_install_darwin
-#    displayName: "Install Dependencies"
-#  - script: ./CI/travis/make_darwin
-#    displayName: "Build"
+#      macOS_11_0:
+#        imageName: 'macOS-11.0'
+  pool:
+    vmImage: $(imageName)
+  steps:
+  - checkout: self
+    fetchDepth: 1
+    clean: true
+  - script: ./CI/travis/before_install_darwin
+    displayName: "Install Dependencies"
+  - script: ./CI/travis/make_darwin
+    displayName: "Build"


### PR DESCRIPTION
Matrix strategy adapted from Travis Collins' work on libiio with Azure Pipelines.
This reduces duplication of the same steps for Linux & Mac builds.

Publishing build artifacts for Mac & Linux.
Also adapted from Travis Collins' example. But this uses the
PublishPipelineArtifact@1 (some parts of the doc recommend this over
PublishBuildArtifact@1).
The artifacts will be published for non-Pull-Request cases.
And the artifact names have been parametrized based on branch, so that
'master' artifacts propagate to the next builds, and release artifacts
(20XX_RY branches) propagate over the same branch names.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>