### PR TITLE
ci,azure-pipelines: re-purpose VS2017 builds as VS2019_Win32

### DIFF
--- a/CI/install_deps_win.ps1
+++ b/CI/install_deps_win.ps1
@@ -1,4 +1,6 @@
 
+$ARCH=$Env:ARCH
+
 git submodule update --init
 
 if (!(Test-Path deps)) {
@@ -7,7 +9,12 @@ if (!(Test-Path deps)) {
 cd deps
 
 mkdir libxml
-wget https://www.zlatkovic.com/pub/libxml/64bit/libxml2-2.9.3-win32-x86_64.7z -OutFile "libxml.7z"
+
+if ( "$ARCH" -eq "x64" ) {
+	wget https://www.zlatkovic.com/pub/libxml/64bit/libxml2-2.9.3-win32-x86_64.7z -OutFile "libxml.7z"
+} else {
+	wget https://www.zlatkovic.com/pub/libxml/64bit/libxml2-2.9.3-win32-x86.7z -OutFile "libxml.7z"
+}
 7z x -y libxml.7z
 rm libxml.7z
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,12 +110,12 @@ jobs:
 - job: WindowsBuilds
   strategy:
     matrix:
-      VS2017:
-        imageName: 'vs2017-win2016'
-        COMPILER: 'Visual Studio 15 2017'
-        ARCH: 'x64'
-        artifactName: 'Windows-VS-15-2017-x64'
-      VS2019:
+      VS2019_Win32:
+        imageName: 'windows-2019'
+        COMPILER: 'Visual Studio 16 2019'
+        ARCH: 'Win32'
+        artifactName: 'Windows-VS-16-2019-Win32'
+      VS2019_Win64:
         imageName: 'windows-2019'
         COMPILER: 'Visual Studio 16 2019'
         ARCH: 'x64'


### PR DESCRIPTION
Microsoft has a pretty good track record for making their Visual Studio
compilers work fine across multiple Windows versions.
And libiio isn't a super-complicated project, in terms of scale and what
Visual Studio can handle.

So, instead of building on 2 versions of Visual Studio, might as well build
for a single one, but for different architectures.
Building for Win32 & Win64 is more important.

This change re-purposes the VS2017 build to VS2019_Win32 (i.e. Visual
Studio 2019 and Win32).

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>