### PR TITLE
Local backend: Fix invalid error message in local_close()

### DIFF
--- a/local.c
+++ b/local.c
@@ -1039,8 +1039,7 @@ static int local_close(const struct iio_device *dev)
 
 	ret1 = local_buffer_enabled_set(dev, false);
 	if (ret1) {
-		ret1 = -errno;
-		iio_strerror(errno, err_str, sizeof(err_str));
+		iio_strerror(-ret1, err_str, sizeof(err_str));
 		IIO_ERROR("Error during buffer disable: %s\n", err_str);
 		if (ret == 0)
 			ret = ret1;

--- a/local.c
+++ b/local.c
@@ -403,10 +403,16 @@ static ssize_t local_write(const struct iio_device *dev,
 		return ret;
 }
 
-static ssize_t local_buffer_enabled_set(const struct iio_device *dev, bool en)
+static int local_buffer_enabled_set(const struct iio_device *dev, bool en)
 {
-	return local_write_dev_attr(dev, "buffer/enable", en ? "1" : "0",
-				    2, false);
+	int ret;
+
+	ret = (int) local_write_dev_attr(dev, "buffer/enable", en ? "1" : "0",
+					 2, false);
+	if (ret < 0)
+		return ret;
+
+	return 0;
 }
 
 static int local_set_kernel_buffers_count(const struct iio_device *dev,


### PR DESCRIPTION
Fix the error message **"ERROR: Error during buffer disable: Success"**
Which is actually a combination of two bugs:
- `local_close()` called `local_buffer_enabled_set()`, and read the error code from `errno` if the return value was non-zero, while this function returned the error code directly;
- `local_buffer_enabled_set()` returned positive values on success, which means that checking for a non-zero return value is invalid.