### PR TITLE
IIOD: Drop dependency on private headers

### DIFF
--- a/iio-private.h
+++ b/iio-private.h
@@ -11,21 +11,7 @@
 
 /* Include public interface */
 #include "iio.h"
-
-#ifdef _WIN32
-#   ifdef LIBIIO_EXPORTS
-#	define __api __declspec(dllexport)
-#   else
-#	define __api __declspec(dllimport)
-#   endif
-#elif __GNUC__ >= 4
-#   define __api __attribute__((visibility ("default")))
-#else
-#   define __api
-#endif
-
 #include "iio-backend.h"
-
 #include "iio-config.h"
 
 #include <stdbool.h>
@@ -270,8 +256,7 @@ void dnssd_context_scan_free(struct iio_scan_backend_context *ctx);
 int dnssd_context_scan(struct iio_scan_backend_context *ctx,
 		struct iio_scan_result *scan_result);
 
-/* This function is not part of the API, but is used by the IIO daemon */
-__api ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
+ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 		const uint32_t *mask, size_t words);
 
 void iio_channel_init_finalize(struct iio_channel *chn);
@@ -292,7 +277,5 @@ int add_iio_dev_attr(struct iio_dev_attrs *attrs, const char *attr,
 		     const char *type, const char *dev_id);
 
 ssize_t __iio_printf iio_snprintf(char *buf, size_t len, const char *fmt, ...);
-
-#undef __api
 
 #endif /* __IIO_PRIVATE_H__ */

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -10,7 +10,6 @@
 #include "parser.h"
 #include "thread-pool.h"
 #include "../debug.h"
-#include "../iio-private.h"
 
 #include <errno.h>
 #include <limits.h>

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -712,8 +712,17 @@ static void rw_thd(struct thread_pool *pool, void *d)
 
 			pthread_mutex_lock(&entry->thdlist_lock);
 
-			/* Reset the size of the buffer to its maximum size */
-			entry->buf->data_length = entry->buf->length;
+			/* Reset the size of the buffer to its maximum size.
+			 *
+			 * XXX(pcercuei): There is no way to perform this with
+			 * the public libiio API. However, it probably does not
+			 * matter; we only need to reset the size of the buffer
+			 * if the buffer was used for receiving samples, and
+			 * to date there is no IIO device that supports both
+			 * receiving and sending samples.
+			 *
+			 * entry->buf->data_length = entry->buf->length;
+			 */
 
 			/* Same comment as above */
 			for (thd = SLIST_FIRST(&entry->thdlist_head);

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -136,6 +136,21 @@ static unsigned int get_channel_number(const struct iio_channel *chn)
 	return i;
 }
 
+static inline const char *dev_label_or_name_or_id(const struct iio_device *dev)
+{
+	const char *name;
+
+	name = iio_device_get_label(dev);
+	if (name)
+		return name;
+
+	name = iio_device_get_name(dev);
+	if (name)
+		return name;
+
+	return iio_device_get_id(dev);
+}
+
 #if WITH_AIO
 static ssize_t async_io(struct parser_pdata *pdata, void *buf, size_t len,
 	bool do_read)
@@ -542,7 +557,7 @@ static void rw_thd(struct thread_pool *pool, void *d)
 	ssize_t ret = 0;
 
 	IIO_DEBUG("R/W thread started for device %s\n",
-			dev->name ? dev->name : dev->id);
+		  dev_label_or_name_or_id(dev));
 
 	while (true) {
 		bool has_readers = false, has_writers = false,
@@ -602,7 +617,7 @@ static void rw_thd(struct thread_pool *pool, void *d)
 			}
 
 			IIO_DEBUG("IIO device %s reopened with new mask:\n",
-					dev->id);
+				  dev_label_or_name_or_id(dev));
 			for (i = 0; i < nb_words; i++)
 				IIO_DEBUG("Mask[%i] = 0x%08x\n", i, entry->mask[i]);
 			entry->update_mask = false;
@@ -759,7 +774,7 @@ static void rw_thd(struct thread_pool *pool, void *d)
 	pthread_mutex_unlock(&devlist_lock);
 
 	IIO_DEBUG("Stopping R/W thread for device %s\n",
-			dev->name ? dev->name : dev->id);
+		  dev_label_or_name_or_id(dev));
 
 	dev_entry_put(entry);
 }

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -95,6 +95,7 @@ struct DevEntry {
 	struct iio_device *dev;
 	struct iio_buffer *buf;
 	unsigned int sample_size, nb_clients;
+	unsigned int samples_count;
 	bool update_mask;
 	bool cyclic;
 	bool closed;
@@ -507,7 +508,7 @@ static ssize_t receive_data(struct DevEntry *dev, struct ThdEntry *thd)
 	if (dev->sample_size == thd->sample_size) {
 		/* Short path: Receive directly in the buffer */
 
-		size_t len = dev->buf->length;
+		size_t len = dev->sample_size * dev->samples_count;
 		if (thd->nb < len)
 			len = thd->nb;
 
@@ -630,6 +631,7 @@ static void rw_thd(struct thread_pool *pool, void *d)
 			entry->update_mask = false;
 
 			entry->sample_size = iio_device_get_sample_size(dev);
+			entry->samples_count = samples_count;
 			mask_updated = true;
 		}
 

--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -9,11 +9,11 @@
 #ifndef __OPS_H__
 #define __OPS_H__
 
-#include "../iio-private.h"
 #include "queue.h"
 
 #include <endian.h>
 #include <errno.h>
+#include <iio.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -38,8 +38,20 @@
 	 (((x) & 0x0000ff00) <<  8) | (((x) & 0x000000ff) << 24))
 #endif
 
+#define BIT(x) (1 << (x))
+#define BIT_MASK(bit) BIT((bit) % 32)
+#define BIT_WORD(bit) ((bit) / 32)
+#define TEST_BIT(addr, bit) (!!(*(((uint32_t *) addr) + BIT_WORD(bit)) \
+		& BIT_MASK(bit)))
+
 struct thread_pool;
 extern struct thread_pool *main_thread_pool;
+
+enum iio_attr_type {
+	IIO_ATTR_TYPE_DEVICE,
+	IIO_ATTR_TYPE_DEBUG,
+	IIO_ATTR_TYPE_BUFFER,
+};
 
 struct parser_pdata {
 	struct iio_context *ctx;
@@ -68,6 +80,11 @@ struct parser_pdata {
 };
 
 extern bool server_demux; /* Defined in iiod.c */
+
+static inline void *zalloc(size_t size)
+{
+	return calloc(1, size);
+}
 
 void interpreter(struct iio_context *ctx, int fd_in, int fd_out, bool verbose,
 		 bool is_socket, bool use_aio, struct thread_pool *pool,

--- a/iiod/usbd.c
+++ b/iiod/usbd.c
@@ -7,7 +7,6 @@
  */
 
 #include "../debug.h"
-#include "../iio-private.h"
 #include "ops.h"
 #include "thread-pool.h"
 


### PR DESCRIPTION
With this patchset, IIOD does not depend anymore on any of the private functions and structures of libiio, and only accesses everything through the public API.

One "functionality" of IIOD has been dropped in the process: the support for IIO devices that are both input and output. I think this case never happened and will never happen, so it should be OK.