### PR TITLE
iio: rework entire xml generation

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -177,168 +177,100 @@ void iio_channel_init_finalize(struct iio_channel *chn)
 	}
 }
 
-static char *get_attr_xml(struct iio_channel_attr *attr, size_t *length)
+static ssize_t iio_snprintf_chan_attr_xml(char *str, ssize_t len,
+					  struct iio_channel_attr *attr)
 {
-	char *str;
-	size_t len;
+	if (!attr->filename)
+		return iio_snprintf(str, len, "<attribute name=\"%s\" />", attr->name);
 
-	len = strnlen(attr->name, MAX_ATTR_NAME);
-	len += sizeof("<attribute name=\"\" />") - 1;
-
-	if (attr->filename) {
-		len += strnlen(attr->filename, NAME_MAX);
-		len += sizeof(" filename=\"\"") - 1;
-	}
-
-	*length = len; /* just the chars */
-	len++;         /* room for terminating NULL */
-	str = malloc(len);
-	if (!str)
-		return NULL;
-
-	if (attr->filename)
-		iio_snprintf(str, len, "<attribute name=\"%s\" filename=\"%s\" />",
-				attr->name, attr->filename);
-	else
-		iio_snprintf(str, len, "<attribute name=\"%s\" />", attr->name);
-
-	return str;
+	return iio_snprintf(str, len,
+			    "<attribute name=\"%s\" filename=\"%s\" />",
+			    attr->name, attr->filename);
 }
 
-static char * get_scan_element(const struct iio_channel *chn, size_t *length)
+static ssize_t iio_snprintf_scan_element_xml(char *str, ssize_t len,
+					     const struct iio_channel *chn)
 {
-	char buf[1024], repeat[12] = "", *str;
 	char processed = (chn->format.is_fully_defined ? 'A' - 'a' : 0);
+	char repeat[12] = "", scale[48] = "";
 
 	if (chn->format.repeat > 1)
 		iio_snprintf(repeat, sizeof(repeat), "X%u", chn->format.repeat);
 
-	iio_snprintf(buf, sizeof(buf), "<scan-element index=\"%li\" "
-			"format=\"%ce:%c%u/%u%s&gt;&gt;%u\" />",
+	if (chn->format.with_scale)
+		iio_snprintf(scale, sizeof(scale), "scale=\"%f\" ", chn->format.scale);
+
+	return iio_snprintf(str, len,
+			"<scan-element index=\"%li\" format=\"%ce:%c%u/%u%s&gt;&gt;%u\" %s/>",
 			chn->index, chn->format.is_be ? 'b' : 'l',
 			chn->format.is_signed ? 's' + processed : 'u' + processed,
 			chn->format.bits, chn->format.length, repeat,
-			chn->format.shift);
-
-	if (chn->format.with_scale) {
-		char *ptr = strrchr(buf, '\0');
-		iio_snprintf(ptr - 2, buf + sizeof(buf) - ptr + 2,
-				"scale=\"%f\" />", chn->format.scale);
-	}
-
-	str = iio_strdup(buf);
-	if (str)
-		*length = strlen(str);
-	return str;
+			chn->format.shift, scale);
 }
 
-/* Returns a string containing the XML representation of this channel */
-char * iio_channel_get_xml(const struct iio_channel *chn, size_t *length)
+ssize_t iio_snprintf_channel_xml(char *ptr, ssize_t len,
+				 const struct iio_channel *chn)
 {
-	ssize_t len;
-	char *ptr, *eptr, *str, **attrs, *scan_element = NULL;
-	size_t *attrs_len, scan_element_len = 0;
+	ssize_t ret, alen = 0;
 	unsigned int i;
 
-	len = sizeof("<channel id=\"\" type=\"\" ></channel>") - 1;
-	len += strnlen(chn->id, MAX_CHN_ID);
-	len += (chn->is_output ? sizeof("output") : sizeof("input")) - 1;
-	if (chn->name) {
-		len += sizeof(" name=\"\"") - 1;
-		len += strnlen(chn->name, MAX_CHN_NAME);
+	ret = iio_snprintf(ptr, len, "<channel id=\"%s\"", chn->id);
+	if (ret < 0)
+		return ret;
+	if (ptr) {
+		ptr += ret;
+		len -= ret;
 	}
+	alen += ret;
+
+	if (chn->name) {
+		ret = iio_snprintf(ptr, len, " name=\"%s\"", chn->name);
+		if (ret < 0)
+			return ret;
+		if (ptr) {
+			ptr += ret;
+			len -= ret;
+		}
+		alen += ret;
+	}
+
+	ret = iio_snprintf(ptr, len, " type=\"%s\" >", chn->is_output ? "output" : "input");
+	if (ret < 0)
+		return ret;
+	if (ptr) {
+		ptr += ret;
+		len -= ret;
+	}
+	alen += ret;
 
 	if (chn->is_scan_element) {
-		scan_element = get_scan_element(chn, &scan_element_len);
-		if (!scan_element)
-			return NULL;
-		else
-			len += scan_element_len;
-	}
-
-	attrs_len = malloc(chn->nb_attrs * sizeof(*attrs_len));
-	if (!attrs_len)
-		goto err_free_scan_element;
-
-	attrs = malloc(chn->nb_attrs * sizeof(*attrs));
-	if (!attrs)
-		goto err_free_attrs_len;
-
-	for (i = 0; i < chn->nb_attrs; i++) {
-		char *xml = get_attr_xml(&chn->attrs[i], &attrs_len[i]);
-		if (!xml)
-			goto err_free_attrs;
-		attrs[i] = xml;
-		len += attrs_len[i];
-	}
-
-	len++;  /* room for terminating NULL */
-	str = malloc(len);
-	if (!str)
-		goto err_free_attrs;
-	ptr = str;
-	eptr = str + len;
-
-	if (len > 0) {
-		ptr += iio_snprintf(str, len, "<channel id=\"%s\"", chn->id);
-		len = eptr - ptr;
-	}
-
-	if (chn->name && len > 0) {
-		ptr += iio_snprintf(ptr, len, " name=\"%s\"", chn->name);
-		len = eptr - ptr;
-	}
-
-	if (len > 0) {
-		ptr += iio_snprintf(ptr, len, " type=\"%s\" >", chn->is_output ? "output" : "input");
-		len = eptr - ptr;
-	}
-
-	if (chn->is_scan_element && len > (ssize_t) scan_element_len) {
-		memcpy(ptr, scan_element, scan_element_len); /* Flawfinder: ignore */
-		ptr += scan_element_len;
-		len -= scan_element_len;
-	}
-
-	for (i = 0; i < chn->nb_attrs; i++) {
-		if (len > (ssize_t) attrs_len[i]) {
-			memcpy(ptr, attrs[i], attrs_len[i]); /* Flawfinder: ignore */
-			ptr += attrs_len[i];
-			len -= attrs_len[i];
+		ret = iio_snprintf_scan_element_xml(ptr, len, chn);
+		if (ret < 0)
+			return ret;
+		if (ptr) {
+			ptr += ret;
+			len -= ret;
 		}
-		free(attrs[i]);
+		alen += ret;
 	}
 
-	free(scan_element);
-	free(attrs);
-	free(attrs_len);
-
-	if (len > 0) {
-		ptr += iio_strlcpy(ptr, "</channel>", len);
-		len -= sizeof("</channel>") -1;
+	for (i = 0; i < chn->nb_attrs; i++) {
+		ret = iio_snprintf_chan_attr_xml(ptr, len, &chn->attrs[i]);
+		if (ret < 0)
+			return ret;
+		if (ptr) {
+			ptr += ret;
+			len -= ret;
+		}
+		alen += ret;
 	}
 
-	*length = ptr - str;
+	ret = iio_snprintf(ptr, len, "</channel>");
+	if (ret < 0)
+		return ret;
+	alen += ret;
 
-	/* NULL char should be left, and that is it */
-	if (len != 1) {
-		IIO_ERROR("Internal libIIO error: iio_channel_get_xml str length issue\n");
-		free(str);
-		return NULL;
-	}
-
-	return str;
-
-err_free_attrs:
-	while (i--)
-		free(attrs[i]);
-	free(attrs);
-err_free_attrs_len:
-	free(attrs_len);
-err_free_scan_element:
-	if (chn->is_scan_element)
-		free(scan_element);
-	return NULL;
+	return alen;
 }
 
 const char * iio_channel_get_id(const struct iio_channel *chn)

--- a/context.c
+++ b/context.c
@@ -44,142 +44,88 @@ static const char xml_header[] = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
 "<!ATTLIST buffer-attribute name CDATA #REQUIRED>"
 "]>";
 
+static ssize_t iio_snprintf_context_xml(char *ptr, ssize_t len,
+					const struct iio_context *ctx)
+{
+	ssize_t ret, alen = 0;
+	unsigned int i;
+
+	if (ctx->description)
+		ret = iio_snprintf(ptr, len, "%s<context name=\"%s\" "
+				   "description=\"%s\" >",
+				   xml_header, ctx->name, ctx->description);
+	else
+		ret = iio_snprintf(ptr, len, "%s<context name=\"%s\" >",
+				   xml_header, ctx->name);
+
+	if (ret < 0)
+		return ret;
+
+	if (ptr) {
+		ptr += ret;
+		len -= ret;
+	}
+	alen += ret;
+
+	for (i = 0; i < ctx->nb_attrs; i++) {
+		ret = iio_snprintf(ptr, len,
+				   "<context-attribute name=\"%s\" value=\"%s\" />",
+				  ctx->attrs[i], ctx->values[i]);
+		if (ret < 0)
+			return ret;
+		if (ptr) {
+			ptr += ret;
+			len -= ret;
+		}
+		alen += ret;
+	}
+
+	for (i = 0; i < ctx->nb_devices; i++) {
+		ret = iio_snprintf_device_xml(ptr, len, ctx->devices[i]);
+		if (ret < 0)
+			return ret;
+		if (ptr) {
+			ptr += ret;
+			len -= ret;
+		}
+		alen += ret;
+	}
+
+	ret = iio_snprintf(ptr, len, "</context>");
+	if (ret < 0)
+		return ret;
+	alen += ret;
+
+	return alen;
+}
+
 /* Returns a string containing the XML representation of this context */
 char * iio_context_create_xml(const struct iio_context *ctx)
 {
 	ssize_t len;
-	size_t *devices_len = NULL;
-	char *str, *ptr, *eptr, **devices = NULL;
-	char ** ctx_attrs, **ctx_values;
-	unsigned int i;
+	char *str;
 
-	len = sizeof(xml_header) - 1;
-	len += strnlen(ctx->name, MAX_CTX_NAME);
-	len += sizeof("<context name=\"\" ></context>") - 1;
-
-	if (ctx->description) {
-		len += strnlen(ctx->description, MAX_CTX_DESC);
-		len += sizeof(" description=\"\"") - 1;
-	}
-
-	ctx_attrs = calloc(ctx->nb_attrs, sizeof(*ctx->attrs));
-	if (!ctx_attrs) {
-		errno = ENOMEM;
+	len = iio_snprintf_context_xml(NULL, 0, ctx);
+	if (len < 0) {
+		errno = -len;
 		return NULL;
-	}
-	ctx_values = calloc(ctx->nb_attrs, sizeof(*ctx->values));
-	if (!ctx_values) {
-		errno = ENOMEM;
-		goto err_free_ctx_attrs;
-	}
-
-	for (i = 0; i < ctx->nb_attrs; i++) {
-		ctx_attrs[i] = encode_xml_ndup(ctx->attrs[i]);
-		ctx_values[i] = encode_xml_ndup(ctx->values[i]);
-		if (!ctx_attrs[i] || !ctx_values[i])
-			goto err_free_ctx_attrs_values;
-
-		len += strnlen(ctx_attrs[i], MAX_ATTR_NAME);
-		len += strnlen(ctx_values[i], MAX_ATTR_VALUE);
-		len += sizeof("<context-attribute name=\"\" value=\"\" />") - 1;
-	}
-
-	if (ctx->nb_devices) {
-		devices_len = malloc(ctx->nb_devices * sizeof(*devices_len));
-		if (!devices_len) {
-			errno = ENOMEM;
-			goto err_free_ctx_attrs_values;
-		}
-
-		devices = calloc(ctx->nb_devices, sizeof(*devices));
-		if (!devices)
-			goto err_free_devices_len;
-
-		for (i = 0; i < ctx->nb_devices; i++) {
-			char *xml = iio_device_get_xml(ctx->devices[i],
-					&devices_len[i]);
-			if (!xml)
-				goto err_free_devices;
-			devices[i] = xml;
-			len += devices_len[i];
-		}
 	}
 
 	len++; /* room for terminating NULL */
 	str = malloc(len);
 	if (!str) {
 		errno = ENOMEM;
-		goto err_free_devices;
-	}
-	eptr = str + len;
-	ptr = str;
-
-	if (len > 0) {
-		if (ctx->description) {
-			ptr += iio_snprintf(str, len, "%s<context name=\"%s\" "
-					"description=\"%s\" >",
-					xml_header, ctx->name, ctx->description);
-		} else {
-			ptr += iio_snprintf(str, len, "%s<context name=\"%s\" >",
-					xml_header, ctx->name);
-		}
-		len = eptr - ptr;
+		return NULL;
 	}
 
-	for (i = 0; i < ctx->nb_attrs && len > 0; i++) {
-		ptr += iio_snprintf(ptr, len, "<context-attribute name=\"%s\" value=\"%s\" />",
-				ctx_attrs[i], ctx_values[i]);
-		free(ctx_attrs[i]);
-		free(ctx_values[i]);
-		len = eptr - ptr;
-	}
-
-	free(ctx_attrs);
-	free(ctx_values);
-
-	for (i = 0; i < ctx->nb_devices; i++) {
-		if (len > (ssize_t) devices_len[i]) {
-			memcpy(ptr, devices[i], devices_len[i]); /* Flawfinder: ignore */
-			ptr += devices_len[i];
-			len -= devices_len[i];
-		}
-		free(devices[i]);
-	}
-
-	free(devices);
-	free(devices_len);
-
-	if (len > 0) {
-		ptr += iio_strlcpy(ptr, "</context>", len);
-		len -= sizeof("</context>") - 1;
-	}
-
-	if (len != 1) {
-		IIO_ERROR("Internal libIIO error: iio_context_create_xml str length issue\n");
+	len = iio_snprintf_context_xml(str, len, ctx);
+	if (len < 0) {
+		errno = -len;
 		free(str);
 		return NULL;
 	}
 
 	return str;
-
-err_free_devices:
-	for (i = 0; i < ctx->nb_devices; i++)
-		free(devices[i]);
-	free(devices);
-err_free_devices_len:
-	free(devices_len);
-err_free_ctx_attrs_values:
-	for (i = 0; i < ctx->nb_attrs; i++) {
-		if (ctx_attrs[i])
-			free(ctx_attrs[i]);
-		if (ctx_values[i])
-			free(ctx_values[i]);
-	}
-
-	free(ctx_values);
-err_free_ctx_attrs:
-	free(ctx_attrs);
-	return NULL;
 }
 
 struct iio_context * iio_context_create_from_backend(

--- a/device.c
+++ b/device.c
@@ -262,6 +262,27 @@ err_free_attrs_len:
 	return NULL;
 }
 
+int add_iio_dev_attr(struct iio_dev_attrs *attrs, const char *attr,
+		     const char *type, const char *dev_id)
+{
+	char **names, *name;
+
+	name = iio_strdup(attr);
+	if (!name)
+		return -ENOMEM;
+
+	names = realloc(attrs->names, (1 + attrs->num) * sizeof(char *));
+	if (!names) {
+		free(name);
+		return -ENOMEM;
+	}
+
+	names[attrs->num++] = name;
+	attrs->names = names;
+	IIO_DEBUG("Added%s attr \'%s\' to device \'%s\'\n", type, attr, dev_id);
+	return 0;
+}
+
 const char * iio_device_get_id(const struct iio_device *dev)
 {
 	return dev->id;

--- a/device.c
+++ b/device.c
@@ -81,16 +81,16 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 		len += strnlen(dev->name, MAX_DEV_NAME);
 	}
 
-	attrs_len = malloc(dev->nb_attrs * sizeof(*attrs_len));
+	attrs_len = malloc(dev->attrs.num * sizeof(*attrs_len));
 	if (!attrs_len)
 		return NULL;
 
-	attrs = malloc(dev->nb_attrs * sizeof(*attrs));
+	attrs = malloc(dev->attrs.num * sizeof(*attrs));
 	if (!attrs)
 		goto err_free_attrs_len;
 
-	for (i = 0; i < dev->nb_attrs; i++) {
-		char *xml = get_attr_xml(dev->attrs[i], &attrs_len[i], IIO_ATTR_TYPE_DEVICE);
+	for (i = 0; i < dev->attrs.num; i++) {
+		char *xml = get_attr_xml(dev->attrs.names[i], &attrs_len[i], IIO_ATTR_TYPE_DEVICE);
 		if (!xml)
 			goto err_free_attrs;
 		attrs[i] = xml;
@@ -114,17 +114,17 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 		len += channels_len[j];
 	}
 
-	buffer_attrs_len = malloc(dev->nb_buffer_attrs *
+	buffer_attrs_len = malloc(dev->buffer_attrs.num *
 			sizeof(*buffer_attrs_len));
 	if (!buffer_attrs_len)
 		goto err_free_channels;
 
-	buffer_attrs = malloc(dev->nb_buffer_attrs * sizeof(*buffer_attrs));
+	buffer_attrs = malloc(dev->buffer_attrs.num * sizeof(*buffer_attrs));
 	if (!buffer_attrs)
 		goto err_free_buffer_attrs_len;
 
-	for (k = 0; k < dev->nb_buffer_attrs; k++) {
-		char *xml = get_attr_xml(dev->buffer_attrs[k],
+	for (k = 0; k < dev->buffer_attrs.num; k++) {
+		char *xml = get_attr_xml(dev->buffer_attrs.names[k],
 				&buffer_attrs_len[k], IIO_ATTR_TYPE_BUFFER);
 		if (!xml)
 			goto err_free_buffer_attrs;
@@ -132,17 +132,17 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 		len += buffer_attrs_len[k];
 	}
 
-	debug_attrs_len = malloc(dev->nb_debug_attrs *
+	debug_attrs_len = malloc(dev->debug_attrs.num *
 			sizeof(*debug_attrs_len));
 	if (!debug_attrs_len)
 		goto err_free_buffer_attrs;
 
-	debug_attrs = malloc(dev->nb_debug_attrs * sizeof(*debug_attrs));
+	debug_attrs = malloc(dev->debug_attrs.num * sizeof(*debug_attrs));
 	if (!debug_attrs)
 		goto err_free_debug_attrs_len;
 
-	for (k = 0; k < dev->nb_debug_attrs; k++) {
-		char *xml = get_attr_xml(dev->debug_attrs[k],
+	for (k = 0; k < dev->debug_attrs.num; k++) {
+		char *xml = get_attr_xml(dev->debug_attrs.names[k],
 				&debug_attrs_len[k], IIO_ATTR_TYPE_DEBUG);
 		if (!xml)
 			goto err_free_debug_attrs;
@@ -184,7 +184,7 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	free(channels);
 	free(channels_len);
 
-	for (i = 0; i < dev->nb_attrs; i++) {
+	for (i = 0; i < dev->attrs.num; i++) {
 		if (len > (ssize_t) attrs_len[i]) {
 			memcpy(ptr, attrs[i], attrs_len[i]); /* Flawfinder: ignore */
 			ptr += attrs_len[i];
@@ -196,7 +196,7 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	free(attrs);
 	free(attrs_len);
 
-	for (i = 0; i < dev->nb_buffer_attrs; i++) {
+	for (i = 0; i < dev->buffer_attrs.num; i++) {
 		if (len > (ssize_t) buffer_attrs_len[i]) {
 			memcpy(ptr, buffer_attrs[i], buffer_attrs_len[i]); /* Flawfinder: ignore */
 			ptr += buffer_attrs_len[i];
@@ -208,7 +208,7 @@ char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
 	free(buffer_attrs);
 	free(buffer_attrs_len);
 
-	for (i = 0; i < dev->nb_debug_attrs; i++) {
+	for (i = 0; i < dev->debug_attrs.num; i++) {
 		if (len > (ssize_t) debug_attrs_len[i]) {
 			memcpy(ptr, debug_attrs[i], debug_attrs_len[i]); /* Flawfinder: ignore */
 			ptr += debug_attrs_len[i];
@@ -304,24 +304,24 @@ struct iio_channel * iio_device_find_channel(const struct iio_device *dev,
 
 unsigned int iio_device_get_attrs_count(const struct iio_device *dev)
 {
-	return dev->nb_attrs;
+	return dev->attrs.num;
 }
 
 const char * iio_device_get_attr(const struct iio_device *dev,
 		unsigned int index)
 {
-	if (index >= dev->nb_attrs)
+	if (index >= dev->attrs.num)
 		return NULL;
 	else
-		return dev->attrs[index];
+		return dev->attrs.names[index];
 }
 
 const char * iio_device_find_attr(const struct iio_device *dev,
 		const char *name)
 {
 	unsigned int i;
-	for (i = 0; i < dev->nb_attrs; i++) {
-		const char *attr = dev->attrs[i];
+	for (i = 0; i < dev->attrs.num; i++) {
+		const char *attr = dev->attrs.names[i];
 		if (!strcmp(attr, name))
 			return attr;
 	}
@@ -330,24 +330,24 @@ const char * iio_device_find_attr(const struct iio_device *dev,
 
 unsigned int iio_device_get_buffer_attrs_count(const struct iio_device *dev)
 {
-	return dev->nb_buffer_attrs;
+	return dev->buffer_attrs.num;
 }
 
 const char * iio_device_get_buffer_attr(const struct iio_device *dev,
 		unsigned int index)
 {
-	if (index >= dev->nb_buffer_attrs)
+	if (index >= dev->buffer_attrs.num)
 		return NULL;
 	else
-		return dev->buffer_attrs[index];
+		return dev->buffer_attrs.names[index];
 }
 
 const char * iio_device_find_buffer_attr(const struct iio_device *dev,
 		const char *name)
 {
 	unsigned int i;
-	for (i = 0; i < dev->nb_buffer_attrs; i++) {
-		const char *attr = dev->buffer_attrs[i];
+	for (i = 0; i < dev->buffer_attrs.num; i++) {
+		const char *attr = dev->buffer_attrs.names[i];
 		if (!strcmp(attr, name))
 			return attr;
 	}
@@ -358,8 +358,8 @@ const char * iio_device_find_debug_attr(const struct iio_device *dev,
 		const char *name)
 {
 	unsigned int i;
-	for (i = 0; i < dev->nb_debug_attrs; i++) {
-		const char *attr = dev->debug_attrs[i];
+	for (i = 0; i < dev->debug_attrs.num; i++) {
+		const char *attr = dev->debug_attrs.names[i];
 		if (!strcmp(attr, name))
 			return attr;
 	}
@@ -548,18 +548,18 @@ int iio_device_set_trigger(const struct iio_device *dev,
 void free_device(struct iio_device *dev)
 {
 	unsigned int i;
-	for (i = 0; i < dev->nb_attrs; i++)
-		free(dev->attrs[i]);
-	if (dev->nb_attrs)
-		free(dev->attrs);
-	for (i = 0; i < dev->nb_buffer_attrs; i++)
-		free(dev->buffer_attrs[i]);
-	if (dev->nb_buffer_attrs)
-		free(dev->buffer_attrs);
-	for (i = 0; i < dev->nb_debug_attrs; i++)
-		free(dev->debug_attrs[i]);
-	if (dev->nb_debug_attrs)
-		free(dev->debug_attrs);
+	for (i = 0; i < dev->attrs.num; i++)
+		free(dev->attrs.names[i]);
+	if (dev->attrs.num)
+		free(dev->attrs.names);
+	for (i = 0; i < dev->buffer_attrs.num; i++)
+		free(dev->buffer_attrs.names[i]);
+	if (dev->buffer_attrs.num)
+		free(dev->buffer_attrs.names);
+	for (i = 0; i < dev->debug_attrs.num; i++)
+		free(dev->debug_attrs.names[i]);
+	if (dev->debug_attrs.num)
+		free(dev->debug_attrs.names);
 	for (i = 0; i < dev->nb_channels; i++)
 		free_channel(dev->channels[i]);
 	if (dev->nb_channels)
@@ -795,16 +795,16 @@ ssize_t iio_device_debug_attr_write(const struct iio_device *dev,
 
 unsigned int iio_device_get_debug_attrs_count(const struct iio_device *dev)
 {
-	return dev->nb_debug_attrs;
+	return dev->debug_attrs.num;
 }
 
 const char * iio_device_get_debug_attr(const struct iio_device *dev,
 		unsigned int index)
 {
-	if (index >= dev->nb_debug_attrs)
+	if (index >= dev->debug_attrs.num)
 		return NULL;
 	else
-		return dev->debug_attrs[index];
+		return dev->debug_attrs.names[index];
 }
 
 int iio_device_debug_attr_read_longlong(const struct iio_device *dev,
@@ -903,18 +903,18 @@ int iio_device_identify_filename(const struct iio_device *dev,
 		}
 	}
 
-	for (i = 0; i < dev->nb_attrs; i++) {
+	for (i = 0; i < dev->attrs.num; i++) {
 		/* Devices attributes are named after their filename */
-		if (!strcmp(dev->attrs[i], filename)) {
-			*attr = dev->attrs[i];
+		if (!strcmp(dev->attrs.names[i], filename)) {
+			*attr = dev->attrs.names[i];
 			*chn = NULL;
 			return 0;
 		}
 	}
 
-	for (i = 0; i < dev->nb_debug_attrs; i++) {
-		if (!strcmp(dev->debug_attrs[i], filename)) {
-			*attr = dev->debug_attrs[i];
+	for (i = 0; i < dev->debug_attrs.num; i++) {
+		if (!strcmp(dev->debug_attrs.names[i], filename)) {
+			*attr = dev->debug_attrs.names[i];
 			*chn = NULL;
 			return 0;
 		}

--- a/device.c
+++ b/device.c
@@ -24,242 +24,109 @@
 #include <stdio.h>
 #include <string.h>
 
-static char *get_attr_xml(const char *attr, size_t *length, enum iio_attr_type type)
+static ssize_t iio_snprintf_xml_attr(char *buf, ssize_t len, const char *attr,
+				     enum iio_attr_type type)
 {
-	size_t len;
-	char *str;
-
-	len = sizeof("<attribute name=\"\" />") - 1;
-	len += strnlen(attr, MAX_ATTR_NAME);
-
-	switch(type){
-		case IIO_ATTR_TYPE_DEVICE:
-			break;
-		case IIO_ATTR_TYPE_DEBUG:
-			len += (sizeof("debug-") - 1);
-			break;
-		case IIO_ATTR_TYPE_BUFFER:
-			len += (sizeof("buffer-") - 1);
-			break;
-		default:
-			return NULL;
-	}
-
-	*length = len; /* just the chars */
-	len++; /* room for terminating NULL */
-	str = malloc(len);
-	if (!str)
-		return NULL;
-
 	switch (type) {
 		case IIO_ATTR_TYPE_DEVICE:
-			iio_snprintf(str, len, "<attribute name=\"%s\" />", attr);
-			break;
+			return iio_snprintf(buf, len, "<attribute name=\"%s\" />", attr);
 		case IIO_ATTR_TYPE_DEBUG:
-			iio_snprintf(str, len, "<debug-attribute name=\"%s\" />", attr);
-			break;
+			return iio_snprintf(buf, len, "<debug-attribute name=\"%s\" />", attr);
 		case IIO_ATTR_TYPE_BUFFER:
-			iio_snprintf(str, len, "<buffer-attribute name=\"%s\" />", attr);
-			break;
+			return iio_snprintf(buf, len, "<buffer-attribute name=\"%s\" />", attr);
+		default:
+			return -EINVAL;
 	}
-
-	return str;
 }
 
-/* Returns a string containing the XML representation of this device */
-char * iio_device_get_xml(const struct iio_device *dev, size_t *length)
+ssize_t iio_snprintf_device_xml(char *ptr, ssize_t len,
+				const struct iio_device *dev)
 {
-	ssize_t len;
-	char *ptr, *eptr, *str, **attrs, **channels, **buffer_attrs, **debug_attrs;
-	size_t *attrs_len, *channels_len, *buffer_attrs_len, *debug_attrs_len;
-	unsigned int i, j, k;
+	ssize_t ret, alen = 0;
+	unsigned int i;
 
-	len = sizeof("<device id=\"\" ></device>") - 1;
-	len += strnlen(dev->id, MAX_DEV_ID);
+	ret = iio_snprintf(ptr, len, "<device id=\"%s\"", dev->id);
+	if (ret < 0)
+		return ret;
+	if (ptr) {
+		ptr += ret;
+		len -= ret;
+	}
+	alen += ret;
+
 	if (dev->name) {
-		len += sizeof(" name=\"\"") - 1;
-		len += strnlen(dev->name, MAX_DEV_NAME);
+		ret = iio_snprintf(ptr, len, " name=\"%s\"", dev->name);
+		if (ret < 0)
+			return ret;
+		if (ptr) {
+			ptr += ret;
+			len -= ret;
+		}
+		alen += ret;
 	}
 
-	attrs_len = malloc(dev->attrs.num * sizeof(*attrs_len));
-	if (!attrs_len)
-		return NULL;
-
-	attrs = malloc(dev->attrs.num * sizeof(*attrs));
-	if (!attrs)
-		goto err_free_attrs_len;
-
-	for (i = 0; i < dev->attrs.num; i++) {
-		char *xml = get_attr_xml(dev->attrs.names[i], &attrs_len[i], IIO_ATTR_TYPE_DEVICE);
-		if (!xml)
-			goto err_free_attrs;
-		attrs[i] = xml;
-		len += attrs_len[i];
+	ret = iio_snprintf(ptr, len, " >");
+	if (ret < 0)
+		return ret;
+	if (ptr) {
+		ptr += ret;
+		len -= ret;
 	}
-
-	channels_len = malloc(dev->nb_channels * sizeof(*channels_len));
-	if (!channels_len)
-		goto err_free_attrs;
-
-	channels = malloc(dev->nb_channels * sizeof(*channels));
-	if (!channels)
-		goto err_free_channels_len;
-
-	for (j = 0; j < dev->nb_channels; j++) {
-		char *xml = iio_channel_get_xml(dev->channels[j],
-				&channels_len[j]);
-		if (!xml)
-			goto err_free_channels;
-		channels[j] = xml;
-		len += channels_len[j];
-	}
-
-	buffer_attrs_len = malloc(dev->buffer_attrs.num *
-			sizeof(*buffer_attrs_len));
-	if (!buffer_attrs_len)
-		goto err_free_channels;
-
-	buffer_attrs = malloc(dev->buffer_attrs.num * sizeof(*buffer_attrs));
-	if (!buffer_attrs)
-		goto err_free_buffer_attrs_len;
-
-	for (k = 0; k < dev->buffer_attrs.num; k++) {
-		char *xml = get_attr_xml(dev->buffer_attrs.names[k],
-				&buffer_attrs_len[k], IIO_ATTR_TYPE_BUFFER);
-		if (!xml)
-			goto err_free_buffer_attrs;
-		buffer_attrs[k] = xml;
-		len += buffer_attrs_len[k];
-	}
-
-	debug_attrs_len = malloc(dev->debug_attrs.num *
-			sizeof(*debug_attrs_len));
-	if (!debug_attrs_len)
-		goto err_free_buffer_attrs;
-
-	debug_attrs = malloc(dev->debug_attrs.num * sizeof(*debug_attrs));
-	if (!debug_attrs)
-		goto err_free_debug_attrs_len;
-
-	for (k = 0; k < dev->debug_attrs.num; k++) {
-		char *xml = get_attr_xml(dev->debug_attrs.names[k],
-				&debug_attrs_len[k], IIO_ATTR_TYPE_DEBUG);
-		if (!xml)
-			goto err_free_debug_attrs;
-		debug_attrs[k] = xml;
-		len += debug_attrs_len[k];
-	}
-
-	len++;  /* room for terminating NULL */
-	str = malloc(len);
-	if (!str)
-		goto err_free_debug_attrs;
-	eptr = str + len;
-	ptr = str;
-
-	if (len > 0) {
-		ptr += iio_snprintf(str, len, "<device id=\"%s\"", dev->id);
-		len = eptr - ptr;
-	}
-
-	if (dev->name && len > 0) {
-		ptr += iio_snprintf(ptr, len, " name=\"%s\"", dev->name);
-		len = eptr - ptr;
-	}
-
-	if (len > 0) {
-		ptr += iio_strlcpy(ptr, " >", len);
-		len -= 2;
-	}
+	alen += ret;
 
 	for (i = 0; i < dev->nb_channels; i++) {
-		if (len > (ssize_t) channels_len[i]) {
-			memcpy(ptr, channels[i], channels_len[i]); /* Flawfinder: ignore */
-			ptr += channels_len[i];
-			len -= channels_len[i];
+		ret = iio_snprintf_channel_xml(ptr, len, dev->channels[i]);
+		if (ret < 0)
+			return ret;
+		if (ptr) {
+			ptr += ret;
+			len -= ret;
 		}
-		free(channels[i]);
+		alen += ret;
 	}
-
-	free(channels);
-	free(channels_len);
 
 	for (i = 0; i < dev->attrs.num; i++) {
-		if (len > (ssize_t) attrs_len[i]) {
-			memcpy(ptr, attrs[i], attrs_len[i]); /* Flawfinder: ignore */
-			ptr += attrs_len[i];
-			len -= attrs_len[i];
+		ret = iio_snprintf_xml_attr(ptr, len, dev->attrs.names[i],
+					    IIO_ATTR_TYPE_DEVICE);
+		if (ret < 0)
+			return ret;
+		if (ptr) {
+			ptr += ret;
+			len -= ret;
 		}
-		free(attrs[i]);
+		alen += ret;
 	}
-
-	free(attrs);
-	free(attrs_len);
 
 	for (i = 0; i < dev->buffer_attrs.num; i++) {
-		if (len > (ssize_t) buffer_attrs_len[i]) {
-			memcpy(ptr, buffer_attrs[i], buffer_attrs_len[i]); /* Flawfinder: ignore */
-			ptr += buffer_attrs_len[i];
-			len -= buffer_attrs_len[i];
+		ret = iio_snprintf_xml_attr(ptr, len, dev->buffer_attrs.names[i],
+					    IIO_ATTR_TYPE_BUFFER);
+		if (ret < 0)
+			return ret;
+		if (ptr) {
+			ptr += ret;
+			len -= ret;
 		}
-		free(buffer_attrs[i]);
+		alen += ret;
 	}
-
-	free(buffer_attrs);
-	free(buffer_attrs_len);
 
 	for (i = 0; i < dev->debug_attrs.num; i++) {
-		if (len > (ssize_t) debug_attrs_len[i]) {
-			memcpy(ptr, debug_attrs[i], debug_attrs_len[i]); /* Flawfinder: ignore */
-			ptr += debug_attrs_len[i];
-			len -= debug_attrs_len[i];
+		ret = iio_snprintf_xml_attr(ptr, len, dev->debug_attrs.names[i],
+					    IIO_ATTR_TYPE_DEBUG);
+		if (ret < 0)
+			return ret;
+		if (ptr) {
+			ptr += ret;
+			len -= ret;
 		}
-		free(debug_attrs[i]);
+		alen += ret;
 	}
 
-	free(debug_attrs);
-	free(debug_attrs_len);
+	ret = iio_snprintf(ptr, len, "</device>");
+	if (ret < 0)
+		return ret;
+	alen += ret;
 
-	if (len > 0) {
-		ptr += iio_strlcpy(ptr, "</device>", len);
-		len -= sizeof("</device>") - 1;
-	}
-
-	*length = ptr - str;
-
-	if (len != 1) {
-		IIO_ERROR("Internal libIIO error: iio_device_get_xml str length issue\n");
-		free(str);
-		return NULL;
-	}
-
-	return str;
-
-err_free_debug_attrs:
-	while (k--)
-		free(debug_attrs[k]);
-	free(debug_attrs);
-err_free_debug_attrs_len:
-	free(debug_attrs_len);
-err_free_buffer_attrs:
-	while (k--)
-		free(buffer_attrs[k]);
-	free(buffer_attrs);
-err_free_buffer_attrs_len:
-	free(buffer_attrs_len);
-err_free_channels:
-	while (j--)
-		free(channels[j]);
-	free(channels);
-err_free_channels_len:
-	free(channels_len);
-err_free_attrs:
-	while (i--)
-		free(attrs[i]);
-	free(attrs);
-err_free_attrs_len:
-	free(attrs_len);
-	return NULL;
+	return alen;
 }
 
 int add_iio_dev_attr(struct iio_dev_attrs *attrs, const char *attr,

--- a/iio-private.h
+++ b/iio-private.h
@@ -213,8 +213,10 @@ struct iio_context_info ** iio_scan_result_add(
 void free_channel(struct iio_channel *chn);
 void free_device(struct iio_device *dev);
 
-char *iio_channel_get_xml(const struct iio_channel *chn, size_t *len);
-char *iio_device_get_xml(const struct iio_device *dev, size_t *len);
+ssize_t iio_snprintf_channel_xml(char *str, ssize_t slen,
+				 const struct iio_channel *chn);
+ssize_t iio_snprintf_device_xml(char *str, ssize_t slen,
+				const struct iio_device *dev);
 
 char *encode_xml_ndup(const char * input);
 char *iio_context_create_xml(const struct iio_context *ctx);

--- a/iio-private.h
+++ b/iio-private.h
@@ -275,6 +275,9 @@ int iio_context_add_attr(struct iio_context *ctx,
 
 struct iio_context_pdata * iio_context_get_pdata(const struct iio_context *ctx);
 
+int add_iio_dev_attr(struct iio_dev_attrs *attrs, const char *attr,
+		     const char *type, const char *dev_id);
+
 #undef __api
 
 #endif /* __IIO_PRIVATE_H__ */

--- a/iio-private.h
+++ b/iio-private.h
@@ -163,6 +163,11 @@ struct iio_channel {
 	unsigned int number;
 };
 
+struct iio_dev_attrs {
+	char **names;
+	unsigned int num;
+};
+
 struct iio_device {
 	const struct iio_context *ctx;
 	struct iio_device_pdata *pdata;
@@ -170,14 +175,9 @@ struct iio_device {
 
 	char *name, *id;
 
-	char **attrs;
-	unsigned int nb_attrs;
-
-	char **buffer_attrs;
-	unsigned int nb_buffer_attrs;
-
-	char **debug_attrs;
-	unsigned int nb_debug_attrs;
+	struct iio_dev_attrs attrs;
+	struct iio_dev_attrs buffer_attrs;
+	struct iio_dev_attrs debug_attrs;
 
 	struct iio_channel **channels;
 	unsigned int nb_channels;

--- a/local.c
+++ b/local.c
@@ -1221,27 +1221,6 @@ static int read_device_name(struct iio_device *dev)
 		return 0;
 }
 
-static int add_iio_dev_attr(struct iio_dev_attrs *attrs, const char *attr,
-			    const char *type, const char *dev_id)
-{
-	char **names, *name;
-
-	name = iio_strdup(attr);
-	if (!name)
-		return -ENOMEM;
-
-	names = realloc(attrs->names, (1 + attrs->num) * sizeof(char *));
-	if (!names) {
-		free(name);
-		return -ENOMEM;
-	}
-
-	names[attrs->num++] = name;
-	attrs->names = names;
-	IIO_DEBUG("Added%s attr \'%s\' to device \'%s\'\n", type, attr, dev_id);
-	return 0;
-}
-
 static int add_attr_to_device(struct iio_device *dev, const char *attr)
 {
 	unsigned int i;

--- a/xml.c
+++ b/xml.c
@@ -100,16 +100,16 @@ static int add_attr_to_device(struct iio_device *dev, xmlNode *n, enum iio_attr_
 
 	switch(type) {
 		case IIO_ATTR_TYPE_DEBUG:
-			attrs = realloc(dev->debug_attrs,
-					(1 + dev->nb_debug_attrs) * sizeof(char *));
+			attrs = realloc(dev->debug_attrs.names,
+					(1 + dev->debug_attrs.num) * sizeof(char *));
 			break;
 		case IIO_ATTR_TYPE_DEVICE:
-			attrs = realloc(dev->attrs,
-					(1 + dev->nb_attrs) * sizeof(char *));
+			attrs = realloc(dev->attrs.names,
+					(1 + dev->attrs.num) * sizeof(char *));
 			break;
 		case IIO_ATTR_TYPE_BUFFER:
-			attrs = realloc(dev->buffer_attrs,
-					(1 + dev->nb_buffer_attrs) * sizeof(char *));
+			attrs = realloc(dev->buffer_attrs.names,
+					(1 + dev->buffer_attrs.num) * sizeof(char *));
 			break;
 		default:
 			attrs = NULL;
@@ -120,16 +120,16 @@ static int add_attr_to_device(struct iio_device *dev, xmlNode *n, enum iio_attr_
 
 	switch(type) {
 		case IIO_ATTR_TYPE_DEBUG:
-			attrs[dev->nb_debug_attrs++] = name;
-			dev->debug_attrs = attrs;
+			attrs[dev->debug_attrs.num++] = name;
+			dev->debug_attrs.names = attrs;
 			break;
 		case IIO_ATTR_TYPE_DEVICE:
-			attrs[dev->nb_attrs++] = name;
-			dev->attrs = attrs;
+			attrs[dev->attrs.num++] = name;
+			dev->attrs.names = attrs;
 			break;
 		case IIO_ATTR_TYPE_BUFFER:
-			attrs[dev->nb_buffer_attrs++] = name;
-			dev->buffer_attrs = attrs;
+			attrs[dev->buffer_attrs.num++] = name;
+			dev->buffer_attrs.names = attrs;
 			break;
 	}
 


### PR DESCRIPTION
The entire XML generation (the one done manually) is pretty difficult to
change, so if someone wants to add some attributes (because some kernel ABI
got updated), it's easy to change and introduce leaks.

This code as-is already has some potential leaks (and faults).
One example is in in iio_device_get_xml() (on the error path), where:
```
err_free_debug_attrs:
	while (k--)
		free(debug_attrs[k]);
	free(debug_attrs);
err_free_debug_attrs_len:
	free(debug_attrs_len);
err_free_buffer_attrs:
	while (k--)
		free(buffer_attrs[k]);
	free(buffer_attrs);
```

Now, it's obvious that such errors can be fixed, but a better idea is to do
a single allocation and use the 'snprintf(NULL, 0, ...)' to count the
amount of memory we need for the XML string.

This change does that. And all the allocations (that were needed before)
are reduced to a single one (vs 10+ ... I stopped counting).

This obviously simplifies error paths as the risk of leaks is dramatically
reduced. A lot of code is also reduced, because we don't need to track any
pointers ourselves.
Admittedly, snprintf() may do some allocations under the hood, it's still
better to offload the pointer tracking to snprintf(), than keep doing it
ourselves.

Unfortunately, this change has to be done a single go. A bit more effort
could be invested into splitting this into smaller commits. But the way the
XML string generation works, once you start pulling on this thread, it
tends to unwind in multiple places.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>