### PR TITLE
xml: Remove unused function encode_xml_ndup()

### DIFF
--- a/iio-private.h
+++ b/iio-private.h
@@ -218,7 +218,6 @@ ssize_t iio_snprintf_channel_xml(char *str, ssize_t slen,
 ssize_t iio_snprintf_device_xml(char *str, ssize_t slen,
 				const struct iio_device *dev);
 
-char *encode_xml_ndup(const char * input);
 char *iio_context_create_xml(const struct iio_context *ctx);
 int iio_context_init(struct iio_context *ctx);
 

--- a/xml.c
+++ b/xml.c
@@ -23,16 +23,6 @@
 #include <libxml/tree.h>
 #include <string.h>
 
-/* 'input' must be in UTF-8 encoded, null terminated */
-char * encode_xml_ndup(const char * input)
-{
-	char * out;
-
-	out = (char *)xmlEncodeEntitiesReentrant(NULL, (const xmlChar *)input);
-
-	return out;
-}
-
 static int add_attr_to_channel(struct iio_channel *chn, xmlNode *n)
 {
 	xmlAttr *attr;


### PR DESCRIPTION
This function is not used anywhere anymore since commit 9d79757.

Fixes #588.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>