### PR TITLE
Add support for ZSTD-compressed metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,19 @@ else()
 	message(STATUS "Looking for libserialport : Failed; building without serial")
 endif()
 
+option(WITH_ZSTD "Support for ZSTD compressed metadata" OFF)
+if (WITH_ZSTD)
+	find_library(LIBZSTD_LIBRARIES zstd)
+	find_path(LIBZSTD_INCLUDE_DIR zstd.h)
+
+	if (NOT LIBZSTD_LIBRARIES OR NOT LIBZSTD_INCLUDE_DIR)
+		message(SEND_ERROR "Unable to find libzstd")
+	endif()
+
+	list(APPEND LIBS_TO_LINK ${LIBZSTD_LIBRARIES})
+	include_directories(${LIBZSTD_INCLUDE_DIR})
+endif (WITH_ZSTD)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
 if(WITH_NETWORK_BACKEND)

--- a/iio-config.h.cmakein
+++ b/iio-config.h.cmakein
@@ -20,6 +20,7 @@
 #cmakedefine01 HAVE_DNS_SD
 #cmakedefine01 HAVE_AVAHI
 #cmakedefine01 ENABLE_AIO
+#cmakedefine01 WITH_ZSTD
 
 #cmakedefine HAS_PIPE2
 #cmakedefine HAS_STRDUP

--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -58,6 +58,11 @@ if (ENABLE_AIO)
 	target_link_libraries(iiod ${LIBAIO_LIBRARIES})
 endif ()
 
+if (WITH_ZSTD)
+	include_directories(${LIBZSTD_INCLUDE_DIR})
+	target_link_libraries(iiod ${LIBZSTD_LIBRARIES})
+endif()
+
 add_definitions(-D_GNU_SOURCE=1)
 
 if (HAVE_AVAHI)

--- a/iiod/lexer.l
+++ b/iiod/lexer.l
@@ -32,6 +32,10 @@ WORD (([[:alpha:]]+,)|(iio:))?(-|_|\.|[[:alnum:]])+
 	return PRINT;
 }
 
+<INITIAL>ZPRINT|zprint {
+	return ZPRINT;
+}
+
 <INITIAL>EXIT|exit|QUIT|quit {
 	return EXIT;
 }

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -1352,7 +1352,8 @@ ssize_t read_line(struct parser_pdata *pdata, char *buf, size_t len)
 }
 
 void interpreter(struct iio_context *ctx, int fd_in, int fd_out, bool verbose,
-	bool is_socket, bool use_aio, struct thread_pool *pool)
+		 bool is_socket, bool use_aio, struct thread_pool *pool,
+		 const void *xml_zstd, size_t xml_zstd_len)
 {
 	yyscan_t scanner;
 	struct parser_pdata pdata;
@@ -1365,6 +1366,9 @@ void interpreter(struct iio_context *ctx, int fd_in, int fd_out, bool verbose,
 	pdata.fd_out = fd_out;
 	pdata.verbose = verbose;
 	pdata.pool = pool;
+
+	pdata.xml_zstd = xml_zstd;
+	pdata.xml_zstd_len = xml_zstd_len;
 
 	pdata.fd_in_is_socket = is_socket;
 	pdata.fd_out_is_socket = is_socket;

--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -60,6 +60,9 @@ struct parser_pdata {
 #endif
 	struct thread_pool *pool;
 
+	const void *xml_zstd;
+	size_t xml_zstd_len;
+
 	ssize_t (*writefd)(struct parser_pdata *pdata, const void *buf, size_t len);
 	ssize_t (*readfd)(struct parser_pdata *pdata, void *buf, size_t len);
 };
@@ -67,11 +70,13 @@ struct parser_pdata {
 extern bool server_demux; /* Defined in iiod.c */
 
 void interpreter(struct iio_context *ctx, int fd_in, int fd_out, bool verbose,
-	bool is_socket, bool use_aio, struct thread_pool *pool);
+		 bool is_socket, bool use_aio, struct thread_pool *pool,
+		 const void *xml_zstd, size_t xml_zstd_len);
 
 int start_usb_daemon(struct iio_context *ctx, const char *ffs,
 		bool debug, bool use_aio, unsigned int nb_pipes,
-		struct thread_pool *pool);
+		struct thread_pool *pool,
+		const void *xml_zstd, size_t xml_zstd_len);
 
 int open_dev(struct parser_pdata *pdata, struct iio_device *dev,
 		size_t samples_count, const char *mask, bool cyclic);

--- a/iiod/parser.y
+++ b/iiod/parser.y
@@ -66,6 +66,7 @@ ssize_t yy_input(yyscan_t scanner, char *buf, size_t max_size);
 %token OPEN
 %token CLOSE
 %token PRINT
+%token ZPRINT
 %token READ
 %token READBUF
 %token WRITEBUF
@@ -108,6 +109,8 @@ Line:
 		"\t\tClose the current session\n"
 		"\tPRINT\n"
 		"\t\tDisplays a XML string corresponding to the current IIO context\n"
+		"\tZPRINT\n"
+		"\t\tGet a compressed XML string corresponding to the current IIO context\n"
 		"\tVERSION\n"
 		"\t\tGet the version of libiio in use\n"
 		"\tTIMEOUT <timeout_ms>\n"
@@ -151,6 +154,25 @@ Line:
 		output(pdata, xml);
 		output(pdata, "\n");
 		YYACCEPT;
+	}
+	| ZPRINT END {
+		struct parser_pdata *pdata = yyget_extra(scanner);
+		if (pdata->xml_zstd) {
+			if (!pdata->verbose) {
+				char buf[128];
+				sprintf(buf, "%lu\n", (unsigned long)pdata->xml_zstd_len);
+				output(pdata, buf);
+			}
+			if (write_all(pdata, pdata->xml_zstd, pdata->xml_zstd_len) <= 0)
+				pdata->stop = true;
+			output(pdata, "\n");
+			YYACCEPT;
+		} else {
+			char buf[128];
+			sprintf(buf, "%d\n", -EINVAL);
+			output(pdata, buf);
+			YYABORT;
+		}
 	}
 	| TIMEOUT SPACE WORD END {
 		char *word = $3;

--- a/iiod/usbd.c
+++ b/iiod/usbd.c
@@ -45,6 +45,9 @@ struct usbd_pdata {
 	bool debug, use_aio;
 	struct thread_pool **pool;
 	unsigned int nb_pipes;
+
+	const void *xml_zstd;
+	size_t xml_zstd_len;
 };
 
 struct usbd_client_pdata {
@@ -70,7 +73,8 @@ static void usbd_client_thread(struct thread_pool *pool, void *d)
 
 	interpreter(pdata->pdata->ctx, pdata->ep_in, pdata->ep_out,
 			pdata->pdata->debug, false,
-			pdata->pdata->use_aio, pool);
+			pdata->pdata->use_aio, pool,
+			pdata->pdata->xml_zstd, pdata->pdata->xml_zstd_len);
 
 	close(pdata->ep_in);
 	close(pdata->ep_out);
@@ -327,7 +331,8 @@ static int write_header(int fd, unsigned int nb_pipes)
 
 int start_usb_daemon(struct iio_context *ctx, const char *ffs,
 		bool debug, bool use_aio, unsigned int nb_pipes,
-		struct thread_pool *pool)
+		struct thread_pool *pool,
+		const void *xml_zstd, size_t xml_zstd_len)
 {
 	struct usbd_pdata *pdata;
 	unsigned int i;
@@ -375,6 +380,8 @@ int start_usb_daemon(struct iio_context *ctx, const char *ffs,
 	pdata->ctx = ctx;
 	pdata->debug = debug;
 	pdata->use_aio = use_aio;
+	pdata->xml_zstd = xml_zstd;
+	pdata->xml_zstd_len = xml_zstd_len;
 
 	ret = thread_pool_add_thread(pool, usbd_main, pdata, "usbd_main_thd");
 	if (!ret)


### PR DESCRIPTION
When compiled WITH_ZSTD, the ZPRINT command will return the same XML
string the PRINT command returns, but compressed with the ZSTD
algorithm.

The XML string is compressed when IIOD starts, and as such, once started
this has zero overhead.

Then, the ZSTD-compressed payload that can be decompressed into
the original XML string of the remote context. If the remote IIOD does not
support ZPRINT, it will simply revert to using PRINT instead.

This can dramatically speed up context creation when using a slow
transport (e.g. serial), as the XML strings can be really big.

For instance, the XML string of the ADALM-Pluto is close to 25 KiB.
On a standard 57600 bps UART connection, this would take about ~3.4
seconds to transfer. The compressed payload amounts to only about
3.7 KiB, which would take about ~0.5 seconds to transfer.