### PR TITLE
tests: Print context creation messages to stderr

### DIFF
--- a/tests/iio_common.c
+++ b/tests/iio_common.c
@@ -95,11 +95,11 @@ struct iio_context * autodetect_context(bool rtn, const char * name, const char 
 	}
 
 	if (ret == 0) {
-		printf("No IIO context found.\n");
+		fprintf(stderr, "No IIO context found.\n");
 		goto err_free_info_list;
 	}
 	if (rtn && ret == 1) {
-		printf("Using auto-detected IIO context at URI \"%s\"\n",
+		fprintf(stderr, "Using auto-detected IIO context at URI \"%s\"\n",
 		iio_context_info_get_uri(info[0]));
 		ctx = iio_create_context_from_uri(iio_context_info_get_uri(info[0]));
 	} else {


### PR DESCRIPTION
When using iio_readdev, stdout is reserved for the data output; so
information messages about the context creation must be sent to stderr
so that the data stream is not polluted.

Fixes #583.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>