### PR TITLE
ci,azure-pipelines: add coverity job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,23 @@ pr:
 - 20*
 
 jobs:
+- job: Coverity
+  variables:
+    PLATFORM: linux
+    BITS: 64
+    HOST: x86_64
+    CHECK_RULE: coverage
+    GCOV: 1
+    PKG_RULE: gzip
+    PYPI: yes
+    COVERITY_SCAN_PROJECT_NAME: 'analogdevicesinc/libiio'
+    COVERITY_SCAN_BRANCH_PATTERN: master
+    COVERITY_SCAN_NOTIFICATION_EMAIL: "cse-ci-notifications@analog.com"
+    COVERITY_SCAN_BUILD_COMMAND_PREPEND: "mkdir build && cd build && cmake -DWITH_EXAMPLES=ON .."
+    COVERITY_SCAN_BUILD_COMMAND: make
+  steps:
+  - script: |
+      echo "Coverity should run now"
 - job: LinuxBuilds
   strategy:
     matrix:


### PR DESCRIPTION
This change adds job for the Coverity scan project. There doesn't seem to
be an environment variable (at first glance) for the repo slug.
So, the name of the repo was added directly in the yaml file.

This doesn't run yet. Some more setup is required. It does a port of the
environment variables from the .travis.yml file.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>