### PR TITLE
Sanitize context attributes for XML

### DIFF
--- a/iio-private.h
+++ b/iio-private.h
@@ -32,11 +32,17 @@
 
 #ifdef _MSC_BUILD
 #define inline __inline
-#define iio_snprintf sprintf_s
 #define iio_sscanf sscanf_s
 #else
-#define iio_snprintf snprintf
 #define iio_sscanf sscanf
+#endif
+
+#if defined(__MINGW32__)
+#   define __iio_printf __attribute__((__format__(ms_printf, 3, 4)))
+#elif defined(__GNUC__)
+#   define __iio_printf __attribute__((__format__(gnu_printf, 3, 4)))
+#else
+#   define __iio_printf
 #endif
 
 #define ARRAY_SIZE(x) (sizeof(x) ? sizeof(x) / sizeof((x)[0]) : 0)
@@ -282,6 +288,8 @@ struct iio_context_pdata * iio_context_get_pdata(const struct iio_context *ctx);
 
 int add_iio_dev_attr(struct iio_dev_attrs *attrs, const char *attr,
 		     const char *type, const char *dev_id);
+
+ssize_t __iio_printf iio_snprintf(char *buf, size_t len, const char *fmt, ...);
 
 #undef __api
 

--- a/iiod/dns-sd.c
+++ b/iiod/dns-sd.c
@@ -259,7 +259,7 @@ static void start_avahi_thd(struct thread_pool *pool, void *d)
 		if (ret || !strcmp(host, "none"))
 			goto again;
 
-		iio_snprintf(label, sizeof(label), "%s%s", IIOD_ON, host);
+		snprintf(label, sizeof(label), "%s%s", IIOD_ON, host);
 
 		if (!avahi.name)
 			avahi.name = avahi_strdup(label);

--- a/iiod/iiod.c
+++ b/iiod/iiod.c
@@ -88,7 +88,6 @@ static const char *options_descriptions[] = {
 	"Specify the number of USB pipes (ep couples) to use",
 };
 
-
 static void usage(void)
 {
 	unsigned int i;

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -343,7 +343,7 @@ static void print_value(struct parser_pdata *pdata, long value)
 		output(pdata, "\n");
 	} else {
 		char buf[128];
-		iio_snprintf(buf, sizeof(buf), "%li\n", value);
+		snprintf(buf, sizeof(buf), "%li\n", value);
 		output(pdata, buf);
 	}
 }
@@ -424,7 +424,7 @@ static ssize_t send_data(struct DevEntry *dev, struct ThdEntry *thd, size_t len)
 		/* Send the current mask */
 		for (i = dev->nb_words; i > 0 && ptr < buf + sizeof(buf);
 				i--, ptr += 8) {
-			iio_snprintf(ptr, length, "%08x", mask[i - 1]);
+			snprintf(ptr, length, "%08x", mask[i - 1]);
 			length -= 8;
 		}
 
@@ -830,7 +830,7 @@ static uint32_t *get_mask(const char *mask, size_t *len)
 	ptr = words + nb;
 	while (*mask) {
 		char buf[9];
-		iio_snprintf(buf, sizeof(buf), "%.*s", 8, mask);
+		snprintf(buf, sizeof(buf), "%.*s", 8, mask);
 		sscanf(buf, "%08x", --ptr);
 		mask += 8;
 		IIO_DEBUG("Mask[%lu]: 0x%08x\n",
@@ -1255,7 +1255,7 @@ ssize_t get_trigger(struct parser_pdata *pdata, struct iio_device *dev)
 		ret = strlen(trigger->name);
 		print_value(pdata, ret);
 
-		iio_snprintf(buf, sizeof(buf), "%s\n", trigger->name);
+		snprintf(buf, sizeof(buf), "%s\n", trigger->name);
 		ret = write_all(pdata, buf, ret + 1);
 	} else {
 		print_value(pdata, ret);

--- a/iiod/usbd.c
+++ b/iiod/usbd.c
@@ -97,14 +97,14 @@ static int usb_open_pipe(struct usbd_pdata *pdata, unsigned int pipe_id)
 	 * before opening the endpoints again. */
 	thread_pool_stop_and_wait(pdata->pool[pipe_id]);
 
-	iio_snprintf(buf, sizeof(buf), "%s/ep%u", pdata->ffs, pipe_id * 2 + 1);
+	snprintf(buf, sizeof(buf), "%s/ep%u", pdata->ffs, pipe_id * 2 + 1);
 	cpdata->ep_out = open(buf, O_WRONLY);
 	if (cpdata->ep_out < 0) {
 		err = -errno;
 		goto err_free_cpdata;
 	}
 
-	iio_snprintf(buf, sizeof(buf), "%s/ep%u", pdata->ffs, pipe_id * 2 + 2);
+	snprintf(buf, sizeof(buf), "%s/ep%u", pdata->ffs, pipe_id * 2 + 2);
 	cpdata->ep_in = open(buf, O_RDONLY);
 	if (cpdata->ep_in < 0) {
 		err = -errno;
@@ -352,7 +352,7 @@ int start_usb_daemon(struct iio_context *ctx, const char *ffs,
 		goto err_free_pdata_pool;
 	}
 
-	iio_snprintf(buf, sizeof(buf), "%s/ep0", ffs);
+	snprintf(buf, sizeof(buf), "%s/ep0", ffs);
 
 	pdata->ep0_fd = open(buf, O_RDWR);
 	if (pdata->ep0_fd < 0) {

--- a/utilities.c
+++ b/utilities.c
@@ -15,6 +15,7 @@
 
 #include <errno.h>
 #include <locale.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -314,4 +315,18 @@ wrong_str:
 	free(hostname);
 #endif
 	return NULL;
+}
+
+ssize_t __iio_printf iio_snprintf(char *buf, size_t len, const char *fmt, ...)
+{
+	va_list ap;
+	int ret;
+
+	va_start(ap, fmt);
+	ret = vsnprintf(buf, len, fmt, ap);
+	if (len && ret >= (ssize_t)len)
+		ret = -ERANGE;
+	va_end(ap);
+
+	return (ssize_t)ret;
 }


### PR DESCRIPTION
This set of commits work on sanitizing the context attributes, so that they can be used in XML.

I did move `iio_snprintf` to being its own function. See the corresponding commit for details. `vsnprintf` is listed as supported in Microsoft's docs, so I expect it to build under MSVC with no problems.