### PR TITLE
[RFC] ci,linux: reduce python pip deps and use distro's python3

### DIFF
--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -13,26 +13,6 @@ install_sphinx() {
 	fi
 }
 
-install_pyenv() {
-	if ! command_exists pyenv ; then
-		echo installing pyenv
-		git clone git://github.com/yyuu/pyenv.git $HOME/.pyenv
-		export PATH="$HOME/.pyenv/bin:$PATH"
-		export PYENV_ROOT="$HOME/.pyenv"
-	fi
-}
-
-install_python() {
-	echo "### installing python"
-	command -v pyenv
-	add_python_path
-	pyenv install --list | grep "^[[:space:]]*[0-9]"
-	pyenv install 3.6.3
-	pyenv global 3.6.3
-	add_python_path
-}
-
-
 handle_centos() {
 	# needed for man2html and a few other popular tools
 	yum search epel-release
@@ -101,12 +81,10 @@ handle_default() {
 	sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential \
 		libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
 		wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev \
-		libffi-dev liblzma-dev python-openssl git
+		libffi-dev liblzma-dev python-openssl git \
+		doxygen man2html python3 python3-pip
 
-	if ! is_arm ; then
-		install_pyenv
-		install_python
-		sudo apt-get install -y doxygen man2html
+	if is_python_at_least_ver "python" "3.6" ; then
 		install_sphinx
 	fi
 }

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -6,8 +6,6 @@ install_sphinx() {
 	if command_exists $PYTHON ; then
 		$PYTHON --version
 		command -v $PYTHON
-		$PYTHON -m pip install -U pip
-		$PYTHON -m pip install -U setuptools
 		$PYTHON -m pip install sphinx
 		$PYTHON -m pip install sphinx-rtd-theme
 	fi

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -3,13 +3,13 @@
 . CI/travis/lib.sh
 
 install_sphinx() {
-	if command_exists python ; then
-		python --version
-		command -v python
-		python -m pip install -U pip
-		python -m pip install -U setuptools
-		python -m pip install sphinx
-		python -m pip install sphinx-rtd-theme
+	if command_exists $PYTHON ; then
+		$PYTHON --version
+		command -v $PYTHON
+		$PYTHON -m pip install -U pip
+		$PYTHON -m pip install -U setuptools
+		$PYTHON -m pip install sphinx
+		$PYTHON -m pip install sphinx-rtd-theme
 	fi
 }
 
@@ -81,10 +81,10 @@ handle_default() {
 	sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential \
 		libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
 		wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev \
-		libffi-dev liblzma-dev python-openssl git \
+		libffi-dev liblzma-dev python3-openssl git \
 		doxygen man2html python3 python3-pip
 
-	if is_python_at_least_ver "python" "3.6" ; then
+	if is_python_at_least_ver "$PYTHON" "3.6" ; then
 		install_sphinx
 	fi
 }

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -22,13 +22,6 @@ handle_centos() {
 	yum -y install cmake libxml2-devel libusb1-devel libaio-devel \
 		bzip2 gzip rpm rpm-build
 
-	# needed for building python with pyenv
-	yum install -y  gcc gcc-c++ make git patch openssl-devel zlib-devel readline-devel sqlite-devel bzip2-devel
-
-	# CentOS 6 & 7 don't work with doc, or the latest python.
-	# install_pyenv
-	# install_python
-
 	if [ "$(get_version | head -c 1)" = "7" ] ; then
 		# install Cmake3, and make it the default
 		yum -y install cmake3
@@ -69,18 +62,11 @@ handle_ubuntu_docker() {
 
 handle_default() {
 	sudo apt-get -qq update
-	sudo apt-get install -y apt-utils
 	sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake graphviz \
 		libaio-dev libavahi-client-dev libserialport-dev \
 		libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar \
-		bzip2 gzip flex bison git libncurses5-dev libcdk5-dev
-
-	# Most of these should be here, but are needed for building python by pyenv
-	sudo DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential \
-		libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev \
-		wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev \
-		libffi-dev liblzma-dev python3-openssl git \
-		doxygen man2html python3 python3-pip
+		bzip2 gzip flex bison git libncurses5-dev libcdk5-dev \
+		doxygen man2html python3 python3-pip python3-setuptools
 
 	if is_python_at_least_ver "$PYTHON" "3.6" ; then
 		install_sphinx

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -10,6 +10,9 @@ LOCAL_BUILD_DIR=${LOCAL_BUILD_DIR:-build}
 HOMEBREW_NO_INSTALL_CLEANUP=1
 export HOMEBREW_NO_INSTALL_CLEANUP
 
+PYTHON=python3
+export PYTHON
+
 # This needs to be duplicated inside 'inside_docker.sh'
 # It's the common convention between host & container
 INSIDE_DOCKER_BUILD_DIR=/docker_build_dir

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -46,33 +46,6 @@ backtrace() {
 	fi
 }
 
-add_python_path() {
-	echo "adding Python to the path"
-	if [ -d "$HOME/.pyenv/bin" -a "$(echo "$PATH" | grep .pyenv/bin | wc -c)" -eq "0" ] ; then
-		echo "adding $HOME/.pyenv/bin to path"
-		export PATH="$HOME/.pyenv/bin:$PATH"
-	fi
-	if [ -z "${PYENV_SHELL}" ] ; then
-		echo init pyenv
-		eval "$(pyenv init -)"
-	fi
-	if [ -d /opt/pyenv/versions/3.6.3/bin -a "$(echo "$PATH" | grep opt/pyenv/versions | wc -c)" -eq "0" ] ; then
-		echo adding python on opt to PATH
-		export PATH="/opt/pyenv/versions/3.6.3/bin:$PATH"
-	fi
-	if [ -d /root/.pyenv/versions/3.6.3/bin -a "$(echo "$PATH" | grep root/.pyenv/versions | wc -c)" -eq "0" ] ; then
-		echo adding python on root/.pyenv to PATH
-		export PATH="/root/.pyenv/versions/3.6.3/bin:$PATH"
-	fi
-	if ! command_exists python ; then
-		echo No python on path
-		echo "$PATH"
-	else
-		python --version
-		command -v python
-	fi
-}
-
 get_script_path() {
 	local script="$1"
 
@@ -509,6 +482,15 @@ is_ubuntu_at_least_ver() {
 is_centos_at_least_ver() {
 	[ "$(get_dist_id)" = "centos" ] || return 1
 	version_ge "$(get_version)" "$1"
+}
+
+is_python_at_least_ver() {
+	local out python_exec
+
+	python_exec="$1"
+	command_exists "$python_exec" || return 1
+	out=$($python_exec --version)
+	version_ge "${out#* }" "$2"
 }
 
 is_arm() {

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -9,14 +9,14 @@ handle_default() {
 	mkdir -p build
 	cd build
 
-	if command_exists python ; then
-		command -v python
-		python --version
+	if command_exists $PYTHON ; then
+		command -v $PYTHON
+		$PYTHON --version
 
 		PYTHON_HELP="-DPYTHON_BINDINGS=ON \
-			-DPYTHON_INCLUDE_DIR=$(python -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())") \
-			-DPYTHON_LIBRARY=$(python -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR'))") \
-			-DPYTHON_EXECUTABLE=$(command -v python)"
+			-DPYTHON_INCLUDE_DIR=$($PYTHON -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())") \
+			-DPYTHON_LIBRARY=$($PYTHON -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR'))") \
+			-DPYTHON_EXECUTABLE=$(command -v $PYTHON)"
 
 		# Add ~/.local dir to paths; this is where pip installs things (if no sudo)
 		export PATH="$PATH:$(readlink -f ~/.local/bin/)"

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -9,7 +9,6 @@ handle_default() {
 	mkdir -p build
 	cd build
 
-	add_python_path
 	if command_exists python ; then
 		command -v python
 		python --version
@@ -18,6 +17,11 @@ handle_default() {
 			-DPYTHON_INCLUDE_DIR=$(python -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())") \
 			-DPYTHON_LIBRARY=$(python -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR'))") \
 			-DPYTHON_EXECUTABLE=$(command -v python)"
+
+		# Add ~/.local dir to paths; this is where pip installs things (if no sudo)
+		export PATH="$PATH:$(readlink -f ~/.local/bin/)"
+		export PYTHONPATH="$(readlink -f ~/.local/lib/python*/site-packages/)"
+
 		if command_exists sphinx-build ; then
 			DOC_HELP="-DWITH_DOC=ON"
 		fi


### PR DESCRIPTION
All Linux distros [except for Ubuntu 16.04] support Python 3.6 or newer.
For this version it might make sense to no longer build docs, since it's getting old (5 years in a few months).

With this change we switch to using the distribution's Python3 package.
This unclutters some Python setup.

Since we're moving to Azure, it is a good opportunity to do this cleanup.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>