### PR TITLE
Fixes for IIO debug functions

### DIFF
--- a/iio-debug.h
+++ b/iio-debug.h
@@ -82,7 +82,7 @@ iio_prm_printf(const struct iio_context_params *params,
 	int _err = (err);						\
 	iio_strerror(_err, _buf, sizeof(_buf));				\
 	prm_err(params, __FIRST(__VA_ARGS__, 0)				\
-		__OTHERS(": %s (%u)\n",__VA_ARGS__, _buf), _err);	\
+		__OTHERS(": %s\n",__VA_ARGS__, _buf));			\
 	errno = _err;							\
 } while (0)
 #define ctx_perror(ctx, err, ...)	prm_perror(__ctx_params_or_null(ctx), err, __VA_ARGS__)

--- a/iio-debug.h
+++ b/iio-debug.h
@@ -9,6 +9,8 @@
 #ifndef __IIO_DEBUG_H__
 #define __IIO_DEBUG_H__
 
+#include "iio-config.h"
+
 #include <iio.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -41,7 +43,7 @@ iio_prm_printf(const struct iio_context_params *params,
 			out = params->err ? params->err : stderr;
 		else
 			out = params->out ? params->out : stdout;
-	} else if (!params && msg_level <= LEVEL_INFO) {
+	} else if (!params && msg_level <= DEFAULT_LOG_LEVEL) {
 		out = msg_level <= LEVEL_WARNING ? stderr : stdout;
 	}
 


### PR DESCRIPTION
Two small fixes to the IIO debug functions in the dev branch:
- the default log level, set at compilation time, was ignored when the params pointer was NULL;
- the error code was printed twice in the *_perror macros.