### PR TITLE
CMake: Allow building as static lib in MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,10 @@ endif()
 
 set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
 
+if (NOT BUILD_SHARED_LIBS)
+	add_definitions(-DLIBIIO_STATIC=1)
+endif()
+
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	option(OSX_PACKAGE "Create a OSX package" ON)
 

--- a/iio.h
+++ b/iio.h
@@ -72,7 +72,9 @@ typedef ptrdiff_t ssize_t;
 #endif
 
 #ifdef _WIN32
-#   ifdef LIBIIO_EXPORTS
+#   ifdef LIBIIO_STATIC
+#	define __api
+#   elif defined(LIBIIO_EXPORTS)
 #	define __api __declspec(dllexport)
 #   else
 #	define __api __declspec(dllimport)


### PR DESCRIPTION
Set the LIBIIO_STATIC define when compiling a static library, which then
causes the __api to be resolved as empty.

This fixes building statically under MSVC.

Fixes #616.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>