### PR TITLE
ci,azure-pipelines: add ARM{64} Debian Buster builds 

### DIFF
--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -81,12 +81,8 @@ handle_centos() {
 	yum -y install avahi-devel
 }
 
-handle_centos_docker() {
-	prepare_docker_image "centos:centos${OS_VERSION}"
-}
-
-handle_ubuntu_docker() {
-	prepare_docker_image "ubuntu:${OS_VERSION}"
+handle_generic_docker() {
+	prepare_docker_image
 }
 
 handle_default() {
@@ -111,6 +107,6 @@ handle_default() {
 	fi
 }
 
-OS_TYPE=${OS_TYPE:-default}
+setup_build_type_env_vars
 
-handle_${OS_TYPE}
+handle_${BUILD_TYPE}

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -107,6 +107,10 @@ handle_default() {
 	fi
 }
 
+handle_debian() {
+	handle_default
+}
+
 setup_build_type_env_vars
 
 handle_${BUILD_TYPE}

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -103,6 +103,10 @@ handle_centos() {
 	cd ..
 }
 
+handle_debian() {
+	handle_default
+}
+
 handle_generic_docker() {
 	run_docker_script inside_docker.sh
 }

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -103,17 +103,10 @@ handle_centos() {
 	cd ..
 }
 
-handle_centos_docker() {
-	run_docker_script inside_docker.sh \
-		"centos:centos${OS_VERSION}" "centos"
+handle_generic_docker() {
+	run_docker_script inside_docker.sh
 }
 
-handle_ubuntu_docker() {
-	run_docker_script inside_docker.sh \
-		"ubuntu:${OS_VERSION}"
-}
+setup_build_type_env_vars
 
-OS_TYPE=${OS_TYPE:-default}
-
-handle_${OS_TYPE}
-
+handle_${BUILD_TYPE}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,12 +16,12 @@ jobs:
       centos_7_x86_64:
         imageName: 'ubuntu-latest'
         OS_TYPE: 'centos_docker'
-        OS_VERSION: 7
+        OS_VERSION: centos7
         artifactName: 'Linux-CentOS-7-x86_64'
       centos_8_x86_64:
         imageName: 'ubuntu-latest'
         OS_TYPE: 'centos_docker'
-        OS_VERSION: 8
+        OS_VERSION: centos8
         artifactName: 'Linux-CentOS-8-x86_64'
       ubuntu_16_04_x86_64:
         imageName: 'ubuntu-16.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,6 +33,16 @@ jobs:
         imageName: 'ubuntu-20.04'
         artifactName: 'Linux-Ubuntu-20.04-x86_64'
         CHECK_AGAINST_KERNEL_HEADER: 1
+      debian_buster_arm32v7:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'arm32v7/debian_docker'
+        OS_VERSION: 'buster'
+        artifactName: 'Linux-Debian-Buster-ARM'
+      debian_buster_arm64v8:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'arm64v8/debian_docker'
+        OS_VERSION: 'buster'
+        artifactName: 'Linux-Debian-Buster-ARM64'
   pool:
     vmImage: $(imageName)
   steps:


### PR DESCRIPTION
These ARM builds should work also on Raspberry Pi (starting with Raspbian
Buster). These packages should install on newer (than Buster) Debian
versions as well.
 
Tested on a Raspbian that the libiio deb package installs and iio_info
runs, and iiod starts (even though is started manually, but this requires
some more work for packaging the service installation).

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>