### PR TITLE
ci: re-enable check-kernel script for linux

### DIFF
--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -87,7 +87,7 @@ handle_default() {
 	cd ..
 
 	# make sure we are up to date (once)
-	if [ "$LDIST" = "DO_NOT_DEPLOY" ] ; then
+	if [ "$CHECK_AGAINST_KERNEL_HEADER" = "1" ] ; then
 		./CI/travis/check_kernel.sh
 	fi
 	echo "### All done building"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,6 +32,7 @@ jobs:
       ubuntu_20_04_x86_64:
         imageName: 'ubuntu-20.04'
         artifactName: 'Linux-Ubuntu-20.04-x86_64'
+        CHECK_AGAINST_KERNEL_HEADER: 1
   pool:
     vmImage: $(imageName)
   steps:


### PR DESCRIPTION
This time we add a CHECK_AGAINST_KERNEL_HEADER env var to enable this
script, and tie it to the Ubuntu 20.04 build. Since this is the most recent
Linux image.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>