### PR TITLE
Use gnu_printf format with GCC

### DIFF
--- a/iio-private.h
+++ b/iio-private.h
@@ -37,7 +37,9 @@
 #define iio_sscanf sscanf
 #endif
 
-#if defined(__GNUC__)
+#if defined(__MINGW32__)
+#   define __iio_printf __attribute__((__format__(gnu_printf, 3, 4)))
+#elif defined(__GNUC__)
 #   define __iio_printf __attribute__((__format__(printf, 3, 4)))
 #else
 #   define __iio_printf


### PR DESCRIPTION
We don't actually *need* any of the GNU printf format specifiers.

However, older versions of MinGW will complain about C99-compliant
specifiers like %lld unless 'gnu_printf' is used.

Since this is used only with GCC, which is the "GNU C Compiler", it is
pretty safe to enable the 'gnu_printf' format unconditionally.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>