### PR TITLE
Various CMake/Network fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,6 +368,7 @@ if(WITH_NETWORK_BACKEND)
 	set(NEED_LIBXML2 1)
 else()
 	message(STATUS "Building without network support")
+	set(HAVE_DNS_SD OFF)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,19 +303,24 @@ if(WITH_NETWORK_BACKEND)
 		option(WITH_NETWORK_GET_BUFFER "Enable experimental zero-copy transfers" OFF)
 		if (WITH_NETWORK_GET_BUFFER)
 			include(CheckCSourceCompiles)
-			check_c_source_compiles("#include <fcntl.h>\nint main(void) { return O_TMPFILE; }" HAS_O_TMPFILE)
+			check_c_source_compiles("#define _GNU_SOURCE=1\n#include <fcntl.h>\nint main(void) { return O_TMPFILE; }"
+				HAS_O_TMPFILE)
 
 			if (NOT HAS_O_TMPFILE)
 				message(SEND_ERROR "Zero-copy requires the O_TMPFILE flag, which is not available on the system.")
 			endif()
 		endif()
 
-		check_c_source_compiles("#include <sys/eventfd.h>\nint main(void) { return eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK); }" WITH_NETWORK_EVENTFD)
-	endif()
+		check_c_source_compiles("#include <sys/eventfd.h>\nint main(void) { return eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK); }"
+			WITH_NETWORK_EVENTFD)
+		if (NOT WITH_NETWORK_EVENTFD)
+			check_c_source_compiles("#define _GNU_SOURCE=1\n#include <unistd.h>\n#include <fcntl.h>\nint main(void) { int fd[2]; return pipe2(fd, O_CLOEXEC | O_NONBLOCK); }"
+				HAS_PIPE2)
+		endif()
 
-	if(NOT WIN32)
-		include(CheckCSourceCompiles)
-		check_c_source_compiles("#include <unistd.h>\n#include <fcntl.h>\nint main(void) { int fd[2]; return pipe2(fd, O_CLOEXEC | O_NONBLOCK); }" HAS_PIPE2)
+		if (WITH_NETWORK_GET_BUFFER OR HAS_PIPE2)
+			add_definitions(-D_GNU_SOURCE=1)
+		endif()
 	endif()
 
 	list(APPEND LIBIIO_CFILES network.c)

--- a/network-unix.c
+++ b/network-unix.c
@@ -38,7 +38,7 @@ int set_blocking_mode(int fd, bool blocking)
 #if WITH_NETWORK_EVENTFD
 #include <sys/eventfd.h>
 
-int create_cancel_fd(struct iiod_client_pdata *io_ctx)
+static int create_cancel_fd(struct iiod_client_pdata *io_ctx)
 {
 	io_ctx->cancel_fd[0] = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
 	if (io_ctx->cancel_fd[0] < 0)
@@ -48,7 +48,7 @@ int create_cancel_fd(struct iiod_client_pdata *io_ctx)
 
 #else /* WITH_NETWORK_EVENTFD */
 
-int create_cancel_fd(struct iiod_client_pdata *io_ctx)
+static int create_cancel_fd(struct iiod_client_pdata *io_ctx)
 {
 	int ret;
 

--- a/network.c
+++ b/network.c
@@ -27,9 +27,13 @@
  * Old OSes (CentOS 7, Ubuntu 16.04) require this for the
  * IN6_IS_ADDR_LINKLOCAL() macro to work.
  */
+#ifndef _GNU_SOURCE
 #define __USE_MISC
 #include <netinet/in.h>
 #undef __USE_MISC
+#else
+#include <netinet/in.h>
+#endif
 
 #include <arpa/inet.h>
 #include <netdb.h>


### PR DESCRIPTION
I broke things by removing unconditionally `_GNU_SOURCE` in a previous commit, the `WITH_NETWORK_GET_BUFFER` option does need it.

Note that this option is OFF by default which explains why nobody noticed.