### PR TITLE
ci,azure-pipelines: add windows builds

### DIFF
--- a/CI/build_win.ps1
+++ b/CI/build_win.ps1
@@ -1,0 +1,11 @@
+
+$COMPILER=$Env:COMPILER
+$ARCH=$Env:ARCH
+
+$src_dir=$pwd
+
+mkdir build
+cd build
+
+cmake -G "$COMPILER" -A "$ARCH" -DPYTHON_BINDINGS=ON -DLIBXML2_LIBRARIES="$src_dir\deps\lib\libxml2.dll.a" ..
+cmake --build . --config Release

--- a/CI/install_deps_win.ps1
+++ b/CI/install_deps_win.ps1
@@ -1,0 +1,23 @@
+
+git submodule update --init
+
+if (!(Test-Path deps)) {
+	mkdir deps
+}
+cd deps
+
+mkdir libxml
+wget https://www.zlatkovic.com/pub/libxml/64bit/libxml2-2.9.3-win32-x86_64.7z -OutFile "libxml.7z"
+7z x -y libxml.7z
+rm libxml.7z
+
+echo "Downloading deps..."
+cd C:\
+wget http://swdownloads.analog.com/cse/build/libiio-win-deps.zip -OutFile "libiio-win-deps.zip"
+7z x -y "C:\libiio-win-deps.zip"
+
+# Note: InnoSetup is already installed on Azure images; so don't run this step
+#       Running choco seems a bit slow; seems to save about 40-60 seconds here
+#choco install InnoSetup
+
+set PATH=%PATH%;"C:\Program Files (x86)\Inno Setup 6"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,3 +89,49 @@ jobs:
     inputs:
       targetPath: '$(Build.ArtifactStagingDirectory)'
       artifactName: '$(artifactName)'
+
+- job: WindowsBuilds
+  strategy:
+    matrix:
+      VS2017:
+        imageName: 'vs2017-win2016'
+        COMPILER: 'Visual Studio 15 2017'
+        ARCH: 'x64'
+        artifactName: 'Windows-VS-15-2017-x64'
+      VS2019:
+        imageName: 'windows-2019'
+        COMPILER: 'Visual Studio 16 2019'
+        ARCH: 'x64'
+        artifactName: 'Windows-VS-16-2019-x64'
+  pool:
+    vmImage: $[ variables['imageName'] ]
+  steps:
+  - checkout: self
+    fetchDepth: 1
+    clean: true
+  - task: PowerShell@2
+    inputs:
+      targetType: 'filePath'
+      filePath: .\CI\install_deps_win.ps1
+    displayName: Dependencies
+  - task: PowerShell@2
+    inputs:
+      targetType: 'filePath'
+      filePath: .\CI\build_win.ps1
+    displayName: Build
+  - task: CopyFiles@2
+    displayName: 'Copy libraries'
+    inputs:
+      sourceFolder: '$(Agent.BuildDirectory)/s/build/Release'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+  - task: CopyFiles@2
+    displayName: 'Copy iio.h header'
+    inputs:
+      sourceFolder: '$(Agent.BuildDirectory)/s/'
+      contents: 'iio.h'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+  - task: PublishPipelineArtifact@1
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)'
+      artifactName: '$(artifactName)'


### PR DESCRIPTION
This change adds a minimal configuration to build some Windows artifacts
for libiio.
These are stored after the pipeline is done.

Adapted from Travis Collins' work.
Added into PowerShell scripts. Ideally we should not add any script-code
into yaml files, as that makes it harder to scale, and even harder to
migrate (if ever will be needed again).

Publishing artifacts, the generated DLL, static library, and the iio.h
header, which will be used in the next jobs.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>