### PR TITLE
ERR_PTR

### DIFF
--- a/context.c
+++ b/context.c
@@ -100,29 +100,24 @@ static ssize_t iio_snprintf_context_xml(char *ptr, ssize_t len,
 }
 
 /* Returns a string containing the XML representation of this context */
-char * iio_context_create_xml(const struct iio_context *ctx)
+static char * iio_context_create_xml(const struct iio_context *ctx)
 {
 	ssize_t len;
 	char *str;
 
 	len = iio_snprintf_context_xml(NULL, 0, ctx);
-	if (len < 0) {
-		errno = -len;
-		return NULL;
-	}
+	if (len < 0)
+		return ERR_TO_PTR(len);
 
 	len++; /* room for terminating NULL */
 	str = malloc(len);
-	if (!str) {
-		errno = ENOMEM;
-		return NULL;
-	}
+	if (!str)
+		return ERR_TO_PTR(-ENOMEM);
 
 	len = iio_snprintf_context_xml(str, len, ctx);
 	if (len < 0) {
-		errno = -len;
 		free(str);
-		return NULL;
+		return ERR_TO_PTR(len);
 	}
 
 	return str;
@@ -290,8 +285,8 @@ int iio_context_init(struct iio_context *ctx)
 
 	if (!ctx->xml) {
 		ctx->xml = iio_context_create_xml(ctx);
-		if (!ctx->xml)
-			return -ENOMEM;
+		if (IS_ERR(ctx->xml))
+			return PTR_TO_ERR(ctx->xml);
 	}
 
 	return 0;

--- a/iio-private.h
+++ b/iio-private.h
@@ -113,6 +113,21 @@ static inline void *zalloc(size_t size)
 	return calloc(1, size);
 }
 
+static inline __check_ret bool IS_ERR(const void *ptr)
+{
+	return (uintptr_t)ptr >= (uintptr_t)-4095;
+}
+
+static inline __check_ret intptr_t PTR_TO_ERR(const void *ptr)
+{
+	return (intptr_t)ptr;
+}
+
+static inline __check_ret void * ERR_TO_PTR(intptr_t err)
+{
+	return (void *)err;
+}
+
 /*
  * If these structures are updated, the qsort functions defined in sort.c
  * may need to be updated.

--- a/iio-private.h
+++ b/iio-private.h
@@ -233,7 +233,6 @@ ssize_t iio_snprintf_channel_xml(char *str, ssize_t slen,
 ssize_t iio_snprintf_device_xml(char *str, ssize_t slen,
 				const struct iio_device *dev);
 
-char *iio_context_create_xml(const struct iio_context *ctx);
 int iio_context_init(struct iio_context *ctx);
 
 bool iio_device_is_tx(const struct iio_device *dev);


### PR DESCRIPTION
If you are familiar with the Linux kernel, you will know how useful these functions are.

The first commit adds `IS_ERR()`, `ERR_TO_PTR()` and `PTR_TO_ERR()` macros, which can be used to encode or retrieve error codes into pointers.

The second commit shows how it can be used to make sure the error codes are properly cascaded back to the calling process, by updating the `iio_context_create_xml()` function.