### PR TITLE
ci,azure-pipelines: wrap all Ubuntu builds in official docker images

### DIFF
--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -107,6 +107,10 @@ handle_default() {
 	fi
 }
 
+handle_ubuntu() {
+	handle_default
+}
+
 handle_debian() {
 	handle_default
 }

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -4,6 +4,8 @@ if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 
 . CI/travis/lib.sh
 
+INSIDE_DOCKER_TRAVIS_CI_ENV="$INSIDE_DOCKER_TRAVIS_CI_ENV CHECK_AGAINST_KERNEL_HEADER"
+
 handle_default() {
 	echo "### making build dir"
 	mkdir -p build
@@ -101,6 +103,10 @@ handle_centos() {
 	make
 	make package
 	cd ..
+}
+
+handle_ubuntu() {
+	handle_default
 }
 
 handle_debian() {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,13 +24,19 @@ jobs:
         OS_VERSION: centos8
         artifactName: 'Linux-CentOS-8-x86_64'
       ubuntu_16_04_x86_64:
-        imageName: 'ubuntu-16.04'
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'ubuntu_docker'
+        OS_VERSION: xenial
         artifactName: 'Linux-Ubuntu-16.04-x86_64'
       ubuntu_18_04_x86_64:
-        imageName: 'ubuntu-18.04'
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'ubuntu_docker'
+        OS_VERSION: bionic
         artifactName: 'Linux-Ubuntu-18.04-x86_64'
       ubuntu_20_04_x86_64:
-        imageName: 'ubuntu-20.04'
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'ubuntu_docker'
+        OS_VERSION: focal
         artifactName: 'Linux-Ubuntu-20.04-x86_64'
         CHECK_AGAINST_KERNEL_HEADER: 1
       debian_buster_arm32v7:


### PR DESCRIPTION
Sadly, Azure Pipelines, seems to have their Ubuntu images pre-configured
with stuff we don't want.

The stuff that seems to pain us more is that they install some PPAs that we
don't need, and that results in installing newer versions of packages than
what Ubuntu officially supports.

Example (for libxml2):
https://dev.azure.com/AnalogDevices/OpenSource/_build/results?buildId=301&view=logs&j=619eeb56-1e32-5748-8918-b91b4093a911&t=abb0dc85-7ed9-5413-b9ef-6502ddb91e27

```
The following packages will be upgraded:
  libxml2 libxml2-dev
```

```
Get:13 http://ppa.launchpad.net/ondrej/php/ubuntu xenial/main amd64 libxml2-dev amd64 2.9.10+dfsg-5+ubuntu16.04.1+deb.sury.org+3 [809 kB]
```

When trying to test these deb packages on an official Ubuntu docker, it
complains that it requires a newer libxml2 library than the one Ubuntu
officially has.

One idea is to disable all PPAs, but that sounds like the start of a
continuous cleanup of Azure's Ubuntu images.

The cost of using official Ubuntu dockers is smaller in comparison.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>