### PR TITLE
Context scan cleanups

### DIFF
--- a/dns_sd.c
+++ b/dns_sd.c
@@ -77,10 +77,6 @@ static void dnssd_remove_node(struct dns_sd_discovery_data **ddata, int n)
  * DNS Service Discovery is turned on
  */
 
-struct iio_scan_backend_context {
-	struct addrinfo *res;
-};
-
 static int dnssd_fill_context_info(struct iio_context_info *info,
 		char *hostname, char *addr_str, int port)
 {
@@ -142,24 +138,6 @@ static int dnssd_fill_context_info(struct iio_context_info *info,
 	}
 
 	return 0;
-}
-
-struct iio_scan_backend_context * dnssd_context_scan_init(void)
-{
-	struct iio_scan_backend_context *ctx;
-
-	ctx = malloc(sizeof(*ctx));
-	if (!ctx) {
-		errno = ENOMEM;
-		return NULL;
-	}
-
-	return ctx;
-}
-
-void dnssd_context_scan_free(struct iio_scan_backend_context *ctx)
-{
-	free(ctx);
 }
 
 /*
@@ -255,8 +233,7 @@ void remove_dup_discovery_data(struct dns_sd_discovery_data **ddata)
 	*ddata = d;
 }
 
-int dnssd_context_scan(struct iio_scan_backend_context *ctx,
-		struct iio_scan_result *scan_result)
+int dnssd_context_scan(struct iio_scan_result *scan_result)
 {
 	struct iio_context_info **info;
 	struct dns_sd_discovery_data *ddata, *ndata;

--- a/dns_sd.c
+++ b/dns_sd.c
@@ -235,8 +235,8 @@ void remove_dup_discovery_data(struct dns_sd_discovery_data **ddata)
 
 int dnssd_context_scan(struct iio_scan_result *scan_result)
 {
-	struct iio_context_info **info;
 	struct dns_sd_discovery_data *ddata, *ndata;
+	struct iio_context_info *info;
 	int ret = 0;
 
 	ret = dnssd_find_hosts(&ddata);
@@ -251,14 +251,14 @@ int dnssd_context_scan(struct iio_scan_result *scan_result)
 		goto fail;
 
 	for (ndata = ddata; ndata->next != NULL; ndata = ndata->next) {
-		info = iio_scan_result_add(scan_result, 1);
+		info = iio_scan_result_add(scan_result);
 		if (!info) {
 			IIO_ERROR("Out of memory when adding new scan result\n");
 			ret = -ENOMEM;
 			break;
 		}
 
-		ret = dnssd_fill_context_info(*info,
+		ret = dnssd_fill_context_info(info,
 				ndata->hostname, ndata->addr_str,ndata->port);
 		if (ret < 0) {
 			IIO_DEBUG("Failed to add %s (%s) err: %d\n", ndata->hostname, ndata->addr_str, ret);

--- a/iio-private.h
+++ b/iio-private.h
@@ -209,8 +209,8 @@ struct iio_scan_result {
 	struct iio_context_info **info;
 };
 
-struct iio_context_info ** iio_scan_result_add(
-	struct iio_scan_result *scan_result, size_t num);
+struct iio_context_info *
+iio_scan_result_add(struct iio_scan_result *scan_result);
 
 void free_channel(struct iio_channel *chn);
 void free_device(struct iio_device *dev);

--- a/iio-private.h
+++ b/iio-private.h
@@ -124,7 +124,6 @@ static inline __check_ret void * ERR_TO_PTR(intptr_t err)
 struct iio_context_pdata;
 struct iio_device_pdata;
 struct iio_channel_pdata;
-struct iio_scan_backend_context;
 
 struct iio_channel_attr {
 	char *name;
@@ -246,11 +245,7 @@ struct iio_context * serial_create_context_from_uri(const char *uri);
 
 int local_context_scan(struct iio_scan_result *scan_result);
 
-struct iio_scan_backend_context * usb_context_scan_init(void);
-void usb_context_scan_free(struct iio_scan_backend_context *ctx);
-
-int usb_context_scan(struct iio_scan_backend_context *ctx,
-		struct iio_scan_result *scan_result);
+int usb_context_scan(struct iio_scan_result *scan_result);
 
 int dnssd_context_scan(struct iio_scan_result *scan_result);
 

--- a/iio-private.h
+++ b/iio-private.h
@@ -252,11 +252,7 @@ void usb_context_scan_free(struct iio_scan_backend_context *ctx);
 int usb_context_scan(struct iio_scan_backend_context *ctx,
 		struct iio_scan_result *scan_result);
 
-struct iio_scan_backend_context * dnssd_context_scan_init(void);
-void dnssd_context_scan_free(struct iio_scan_backend_context *ctx);
-
-int dnssd_context_scan(struct iio_scan_backend_context *ctx,
-		struct iio_scan_result *scan_result);
+int dnssd_context_scan(struct iio_scan_result *scan_result);
 
 ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 		const uint32_t *mask, size_t words);

--- a/local.c
+++ b/local.c
@@ -2132,7 +2132,7 @@ static int check_device(void *d, const char *path)
 
 int local_context_scan(struct iio_scan_result *scan_result)
 {
-	struct iio_context_info **info;
+	struct iio_context_info *info;
 	bool exists = false;
 	char *desc, *uri, *machine, buf[2 * BUF_SIZE], names[BUF_SIZE];
 	int ret;
@@ -2169,12 +2169,13 @@ int local_context_scan(struct iio_scan_result *scan_result)
 	if (!uri)
 		goto err_free_desc;
 
-	info = iio_scan_result_add(scan_result, 1);
+	info = iio_scan_result_add(scan_result);
 	if (!info)
 		goto err_free_uri;
 
-	info[0]->description = desc;
-	info[0]->uri = uri;
+	info->description = desc;
+	info->uri = uri;
+
 	return 0;
 
 err_free_uri:

--- a/scan.c
+++ b/scan.c
@@ -15,7 +15,7 @@
 
 struct iio_scan_context {
 	struct iio_scan_backend_context *usb_ctx;
-	struct iio_scan_backend_context *dnssd_ctx;
+	bool scan_network;
 	bool scan_local;
 };
 
@@ -54,8 +54,8 @@ ssize_t iio_scan_context_get_info_list(struct iio_scan_context *ctx,
 		}
 	}
 
-	if (HAVE_DNS_SD && ctx->dnssd_ctx) {
-		int ret = dnssd_context_scan(ctx->dnssd_ctx, &scan_result);
+	if (HAVE_DNS_SD && ctx->scan_network) {
+		int ret = dnssd_context_scan(&scan_result);
 		if (ret < 0) {
 			if (scan_result.info)
 				iio_context_info_list_free(scan_result.info);
@@ -138,8 +138,8 @@ struct iio_scan_context * iio_create_scan_context(
 	if (WITH_USB_BACKEND && (!backend || strstr(backend, "usb")))
 		ctx->usb_ctx = usb_context_scan_init();
 
-	if (HAVE_DNS_SD && (!backend || strstr(backend, "ip")))
-		ctx->dnssd_ctx = dnssd_context_scan_init();
+	if (!backend || strstr(backend, "ip"))
+		ctx->scan_network = true;
 
 	return ctx;
 }
@@ -148,8 +148,6 @@ void iio_scan_context_destroy(struct iio_scan_context *ctx)
 {
 	if (WITH_USB_BACKEND && ctx->usb_ctx)
 		usb_context_scan_free(ctx->usb_ctx);
-	if (HAVE_DNS_SD && ctx->dnssd_ctx)
-		dnssd_context_scan_free(ctx->dnssd_ctx);
 	free(ctx);
 }
 

--- a/scan.c
+++ b/scan.c
@@ -14,7 +14,7 @@
 #include <string.h>
 
 struct iio_scan_context {
-	struct iio_scan_backend_context *usb_ctx;
+	bool scan_usb;
 	bool scan_network;
 	bool scan_local;
 };
@@ -45,8 +45,8 @@ ssize_t iio_scan_context_get_info_list(struct iio_scan_context *ctx,
 		}
 	}
 
-	if (WITH_USB_BACKEND && ctx->usb_ctx) {
-		int ret = usb_context_scan(ctx->usb_ctx, &scan_result);
+	if (WITH_USB_BACKEND && ctx->scan_usb) {
+		int ret = usb_context_scan(&scan_result);
 		if (ret < 0) {
 			if (scan_result.info)
 				iio_context_info_list_free(scan_result.info);
@@ -135,8 +135,8 @@ struct iio_scan_context * iio_create_scan_context(
 	if (!backend || strstr(backend, "local"))
 		ctx->scan_local = true;
 
-	if (WITH_USB_BACKEND && (!backend || strstr(backend, "usb")))
-		ctx->usb_ctx = usb_context_scan_init();
+	if (!backend || strstr(backend, "usb"))
+		ctx->scan_usb = true;
 
 	if (!backend || strstr(backend, "ip"))
 		ctx->scan_network = true;
@@ -146,8 +146,6 @@ struct iio_scan_context * iio_create_scan_context(
 
 void iio_scan_context_destroy(struct iio_scan_context *ctx)
 {
-	if (WITH_USB_BACKEND && ctx->usb_ctx)
-		usb_context_scan_free(ctx->usb_ctx);
 	free(ctx);
 }
 

--- a/scan.c
+++ b/scan.c
@@ -86,33 +86,27 @@ void iio_context_info_list_free(struct iio_context_info **list)
 	free(list);
 }
 
-struct iio_context_info ** iio_scan_result_add(
-		struct iio_scan_result *scan_result, size_t num)
+struct iio_context_info *
+iio_scan_result_add(struct iio_scan_result *scan_result)
 {
 	struct iio_context_info **info;
-	size_t old_size, new_size;
-	size_t i;
+	size_t size = scan_result->size;
 
-	old_size = scan_result->size;
-	new_size = old_size + num;
-
-	info = realloc(scan_result->info, (new_size + 1) * sizeof(*info));
+	info = realloc(scan_result->info, (size + 2) * sizeof(*info));
 	if (!info)
 		return NULL;
 
 	scan_result->info = info;
-	scan_result->size = new_size;
+	scan_result->size = size + 1;
 
-	for (i = old_size; i < new_size; i++) {
-		/* Make sure iio_context_info_list_free won't overflow */
-		info[i + 1] = NULL;
+	/* Make sure iio_context_info_list_free won't overflow */
+	info[size + 1] = NULL;
 
-		info[i] = zalloc(sizeof(**info));
-		if (!info[i])
-			return NULL;
-	}
+	info[size] = zalloc(sizeof(**info));
+	if (!info[size])
+		return NULL;
 
-	return &info[old_size];
+	return info[size];
 }
 
 struct iio_scan_context * iio_create_scan_context(

--- a/usb.c
+++ b/usb.c
@@ -1202,7 +1202,7 @@ static int usb_fill_context_info(struct iio_context_info *info,
 
 int usb_context_scan(struct iio_scan_result *scan_result)
 {
-	struct iio_context_info **info;
+	struct iio_context_info *info;
 	libusb_device **device_list;
 	libusb_context *ctx;
 	unsigned int i;
@@ -1228,12 +1228,12 @@ int usb_context_scan(struct iio_scan_result *scan_result)
 			continue;
 
 		if (!iio_usb_match_device(dev, hdl, &intrfc)) {
-			info = iio_scan_result_add(scan_result, 1);
+			info = iio_scan_result_add(scan_result);
 			if (!info)
 				ret = -ENOMEM;
 			else
-				ret = usb_fill_context_info(*info, dev, hdl,
-						intrfc);
+				ret = usb_fill_context_info(info, dev, hdl,
+							    intrfc);
 		}
 
 		libusb_close(hdl);


### PR DESCRIPTION
A small set of changes that I made for an upcoming pull request to the dev branch, that I thought could be merged into master instead.

This PR removes the "scan context" structures as they are not really useful, and reworks and simplifies iio_scan_result_add().