### PR TITLE
CMakeLists.txt: Disable WITH_SERIAL_BACKEND by default

### DIFF
--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -48,7 +48,7 @@ handle_default() {
 	if [ "${OS_VERSION}" = xenial ] ; then
 		FLAGS="${FLAGS} -DWITH_SERIAL_BACKEND=OFF"
 	else
-		FLAGS="${FLAGS} -DWITH_ZSTD=ON"
+		FLAGS="${FLAGS} -DWITH_SERIAL_BACKEND=ON -DWITH_ZSTD=ON"
 	fi
 
 	echo "### cmake ${FLAGS}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,13 +250,12 @@ if(WITH_LOCAL_BACKEND)
 	endif()
 endif()
 
-option(WITH_SERIAL_BACKEND "Enable the serial backend" ON)
+option(WITH_SERIAL_BACKEND "Enable the serial backend" OFF)
 if (WITH_SERIAL_BACKEND)
 	find_library(LIBSERIALPORT_LIBRARIES serialport)
 	find_path(LIBSERIALPORT_INCLUDE_DIR libserialport.h)
 	if (NOT LIBSERIALPORT_LIBRARIES OR NOT LIBSERIALPORT_INCLUDE_DIR)
-		message(SEND_ERROR "Unable to find libserialport dependency.\n"
-			"If you want to disable the serial backend, set WITH_SERIAL_BACKEND=OFF.")
+		message(SEND_ERROR "Unable to find libserialport dependency.\n")
 	else()
 		message(STATUS "Looking for libserialport : Found")
 


### PR DESCRIPTION
https://ci.appveyor.com/project/analogdevicesinc/scopy/builds/39249068/job/yh1k2u4t425vsxp5

We got this error when building libiio. We could of course set cmake with -DWITH_SERIAL_BACKEND=OFF and it would work. However in my opinion the serial backend should not be enabled by default, but rather be specifically-enabled by the user (the user will know he wants to use the serial backend)

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>