### PR TITLE
ci,lib.sh: double quote the env-vars passed to docker

### DIFF
--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -417,7 +417,7 @@ __save_env_for_docker() {
 	for env in $INSIDE_DOCKER_TRAVIS_CI_ENV ; do
 		val="$(eval echo "\$${env}")"
 		if [ -n "$val" ] ; then
-			echo "export ${env}=${val}" >> "${env_file}"
+			echo "export ${env}=\"${val}\"" >> "${env_file}"
 		fi
 	done
 }


### PR DESCRIPTION
Some env-vars can have spaces. To prevent issues with these, we need to
add explicit double quotes when saving them in the file that the docker
image will read.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>