### PR TITLE
CMake: Fix Python bindings documentation not properly installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -428,6 +428,8 @@ if (WIN32)
 	configure_file(properties.rc.cmakein ${LIBIIO_RC} @ONLY)
 endif()
 
+set(CMAKE_HTML_DEST_DIR "${CMAKE_CURRENT_BINARY_DIR}/html/v${VERSION}")
+
 option(CSHARP_BINDINGS "Install C# bindings" OFF)
 option(PYTHON_BINDINGS "Install Python bindings" OFF)
 add_subdirectory(bindings)

--- a/bindings/csharp/CMakeLists.txt
+++ b/bindings/csharp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.10)
 project(libiio-sharp NONE)
 
 if (WIN32)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.10)
 project(libiio-py NONE)
 
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -55,7 +55,6 @@ if(WITH_DOC)
 		set(CMAKE_CASE_SENSITIVE_FILESYSTEM "NO")
 	endif()
 
-	set(CMAKE_HTML_DEST_DIR "${CMAKE_CURRENT_BINARY_DIR}/html/v${VERSION}")
 	set(CMAKE_API_DEST_DIR "${PROJECT_NAME}")
 
 	configure_file(


### PR DESCRIPTION
Fix the Python bindings not being properly installed, and bump the CMake script of the bindings to 3.10 to match the main script.