### PR TITLE
IIOD: Fix building with AIO

### DIFF
--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -9,6 +9,7 @@
 #ifndef __OPS_H__
 #define __OPS_H__
 
+#include "../iio-config.h"
 #include "queue.h"
 
 #include <endian.h>


### PR DESCRIPTION
This header used to get pulled in via iio-private.h which was removed in commit
3c36a0cc7da78ef01d1bef3bd501952b71f85962.

Signed-off-by: Edward Kigwana <ekigwana@gmail.com>