### PR TITLE
network: Include headers for the errors that are used

### DIFF
--- a/dns_sd.c
+++ b/dns_sd.c
@@ -16,11 +16,11 @@
 #include "iio-lock.h"
 #include "iio-private.h"
 
+#include <errno.h>
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #else
-#include <errno.h>
 #include <netdb.h>
 #include <string.h>
 #include <sys/socket.h>

--- a/network-windows.c
+++ b/network-windows.c
@@ -8,6 +8,7 @@
 
 #include "network.h"
 
+#include <errno.h>
 #include <ws2tcpip.h>
 #define close(s) closesocket(s)
 #ifndef MAXHOSTNAMELEN


### PR DESCRIPTION
Because of the missing headers, build failed when compiling on Ubuntu1804
image supported by Appveyor, with MinGW compiler.

Signed-off-by: Dan Nechita <dan.nechita@analog.com>