### PR TITLE
serial: Detect timeout when reading a byte from serial port

### DIFF
--- a/serial.c
+++ b/serial.c
@@ -281,6 +281,12 @@ static ssize_t serial_read_data(struct iio_context_pdata *pdata,
 				pdata->port, buf, len, pdata->timeout_ms));
 
 	IIO_DEBUG("Read returned %li: %.*s\n", (long) ret, (int) ret, buf);
+
+	if (ret == 0) {
+		IIO_ERROR("sp_blocking_read_next has timedout");
+		return -ETIMEDOUT;
+	}
+
 	return ret;
 }
 
@@ -297,6 +303,11 @@ static ssize_t serial_read_line(struct iio_context_pdata *pdata,
 		ret = libserialport_to_errno(sp_blocking_read_next(
 					pdata->port, &buf[i], 1,
 					pdata->timeout_ms));
+		if (ret == 0) {
+			IIO_ERROR("sp_blocking_read_next has timedout");
+			return -ETIMEDOUT;
+		}
+
 		if (ret < 0) {
 			IIO_ERROR("sp_blocking_read_next returned %i\n", ret);
 			return (ssize_t) ret;


### PR DESCRIPTION
The descrpition of sp_blocking_read_next() specifies that 0 is returned on timeout. This commit handles this.
An issue has been observed when trying to create a context for the wrong serial port (where no tiny-iiod exists on the other end) which causes a really long wait time because sp_blocking_read_next() was being called for at least 1024 times and each time it timedout after 1 second.

This fixes https://github.com/analogdevicesinc/iio-oscilloscope/issues/280