### PR TITLE
Python bindings: Solved Python bindings Context destructor bug.

### DIFF
--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -44,7 +44,6 @@ from ctypes.util import find_library
 from enum import Enum
 from os import strerror as _strerror
 from platform import system as _system
-import weakref
 import abc
 
 if "Windows" in _system():
@@ -1301,7 +1300,7 @@ class Device(_DeviceOrTrigger):
             An new instance of this class
         """
         super(Device, self).__init__(_device)
-        self.ctx = weakref.ref(ctx)
+        self.ctx = ctx
 
     def _set_trigger(self, trigger):
         _d_set_trigger(self._device, trigger._device if trigger else None)


### PR DESCRIPTION
The Device class was only holding a weakref of the Context object. This could lead to calling the Context's destructor before removing all its references.
An example of the crash can be found in #628.
Weakref was permitting Python to call the Context destructor even if it was referenced in the device object. Changing the weakref to a full reference should solve the issue.

Signed-off-by: Cristi Iacob <cristian.iacob@analog.com>