### PR TITLE
examples/cmake: Fix iio-monitor dependency checks

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -48,8 +48,11 @@ set(IIO_EXAMPLES_TARGETS ad9361-iiostream ad9371-iiostream adrv9009-iiostream
                          dummy-iiostream
 )
 
+find_library(PTHREAD_LIBRARIES pthread)
 find_library(CURSES_LIBRARY curses)
 find_library(CDK_LIBRARY cdk)
+
+include(CheckSymbolExists)
 
 if (PTHREAD_LIBRARIES
     AND CURSES_LIBRARY


### PR DESCRIPTION
Running cmake for the examples warns:

    -- Curses Development Kit (CDK) missing or too old, skipping iio-monitor

This happens because PTHREAD_LIBRARIES is not set.
Fix that by looking for the phtread library first.

After that it fails with:

    Unknown CMake command "check_symbol_exists".

Fix that by including CheckSymbolExists.

Fixes: 88b946f4b897ea18 ("iio-monitor: Now the c90 warnings are gone, fix real warnings")
Signed-off-by: Geert Uytterhoeven <geert@linux-m68k.org>
---
On Ubuntu 20.04.2 LTS.