### PR TITLE
Fix warnings under MinGW and Clang

### DIFF
--- a/iio-private.h
+++ b/iio-private.h
@@ -37,10 +37,8 @@
 #define iio_sscanf sscanf
 #endif
 
-#if defined(__MINGW32__)
-#   define __iio_printf __attribute__((__format__(ms_printf, 3, 4)))
-#elif defined(__GNUC__)
-#   define __iio_printf __attribute__((__format__(gnu_printf, 3, 4)))
+#if defined(__GNUC__)
+#   define __iio_printf __attribute__((__format__(printf, 3, 4)))
 #else
 #   define __iio_printf
 #endif


### PR DESCRIPTION
Use the 'printf' format on all GNU compilers, which includes the
MinGW-flavoured GCC and Clang (which is not GNU, but says it is).