### PR TITLE
iio-private.h: Increase MAX_ATTR_VALUE

### DIFF
--- a/iio-private.h
+++ b/iio-private.h
@@ -83,7 +83,7 @@
 #define MAX_CTX_NAME   NAME_MAX  /* nominally "xml" */
 #define MAX_CTX_DESC   NAME_MAX  /* nominally "linux ..." */
 #define MAX_ATTR_NAME  NAME_MAX  /* encoded in the sysfs filename */
-#define MAX_ATTR_VALUE PAGESIZE  /* Linux page size, could be anything */
+#define MAX_ATTR_VALUE (8 * PAGESIZE)  /* 8x Linux page size, could be anything */
 
 /* ntohl/htonl are a nightmare to use in cross-platform applications,
  * since they are defined in different headers on different platforms.


### PR DESCRIPTION
This limit was arbitrarily chosen. Prior in truncating the string,
it got parsed by libini, processed by xmlEncodeEntitiesReentrant().
So we know it is zero terminated and a valid string.
Keep a limit by increase it by 8x. Hopefully no valid use case will ever
exceed this limit.

This fixes a regression on M2k where the temperature calibration values
attribute exceeds 4k.

ERROR: Internal libIIO error: iio_context_create_xml str length issue
ERROR: Unable to create local context: Cannot allocate memory (12)


Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>