### PR TITLE
iiod-client: Pass client data as pointer to struct iiod_client_pdata

### DIFF
--- a/iiod-client.c
+++ b/iiod-client.c
@@ -37,7 +37,8 @@ void iiod_client_mutex_unlock(struct iiod_client *client)
 }
 
 static ssize_t iiod_client_read_integer(struct iiod_client *client,
-		void *desc, int *val)
+					struct iiod_client_pdata *desc,
+					int *val)
 {
 	unsigned int i;
 	char buf[1024], *ptr = NULL, *end;
@@ -74,7 +75,8 @@ static ssize_t iiod_client_read_integer(struct iiod_client *client,
 }
 
 static int iiod_client_exec_command(struct iiod_client *client,
-		void *desc, const char *cmd)
+				    struct iiod_client_pdata *desc,
+				    const char *cmd)
 {
 	int resp;
 	ssize_t ret;
@@ -88,7 +90,8 @@ static int iiod_client_exec_command(struct iiod_client *client,
 }
 
 static ssize_t iiod_client_write_all(struct iiod_client *client,
-		void *desc, const void *src, size_t len)
+				     struct iiod_client_pdata *desc,
+				     const void *src, size_t len)
 {
 	struct iio_context_pdata *pdata = client->pdata;
 	const struct iiod_client_ops *ops = client->ops;
@@ -115,7 +118,8 @@ static ssize_t iiod_client_write_all(struct iiod_client *client,
 }
 
 static ssize_t iiod_client_read_all(struct iiod_client *client,
-		void *desc, void *dst, size_t len)
+				    struct iiod_client_pdata *desc,
+				    void *dst, size_t len)
 {
 	struct iio_context_pdata *pdata = client->pdata;
 	const struct iiod_client_ops *ops = client->ops;
@@ -173,8 +177,10 @@ void iiod_client_destroy(struct iiod_client *client)
 	free(client);
 }
 
-int iiod_client_get_version(struct iiod_client *client, void *desc,
-		unsigned int *major, unsigned int *minor, char *git_tag)
+int iiod_client_get_version(struct iiod_client *client,
+			    struct iiod_client_pdata *desc,
+			    unsigned int *major, unsigned int *minor,
+			    char *git_tag)
 {
 	struct iio_context_pdata *pdata = client->pdata;
 	const struct iiod_client_ops *ops = client->ops;
@@ -223,8 +229,10 @@ int iiod_client_get_version(struct iiod_client *client, void *desc,
 	return 0;
 }
 
-int iiod_client_get_trigger(struct iiod_client *client, void *desc,
-		const struct iio_device *dev, const struct iio_device **trigger)
+int iiod_client_get_trigger(struct iiod_client *client,
+			    struct iiod_client_pdata *desc,
+			    const struct iio_device *dev,
+			    const struct iio_device **trigger)
 {
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	unsigned int i, nb_devices = iio_context_get_devices_count(ctx);
@@ -278,8 +286,10 @@ out_unlock:
 	return ret;
 }
 
-int iiod_client_set_trigger(struct iiod_client *client, void *desc,
-		const struct iio_device *dev, const struct iio_device *trigger)
+int iiod_client_set_trigger(struct iiod_client *client,
+			    struct iiod_client_pdata *desc,
+			    const struct iio_device *dev,
+			    const struct iio_device *trigger)
 {
 	char buf[1024];
 	int ret;
@@ -299,8 +309,10 @@ int iiod_client_set_trigger(struct iiod_client *client, void *desc,
 	return ret;
 }
 
-int iiod_client_set_kernel_buffers_count(struct iiod_client *client, void *desc,
-		const struct iio_device *dev, unsigned int nb_blocks)
+int iiod_client_set_kernel_buffers_count(struct iiod_client *client,
+					 struct iiod_client_pdata *desc,
+					 const struct iio_device *dev,
+					 unsigned int nb_blocks)
 {
 	int ret;
 	char buf[1024];
@@ -315,7 +327,8 @@ int iiod_client_set_kernel_buffers_count(struct iiod_client *client, void *desc,
 }
 
 int iiod_client_set_timeout(struct iiod_client *client,
-		void *desc, unsigned int timeout)
+			    struct iiod_client_pdata *desc,
+			    unsigned int timeout)
 {
 	int ret;
 	char buf[1024];
@@ -328,8 +341,9 @@ int iiod_client_set_timeout(struct iiod_client *client,
 	return ret;
 }
 
-static int iiod_client_discard(struct iiod_client *client, void *desc,
-		char *buf, size_t buf_len, size_t to_discard)
+static int iiod_client_discard(struct iiod_client *client,
+			       struct iiod_client_pdata *desc,
+			       char *buf, size_t buf_len, size_t to_discard)
 {
 	do {
 		size_t read_len;
@@ -350,9 +364,12 @@ static int iiod_client_discard(struct iiod_client *client, void *desc,
 	return 0;
 }
 
-ssize_t iiod_client_read_attr(struct iiod_client *client, void *desc,
-		const struct iio_device *dev, const struct iio_channel *chn,
-		const char *attr, char *dest, size_t len, enum iio_attr_type type)
+ssize_t iiod_client_read_attr(struct iiod_client *client,
+			      struct iiod_client_pdata *desc,
+			      const struct iio_device *dev,
+			      const struct iio_channel *chn,
+			      const char *attr, char *dest,
+			      size_t len, enum iio_attr_type type)
 {
 	const char *id = iio_device_get_id(dev);
 	char buf[1024];
@@ -431,9 +448,12 @@ out_unlock:
 	return ret;
 }
 
-ssize_t iiod_client_write_attr(struct iiod_client *client, void *desc,
-		const struct iio_device *dev, const struct iio_channel *chn,
-		const char *attr, const char *src, size_t len, enum iio_attr_type type)
+ssize_t iiod_client_write_attr(struct iiod_client *client,
+			       struct iiod_client_pdata *desc,
+			       const struct iio_device *dev,
+			       const struct iio_channel *chn,
+			       const char *attr, const char *src,
+			       size_t len, enum iio_attr_type type)
 {
 	struct iio_context_pdata *pdata = client->pdata;
 	const struct iiod_client_ops *ops = client->ops;
@@ -510,7 +530,7 @@ out_unlock:
 
 static struct iio_context *
 iiod_client_create_context_private(struct iiod_client *client,
-				   void *desc, bool zstd)
+				   struct iiod_client_pdata *desc, bool zstd)
 {
 	const char *cmd = zstd ? "ZPRINT\r\n" : "PRINT\r\n";
 	struct iio_context *ctx = NULL;
@@ -592,13 +612,16 @@ out_unlock:
 	return ctx;
 }
 
-struct iio_context * iiod_client_create_context(struct iiod_client *client, void *desc)
+struct iio_context * iiod_client_create_context(struct iiod_client *client,
+						struct iiod_client_pdata *desc)
 {
 	return iiod_client_create_context_private(client, desc, WITH_ZSTD);
 }
 
-int iiod_client_open_unlocked(struct iiod_client *client, void *desc,
-		const struct iio_device *dev, size_t samples_count, bool cyclic)
+int iiod_client_open_unlocked(struct iiod_client *client,
+			      struct iiod_client_pdata *desc,
+			      const struct iio_device *dev,
+			      size_t samples_count, bool cyclic)
 {
 	char buf[1024], *ptr;
 	size_t i;
@@ -624,8 +647,9 @@ int iiod_client_open_unlocked(struct iiod_client *client, void *desc,
 	return iiod_client_exec_command(client, desc, buf);
 }
 
-int iiod_client_close_unlocked(struct iiod_client *client, void *desc,
-		const struct iio_device *dev)
+int iiod_client_close_unlocked(struct iiod_client *client,
+			       struct iiod_client_pdata *desc,
+			       const struct iio_device *dev)
 {
 	char buf[1024];
 
@@ -634,7 +658,8 @@ int iiod_client_close_unlocked(struct iiod_client *client, void *desc,
 }
 
 static int iiod_client_read_mask(struct iiod_client *client,
-		void *desc, uint32_t *mask, size_t words)
+				 struct iiod_client_pdata *desc,
+				 uint32_t *mask, size_t words)
 {
 	size_t i;
 	ssize_t ret;
@@ -668,9 +693,11 @@ out_buf_free:
 	return (int) ret;
 }
 
-ssize_t iiod_client_read_unlocked(struct iiod_client *client, void *desc,
-		const struct iio_device *dev, void *dst, size_t len,
-		uint32_t *mask, size_t words)
+ssize_t iiod_client_read_unlocked(struct iiod_client *client,
+				  struct iiod_client_pdata *desc,
+				  const struct iio_device *dev,
+				  void *dst, size_t len,
+				  uint32_t *mask, size_t words)
 {
 	unsigned int nb_channels = iio_device_get_channels_count(dev);
 	uintptr_t ptr = (uintptr_t) dst;
@@ -724,8 +751,10 @@ ssize_t iiod_client_read_unlocked(struct iiod_client *client, void *desc,
 	return read;
 }
 
-ssize_t iiod_client_write_unlocked(struct iiod_client *client, void *desc,
-		const struct iio_device *dev, const void *src, size_t len)
+ssize_t iiod_client_write_unlocked(struct iiod_client *client,
+				   struct iiod_client_pdata *desc,
+				   const struct iio_device *dev,
+				   const void *src, size_t len)
 {
 	ssize_t ret;
 	char buf[1024];

--- a/iiod-client.h
+++ b/iiod-client.h
@@ -13,15 +13,19 @@
 
 struct iio_mutex;
 struct iiod_client;
+struct iiod_client_pdata;
 struct iio_context_pdata;
 
 struct iiod_client_ops {
 	ssize_t (*write)(struct iio_context_pdata *pdata,
-			void *desc, const char *src, size_t len);
+			 struct iiod_client_pdata *desc,
+			 const char *src, size_t len);
 	ssize_t (*read)(struct iio_context_pdata *pdata,
-			void *desc, char *dst, size_t len);
+			struct iiod_client_pdata *desc,
+			char *dst, size_t len);
 	ssize_t (*read_line)(struct iio_context_pdata *pdata,
-			void *desc, char *dst, size_t len);
+			     struct iiod_client_pdata *desc,
+			     char *dst, size_t len);
 };
 
 void iiod_client_mutex_lock(struct iiod_client *client);
@@ -31,34 +35,65 @@ struct iiod_client * iiod_client_new(struct iio_context_pdata *pdata,
 				     const struct iiod_client_ops *ops);
 void iiod_client_destroy(struct iiod_client *client);
 
-int iiod_client_get_version(struct iiod_client *client, void *desc,
-		unsigned int *major, unsigned int *minor, char *git_tag);
-int iiod_client_get_trigger(struct iiod_client *client, void *desc,
-		const struct iio_device *dev,
-		const struct iio_device **trigger);
-int iiod_client_set_trigger(struct iiod_client *client, void *desc,
-		const struct iio_device *dev, const struct iio_device *trigger);
+int iiod_client_get_version(struct iiod_client *client,
+			    struct iiod_client_pdata *desc,
+			    unsigned int *major, unsigned int *minor,
+			    char *git_tag);
+
+int iiod_client_get_trigger(struct iiod_client *client,
+			    struct iiod_client_pdata *desc,
+			    const struct iio_device *dev,
+			    const struct iio_device **trigger);
+
+int iiod_client_set_trigger(struct iiod_client *client,
+			    struct iiod_client_pdata *desc,
+			    const struct iio_device *dev,
+			    const struct iio_device *trigger);
+
 int iiod_client_set_kernel_buffers_count(struct iiod_client *client,
-		void *desc, const struct iio_device *dev, unsigned int nb_blocks);
+					 struct iiod_client_pdata *desc,
+					 const struct iio_device *dev,
+					 unsigned int nb_blocks);
+
 int iiod_client_set_timeout(struct iiod_client *client,
-		void *desc, unsigned int timeout);
-ssize_t iiod_client_read_attr(struct iiod_client *client, void *desc,
-		const struct iio_device *dev, const struct iio_channel *chn,
-		const char *attr, char *dest, size_t len, enum iio_attr_type type);
-ssize_t iiod_client_write_attr(struct iiod_client *client, void *desc,
-		const struct iio_device *dev, const struct iio_channel *chn,
-		const char *attr, const char *src, size_t len, enum iio_attr_type type);
-int iiod_client_open_unlocked(struct iiod_client *client, void *desc,
-		const struct iio_device *dev, size_t samples_count,
-		bool cyclic);
-int iiod_client_close_unlocked(struct iiod_client *client, void *desc,
-		const struct iio_device *dev);
-ssize_t iiod_client_read_unlocked(struct iiod_client *client, void *desc,
-		const struct iio_device *dev, void *dst, size_t len,
-		uint32_t *mask, size_t words);
-ssize_t iiod_client_write_unlocked(struct iiod_client *client, void *desc,
-		const struct iio_device *dev, const void *src, size_t len);
-struct iio_context * iiod_client_create_context(
-		struct iiod_client *client, void *desc);
+			    struct iiod_client_pdata *desc,
+			    unsigned int timeout);
+
+ssize_t iiod_client_read_attr(struct iiod_client *client,
+			      struct iiod_client_pdata *desc,
+			      const struct iio_device *dev,
+			      const struct iio_channel *chn,
+			      const char *attr, char *dest, size_t len,
+			      enum iio_attr_type type);
+
+ssize_t iiod_client_write_attr(struct iiod_client *client,
+			       struct iiod_client_pdata *desc,
+			       const struct iio_device *dev,
+			       const struct iio_channel *chn,
+			       const char *attr, const char *src,
+			       size_t len, enum iio_attr_type type);
+
+int iiod_client_open_unlocked(struct iiod_client *client,
+			      struct iiod_client_pdata *desc,
+			      const struct iio_device *dev,
+			      size_t samples_count, bool cyclic);
+
+int iiod_client_close_unlocked(struct iiod_client *client,
+			       struct iiod_client_pdata *desc,
+			       const struct iio_device *dev);
+
+ssize_t iiod_client_read_unlocked(struct iiod_client *client,
+				  struct iiod_client_pdata *desc,
+				  const struct iio_device *dev,
+				  void *dst, size_t len,
+				  uint32_t *mask, size_t words);
+
+ssize_t iiod_client_write_unlocked(struct iiod_client *client,
+				   struct iiod_client_pdata *desc,
+				   const struct iio_device *dev,
+				   const void *src, size_t len);
+
+struct iio_context * iiod_client_create_context(struct iiod_client *client,
+						struct iiod_client_pdata *desc);
 
 #endif /* _IIOD_CLIENT_H */

--- a/network-unix.c
+++ b/network-unix.c
@@ -37,7 +37,7 @@ int set_blocking_mode(int fd, bool blocking)
 #if WITH_NETWORK_EVENTFD
 #include <sys/eventfd.h>
 
-int create_cancel_fd(struct iio_network_io_context *io_ctx)
+int create_cancel_fd(struct iiod_client_pdata *io_ctx)
 {
 	io_ctx->cancel_fd[0] = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
 	if (io_ctx->cancel_fd[0] < 0)
@@ -47,7 +47,7 @@ int create_cancel_fd(struct iio_network_io_context *io_ctx)
 
 #else /* WITH_NETWORK_EVENTFD */
 
-int create_cancel_fd(struct iio_network_io_context *io_ctx)
+int create_cancel_fd(struct iiod_client_pdata *io_ctx)
 {
 	int ret;
 
@@ -74,14 +74,14 @@ err_close:
 }
 #endif /* WITH_NETWORK_EVENTFD */
 
-void cleanup_cancel(struct iio_network_io_context *io_ctx)
+void cleanup_cancel(struct iiod_client_pdata *io_ctx)
 {
 	close(io_ctx->cancel_fd[0]);
 	if (!WITH_NETWORK_EVENTFD)
 		close(io_ctx->cancel_fd[1]);
 }
 
-int setup_cancel(struct iio_network_io_context *io_ctx)
+int setup_cancel(struct iiod_client_pdata *io_ctx)
 {
 	int ret;
 
@@ -94,7 +94,7 @@ int setup_cancel(struct iio_network_io_context *io_ctx)
 
 #define CANCEL_WR_FD (!WITH_NETWORK_EVENTFD)
 
-void do_cancel(struct iio_network_io_context *io_ctx)
+void do_cancel(struct iiod_client_pdata *io_ctx)
 {
 	uint64_t event = 1;
 	int ret;
@@ -108,7 +108,7 @@ void do_cancel(struct iio_network_io_context *io_ctx)
 	}
 }
 
-int wait_cancellable(struct iio_network_io_context *io_ctx, bool read)
+int wait_cancellable(struct iiod_client_pdata *io_ctx, bool read)
 {
 	struct pollfd pfd[2];
 	int ret;

--- a/network-windows.c
+++ b/network-windows.c
@@ -30,7 +30,7 @@ int set_blocking_mode(int s, bool blocking)
 	return 0;
 }
 
-int setup_cancel(struct iio_network_io_context *io_ctx)
+int setup_cancel(struct iiod_client_pdata *io_ctx)
 {
 	io_ctx->events[0] = WSACreateEvent();
 	if (io_ctx->events[0] == WSA_INVALID_EVENT)
@@ -45,18 +45,18 @@ int setup_cancel(struct iio_network_io_context *io_ctx)
 	return 0;
 }
 
-void cleanup_cancel(struct iio_network_io_context *io_ctx)
+void cleanup_cancel(struct iiod_client_pdata *io_ctx)
 {
 	WSACloseEvent(io_ctx->events[0]);
 	WSACloseEvent(io_ctx->events[1]);
 }
 
-void do_cancel(struct iio_network_io_context *io_ctx)
+void do_cancel(struct iiod_client_pdata *io_ctx)
 {
 	WSASetEvent(io_ctx->events[1]);
 }
 
-int wait_cancellable(struct iio_network_io_context *io_ctx, bool read)
+int wait_cancellable(struct iiod_client_pdata *io_ctx, bool read)
 {
 	long wsa_events = FD_CLOSE;
 	DWORD ret;

--- a/network.c
+++ b/network.c
@@ -48,14 +48,14 @@
 #define DEFAULT_TIMEOUT_MS 5000
 
 struct iio_context_pdata {
-	struct iio_network_io_context io_ctx;
+	struct iiod_client_pdata io_ctx;
 	struct addrinfo *addrinfo;
 	struct iiod_client *iiod_client;
 	bool msg_trunc_supported;
 };
 
 struct iio_device_pdata {
-	struct iio_network_io_context io_ctx;
+	struct iiod_client_pdata io_ctx;
 #ifdef WITH_NETWORK_GET_BUFFER
 	int memfd;
 	void *mmap_addr;
@@ -65,7 +65,7 @@ struct iio_device_pdata {
 	struct iio_mutex *lock;
 };
 
-static ssize_t network_recv(struct iio_network_io_context *io_ctx,
+static ssize_t network_recv(struct iiod_client_pdata *io_ctx,
 		void *data, size_t len, int flags)
 {
 	ssize_t ret;
@@ -95,7 +95,7 @@ static ssize_t network_recv(struct iio_network_io_context *io_ctx,
 	return ret;
 }
 
-static ssize_t network_send(struct iio_network_io_context *io_ctx,
+static ssize_t network_send(struct iiod_client_pdata *io_ctx,
 		const void *data, size_t len, int flags)
 {
 	ssize_t ret;
@@ -126,7 +126,7 @@ static ssize_t network_send(struct iio_network_io_context *io_ctx,
 	return ret;
 }
 
-static ssize_t write_all(struct iio_network_io_context *io_ctx,
+static ssize_t write_all(struct iiod_client_pdata *io_ctx,
 		const void *src, size_t len)
 {
 	uintptr_t ptr = (uintptr_t) src;
@@ -140,7 +140,7 @@ static ssize_t write_all(struct iio_network_io_context *io_ctx,
 	return (ssize_t)(ptr - (uintptr_t) src);
 }
 
-static ssize_t write_command(struct iio_network_io_context *io_ctx,
+static ssize_t write_command(struct iiod_client_pdata *io_ctx,
 		const char *cmd)
 {
 	ssize_t ret;
@@ -456,7 +456,7 @@ static ssize_t network_write(const struct iio_device *dev,
 
 #ifdef WITH_NETWORK_GET_BUFFER
 
-static ssize_t read_all(struct iio_network_io_context *io_ctx,
+static ssize_t read_all(struct iiod_client_pdata *io_ctx,
 		void *dst, size_t len)
 {
 	uintptr_t ptr = (uintptr_t) dst;
@@ -472,7 +472,7 @@ static ssize_t read_all(struct iio_network_io_context *io_ctx,
 	return (ssize_t)(ptr - (uintptr_t) dst);
 }
 
-static int read_integer(struct iio_network_io_context *io_ctx, long *val)
+static int read_integer(struct iiod_client_pdata *io_ctx, long *val)
 {
 	unsigned int i;
 	char buf[1024], *ptr;
@@ -501,7 +501,7 @@ static int read_integer(struct iio_network_io_context *io_ctx, long *val)
 	return 0;
 }
 
-static ssize_t network_read_mask(struct iio_network_io_context *io_ctx,
+static ssize_t network_read_mask(struct iiod_client_pdata *io_ctx,
 		uint32_t *mask, size_t words)
 {
 	long read_len;
@@ -541,7 +541,7 @@ static ssize_t network_read_mask(struct iio_network_io_context *io_ctx,
 	return (ssize_t) read_len;
 }
 
-static ssize_t read_error_code(struct iio_network_io_context *io_ctx)
+static ssize_t read_error_code(struct iiod_client_pdata *io_ctx)
 {
 	/*
 	 * The server returns two integer codes.
@@ -923,28 +923,31 @@ static const struct iio_backend_ops network_ops = {
 };
 
 static ssize_t network_write_data(struct iio_context_pdata *pdata,
-		void *io_data, const char *src, size_t len)
+				  struct iiod_client_pdata *io_data,
+				  const char *src, size_t len)
 {
-	struct iio_network_io_context *io_ctx = io_data;
+	struct iiod_client_pdata *io_ctx = io_data;
 
 	return network_send(io_ctx, src, len, 0);
 }
 
 static ssize_t network_read_data(struct iio_context_pdata *pdata,
-		void *io_data, char *dst, size_t len)
+				 struct iiod_client_pdata *io_data,
+				 char *dst, size_t len)
 {
-	struct iio_network_io_context *io_ctx = io_data;
+	struct iiod_client_pdata *io_ctx = io_data;
 
 	return network_recv(io_ctx, dst, len, 0);
 }
 
 static ssize_t network_read_line(struct iio_context_pdata *pdata,
-		void *io_data, char *dst, size_t len)
+				 struct iiod_client_pdata *io_data,
+				 char *dst, size_t len)
 {
 	bool found = false;
 	size_t i;
 #ifdef __linux__
-	struct iio_network_io_context *io_ctx = io_data;
+	struct iiod_client_pdata *io_ctx = io_data;
 	ssize_t ret;
 	size_t bytes_read = 0;
 
@@ -1019,7 +1022,7 @@ static const struct iiod_client_ops network_iiod_client_ops = {
  * applications this is not something that can be detected at compile time. If
  * we want to support WSL we have to have a runtime workaround.
  */
-static bool msg_trunc_supported(struct iio_network_io_context *io_ctx)
+static bool msg_trunc_supported(struct iiod_client_pdata *io_ctx)
 {
 	int ret;
 
@@ -1028,7 +1031,7 @@ static bool msg_trunc_supported(struct iio_network_io_context *io_ctx)
 	return ret != -EFAULT && ret != -EINVAL;
 }
 #else
-static bool msg_trunc_supported(struct iio_network_io_context *io_ctx)
+static bool msg_trunc_supported(struct iiod_client_pdata *io_ctx)
 {
 	return false;
 }

--- a/network.h
+++ b/network.h
@@ -14,7 +14,7 @@
 
 struct addrinfo;
 
-struct iio_network_io_context {
+struct iiod_client_pdata {
 	int fd;
 
 	/* Only buffer IO contexts can be cancelled. */
@@ -25,10 +25,10 @@ struct iio_network_io_context {
 	unsigned int timeout_ms;
 };
 
-int setup_cancel(struct iio_network_io_context *io_ctx);
-void cleanup_cancel(struct iio_network_io_context *io_ctx);
-void do_cancel(struct iio_network_io_context *io_ctx);
-int wait_cancellable(struct iio_network_io_context *io_ctx, bool read);
+int setup_cancel(struct iiod_client_pdata *io_ctx);
+void cleanup_cancel(struct iiod_client_pdata *io_ctx);
+void do_cancel(struct iiod_client_pdata *io_ctx);
+int wait_cancellable(struct iiod_client_pdata *io_ctx, bool read);
 
 int do_create_socket(const struct addrinfo *addrinfo);
 

--- a/serial.c
+++ b/serial.c
@@ -255,7 +255,8 @@ static int serial_set_kernel_buffers_count(const struct iio_device *dev,
 }
 
 static ssize_t serial_write_data(struct iio_context_pdata *pdata,
-		void *io_data, const char *data, size_t len)
+				 struct iiod_client_pdata *io_data,
+				 const char *data, size_t len)
 {
 	ssize_t ret = (ssize_t) libserialport_to_errno(sp_blocking_write(
 				pdata->port, data, len, pdata->timeout_ms));
@@ -274,7 +275,8 @@ static ssize_t serial_write_data(struct iio_context_pdata *pdata,
 }
 
 static ssize_t serial_read_data(struct iio_context_pdata *pdata,
-		void *io_data, char *buf, size_t len)
+				struct iiod_client_pdata *io_data,
+				char *buf, size_t len)
 {
 	ssize_t ret = (ssize_t) libserialport_to_errno(sp_blocking_read_next(
 				pdata->port, buf, len, pdata->timeout_ms));
@@ -290,7 +292,8 @@ static ssize_t serial_read_data(struct iio_context_pdata *pdata,
 }
 
 static ssize_t serial_read_line(struct iio_context_pdata *pdata,
-		void *io_data, char *buf, size_t len)
+				struct iiod_client_pdata *io_data,
+				char *buf, size_t len)
 {
 	size_t i;
 	bool found = false;

--- a/usb.c
+++ b/usb.c
@@ -33,7 +33,7 @@ struct iio_usb_ep_couple {
 	struct iio_mutex *lock;
 };
 
-struct iio_usb_io_context {
+struct iiod_client_pdata {
 	struct iio_usb_ep_couple *ep;
 
 	struct iio_mutex *lock;
@@ -56,14 +56,14 @@ struct iio_context_pdata {
 
 	unsigned int timeout_ms;
 
-	struct iio_usb_io_context io_ctx;
+	struct iiod_client_pdata io_ctx;
 };
 
 struct iio_device_pdata {
 	struct iio_mutex *lock;
 
 	bool opened;
-	struct iio_usb_io_context io_ctx;
+	struct iiod_client_pdata io_ctx;
 };
 
 static const unsigned int libusb_to_errno_codes[] = {
@@ -102,7 +102,7 @@ static unsigned int libusb_to_errno(int error)
 	}
 }
 
-static int usb_io_context_init(struct iio_usb_io_context *io_ctx)
+static int usb_io_context_init(struct iiod_client_pdata *io_ctx)
 {
 	io_ctx->lock = iio_mutex_create();
 	if (!io_ctx->lock)
@@ -111,7 +111,7 @@ static int usb_io_context_init(struct iio_usb_io_context *io_ctx)
 	return 0;
 }
 
-static void usb_io_context_exit(struct iio_usb_io_context *io_ctx)
+static void usb_io_context_exit(struct iiod_client_pdata *io_ctx)
 {
 	if (io_ctx->lock) {
 		iio_mutex_destroy(io_ctx->lock);
@@ -564,7 +564,7 @@ static void LIBUSB_CALL sync_transfer_cb(struct libusb_transfer *transfer)
 }
 
 static int usb_sync_transfer(struct iio_context_pdata *pdata,
-	struct iio_usb_io_context *io_ctx, unsigned int ep_type,
+	struct iiod_client_pdata *io_ctx, unsigned int ep_type,
 	char *data, size_t len, int *transferred)
 {
 	unsigned char ep;
@@ -669,7 +669,8 @@ unlock:
 }
 
 static ssize_t write_data_sync(struct iio_context_pdata *pdata,
-		void *ep, const char *data, size_t len)
+			       struct iiod_client_pdata *ep,
+			       const char *data, size_t len)
 {
 	int transferred, ret;
 
@@ -682,7 +683,8 @@ static ssize_t write_data_sync(struct iio_context_pdata *pdata,
 }
 
 static ssize_t read_data_sync(struct iio_context_pdata *pdata,
-		void *ep, char *buf, size_t len)
+			      struct iiod_client_pdata *ep,
+			      char *buf, size_t len)
 {
 	int transferred, ret;
 


### PR DESCRIPTION
Instead of having the iiod-client API use a void* pointer to represent
the client platform data, use a pointer to a 'struct iiod_client_pdata',
that can be defined differently in each client.

This makes the code more robust as the compiler will properly enforce
type safety.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>