### PR TITLE
New scan api

### DIFF
--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -78,11 +78,7 @@ def _isstring(argument):
 # pylint: enable=basestring-builtin
 
 
-class _ScanContext(Structure):
-    pass
-
-
-class _ContextInfo(Structure):
+class _Scan(Structure):
     pass
 
 
@@ -212,8 +208,7 @@ class ChannelType(Enum):
 
 
 # pylint: disable=invalid-name
-_ScanContextPtr = _POINTER(_ScanContext)
-_ContextInfoPtr = _POINTER(_ContextInfo)
+_ScanPtr = _POINTER(_Scan)
 _ContextPtr = _POINTER(_Context)
 _DevicePtr = _POINTER(_Device)
 _ChannelPtr = _POINTER(_Channel)
@@ -237,13 +232,27 @@ _get_backend.argtypes = (c_uint,)
 _get_backend.restype = c_char_p
 _get_backend.errcheck = _check_null
 
-_create_scan_context = _lib.iio_create_scan_context
-_create_scan_context.argtypes = (c_char_p, c_uint)
-_create_scan_context.restype = _ScanContextPtr
-_create_scan_context.errcheck = _check_null
+_scan = _lib.iio_scan
+_scan.argtypes = (_ContextParamsPtr, c_char_p)
+_scan.restype = _ScanPtr
+_scan.errcheck = _check_null
 
-_destroy_scan_context = _lib.iio_scan_context_destroy
-_destroy_scan_context.argtypes = (_ScanContextPtr,)
+_scan_destroy = _lib.iio_scan_destroy
+_scan_destroy.argtypes = (_ScanPtr,)
+
+_scan_get_results_count = _lib.iio_scan_get_results_count
+_scan_get_results_count.argtypes = (_ScanPtr,)
+_scan_get_results_count.restype = c_size_t
+
+_scan_get_description = _lib.iio_scan_get_description
+_scan_get_description.argtypes = (_ScanPtr, c_size_t)
+_scan_get_description.restype = c_char_p
+_scan_get_description.errcheck = _check_null
+
+_scan_get_uri = _lib.iio_scan_get_uri
+_scan_get_uri.argtypes = (_ScanPtr, c_size_t)
+_scan_get_uri.restype = c_char_p
+_scan_get_uri.errcheck = _check_null
 
 _iio_has_backend = _lib.iio_has_backend
 _iio_has_backend.argtypes = (c_char_p,)
@@ -252,22 +261,6 @@ _iio_has_backend.restype = c_bool
 _iio_strerror = _lib.iio_strerror
 _iio_strerror.argtypes = (c_int, c_char_p, c_uint)
 _iio_strerror.restype = None
-
-_get_context_info_list = _lib.iio_scan_context_get_info_list
-_get_context_info_list.argtypes = (_ScanContextPtr, _POINTER(_POINTER(_ContextInfoPtr)))
-_get_context_info_list.restype = c_ssize_t
-_get_context_info_list.errcheck = _check_negative
-
-_context_info_list_free = _lib.iio_context_info_list_free
-_context_info_list_free.argtypes = (_POINTER(_ContextInfoPtr),)
-
-_context_info_get_description = _lib.iio_context_info_get_description
-_context_info_get_description.argtypes = (_ContextInfoPtr,)
-_context_info_get_description.restype = c_char_p
-
-_context_info_get_uri = _lib.iio_context_info_get_uri
-_context_info_get_uri.argtypes = (_ContextInfoPtr,)
-_context_info_get_uri.restype = c_char_p
 
 _new_ctx = _lib.iio_create_context
 _new_ctx.restype = _ContextPtr
@@ -1491,16 +1484,14 @@ class NetworkContext(Context):
 def scan_contexts():
     """Scan Context."""
     scan_ctx = dict()
-    ptr = _POINTER(_ContextInfoPtr)()
 
-    ctx = _create_scan_context(None, 0)
-    ctx_nb = _get_context_info_list(ctx, _byref(ptr))
+    ctx = _scan(None, None)
+    ctx_nb = _scan_get_results_count(ctx)
 
     for i in range(0, ctx_nb):
-        scan_ctx[
-            _context_info_get_uri(ptr[i]).decode("ascii")
-        ] = _context_info_get_description(ptr[i]).decode("ascii")
+        uri = _scan_get_uri(ctx, i).decode("ascii")
+        desc = _scan_get_description(ctx, i).decode("ascii")
+        scan_ctx[uri] = desc
 
-    _context_info_list_free(ptr)
-    _destroy_scan_context(ctx)
+    _scan_destroy(ctx)
     return scan_ctx

--- a/compat.c
+++ b/compat.c
@@ -13,6 +13,11 @@
 
 #include <errno.h>
 
+struct iio_context_info {
+	char *description;
+	char *uri;
+};
+
 struct iio_scan_block {
 	struct iio_scan_context *ctx;
 	struct iio_context_info **info;
@@ -99,4 +104,109 @@ void iio_scan_block_destroy(struct iio_scan_block *blk)
 	iio_context_info_list_free(blk->info);
 	iio_scan_context_destroy(blk->ctx);
 	free(blk);
+}
+
+struct iio_scan_context *
+iio_create_scan_context(const char *backends, unsigned int flags)
+{
+	char buf[256];
+	char *ptr;
+
+	if (!backends)
+		return (struct iio_scan_context *) iio_scan(NULL, NULL);
+
+	iio_strlcpy(buf, backends, sizeof(buf));
+
+	/* iio_scan() requires a comma-separated list of backends */
+	for (ptr = buf; *ptr; ptr++) {
+		if (*ptr == ':')
+			*ptr = ',';
+	}
+
+	return (struct iio_scan_context *) iio_scan(NULL, buf);
+}
+
+void iio_scan_context_destroy(struct iio_scan_context *ctx)
+{
+	iio_scan_destroy((struct iio_scan *) ctx);
+}
+
+ssize_t iio_scan_context_get_info_list(struct iio_scan_context *ctx,
+				       struct iio_context_info ***info)
+{
+	struct iio_scan *scan_ctx = (struct iio_scan *) ctx;
+	struct iio_context_info *results, **results_ptr;
+	size_t nb = iio_scan_get_results_count(scan_ctx);
+	unsigned int i;
+	int ret = -ENOMEM;
+	const char *ptr;
+	char *dup;
+
+	results_ptr = malloc((nb + 1) * sizeof(*results_ptr));
+	if (!results_ptr)
+		return -ENOMEM;
+
+	results_ptr[nb] = NULL;
+
+	results = malloc(nb * sizeof(*results));
+	if (!results)
+		goto out_free_results_ptr;
+
+	for (i = 0; i < nb; i++) {
+		ptr = iio_scan_get_description(scan_ctx, i);
+		dup = iio_strdup(ptr);
+		if (!dup)
+			goto out_free_results_list;
+
+		results[i].description = dup;
+
+		ptr = iio_scan_get_uri(scan_ctx, i);
+		dup = iio_strdup(ptr);
+		if (!dup)
+			goto out_free_results_list;
+
+		results[i].uri = dup;
+
+		results_ptr[i] = &results[i];
+	}
+
+	*info = results_ptr;
+
+	return nb;
+
+out_free_results_list:
+	iio_context_info_list_free(results_ptr);
+out_free_results:
+	free(results);
+out_free_results_ptr:
+	free(results_ptr);
+	return ret;
+}
+
+void iio_context_info_list_free(struct iio_context_info **list)
+{
+	struct iio_context_info **it;
+
+	if (!list)
+		return;
+
+	for (it = list; *it; it++) {
+		struct iio_context_info *info = *it;
+
+		free(info->description);
+		free(info->uri);
+	}
+
+	free(list);
+}
+
+const char *
+iio_context_info_get_description(const struct iio_context_info *info)
+{
+	return info->description;
+}
+
+const char * iio_context_info_get_uri(const struct iio_context_info *info)
+{
+	return info->uri;
 }

--- a/compat.c
+++ b/compat.c
@@ -11,6 +11,14 @@
 #include "iio-backend.h"
 #include "iio-compat.h"
 
+#include <errno.h>
+
+struct iio_scan_block {
+	struct iio_scan_context *ctx;
+	struct iio_context_info **info;
+	ssize_t ctx_cnt;
+};
+
 struct iio_context * iio_create_context_from_uri(const char *uri)
 {
 	return iio_create_context(NULL, uri);
@@ -44,4 +52,51 @@ struct iio_context * iio_create_local_context(void)
 struct iio_context * iio_create_default_context(void)
 {
 	return iio_create_context_from_uri(NULL);
+}
+
+ssize_t iio_scan_block_scan(struct iio_scan_block *blk)
+{
+	iio_context_info_list_free(blk->info);
+	blk->info = NULL;
+	blk->ctx_cnt = iio_scan_context_get_info_list(blk->ctx, &blk->info);
+
+	return blk->ctx_cnt;
+}
+
+struct iio_context_info *iio_scan_block_get_info(
+		struct iio_scan_block *blk, unsigned int index)
+{
+	if (!blk->info || (ssize_t)index >= blk->ctx_cnt) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	return blk->info[index];
+}
+
+struct iio_scan_block *iio_create_scan_block(
+		const char *backend, unsigned int flags)
+{
+	struct iio_scan_block *blk;
+
+	blk = calloc(1, sizeof(*blk));
+	if (!blk) {
+		errno = ENOMEM;
+		return NULL;
+	}
+
+	blk->ctx = iio_create_scan_context(backend, flags);
+	if (!blk->ctx) {
+		free(blk);
+		return NULL;
+	}
+
+	return blk;
+}
+
+void iio_scan_block_destroy(struct iio_scan_block *blk)
+{
+	iio_context_info_list_free(blk->info);
+	iio_scan_context_destroy(blk->ctx);
+	free(blk);
 }

--- a/iio-compat.h
+++ b/iio-compat.h
@@ -23,6 +23,8 @@
 #endif
 #endif
 
+struct iio_scan_block;
+
 
 /* ---------------------------------------------------------------------------*/
 /* ------------------------- Libiio 0.x to 1.x compat API --------------------*/
@@ -94,6 +96,48 @@ __api __check_ret struct iio_context * iio_create_xml_context(const char *xml_fi
  *
  *  For example <i>"serial:/dev/ttyUSB0,115200"</i> <b>or</b> <i>"serial:/dev/ttyUSB0,115200,8n1"</i>*/
 __api __check_ret struct iio_context * iio_create_context_from_uri(const char *uri);
+
+
+/** @brief Create a scan block
+ * @param backend A NULL-terminated string containing the backend to use for
+ * scanning. If NULL, all the available backends are used.
+ * @param flags Unused for now. Set to 0.
+ * @return on success, a pointer to a iio_scan_block structure
+ * @return On failure, NULL is returned and errno is set appropriately
+ *
+ * Introduced in version 0.20. */
+__api struct iio_scan_block *
+iio_create_scan_block(const char *backend, unsigned int flags);
+
+
+/** @brief Destroy the given scan block
+ * @param blk A pointer to an iio_scan_block structure
+ *
+ * <b>NOTE:</b> After that function, the iio_scan_block pointer shall be invalid.
+ *
+ * Introduced in version 0.20. */
+__api void iio_scan_block_destroy(struct iio_scan_block *blk);
+
+
+/** @brief Enumerate available contexts via scan block
+ * @param blk A pointer to a iio_scan_block structure.
+ * @returns On success, the number of contexts found.
+ * @returns On failure, a negative error number.
+ *
+ * Introduced in version 0.20. */
+__api ssize_t iio_scan_block_scan(struct iio_scan_block *blk);
+
+
+/** @brief Get the iio_context_info for a particular context
+ * @param blk A pointer to an iio_scan_block structure
+ * @param index The index corresponding to the context.
+ * @return A pointer to the iio_context_info for the context
+ * @returns On success, a pointer to the specified iio_context_info
+ * @returns On failure, NULL is returned and errno is set appropriately
+ *
+ * Introduced in version 0.20. */
+__api struct iio_context_info *
+iio_scan_block_get_info(struct iio_scan_block *blk, unsigned int index);
 
 
 /** @} *//* ------------------------------------------------------------------*/

--- a/iio-compat.h
+++ b/iio-compat.h
@@ -23,7 +23,9 @@
 #endif
 #endif
 
+struct iio_context_info;
 struct iio_scan_block;
+struct iio_scan_context;
 
 
 /* ---------------------------------------------------------------------------*/
@@ -96,6 +98,59 @@ __api __check_ret struct iio_context * iio_create_xml_context(const char *xml_fi
  *
  *  For example <i>"serial:/dev/ttyUSB0,115200"</i> <b>or</b> <i>"serial:/dev/ttyUSB0,115200,8n1"</i>*/
 __api __check_ret struct iio_context * iio_create_context_from_uri(const char *uri);
+
+
+/** @brief Create a scan context
+ * @param backend A NULL-terminated string containing the backend(s) to use for
+ * scanning (example: pre version 0.20 :  "local", "ip", or "usb"; post version
+ * 0.20 can handle multiple, including "local:usb:", "ip:usb:", "local:usb:ip:").
+ * If NULL, all the available backends are used.
+ * @param flags Unused for now. Set to 0.
+ * @return on success, a pointer to a iio_scan_context structure
+ * @return On failure, NULL is returned and errno is set appropriately */
+__api __check_ret struct iio_scan_context *
+iio_create_scan_context(const char *backend, unsigned int flags);
+
+
+/** @brief Destroy the given scan context
+ * @param ctx A pointer to an iio_scan_context structure
+ *
+ * <b>NOTE:</b> After that function, the iio_scan_context pointer shall be invalid. */
+__api void iio_scan_context_destroy(struct iio_scan_context *ctx);
+
+
+/** @brief Enumerate available contexts
+ * @param ctx A pointer to an iio_scan_context structure
+ * @param info A pointer to a 'const struct iio_context_info **' typed variable.
+ * The pointed variable will be initialized on success.
+ * @returns On success, the number of contexts found.
+ * @returns On failure, a negative error number.
+ */
+__api __check_ret ssize_t
+iio_scan_context_get_info_list(struct iio_scan_context *ctx,
+			       struct iio_context_info ***info);
+
+
+/** @brief Free a context info list
+ * @param info A pointer to a 'const struct iio_context_info *' typed variable
+ */
+__api void iio_context_info_list_free(struct iio_context_info **info);
+
+
+/** @brief Get a description of a discovered context
+ * @param info A pointer to an iio_context_info structure
+ * @return A pointer to a static NULL-terminated string
+ */
+__api __check_ret __pure const char *
+iio_context_info_get_description(const struct iio_context_info *info);
+
+
+/** @brief Get the URI of a discovered context
+ * @param info A pointer to an iio_context_info structure
+ * @return A pointer to a static NULL-terminated string
+ */
+__api __check_ret __pure const char *
+iio_context_info_get_uri(const struct iio_context_info *info);
 
 
 /** @brief Create a scan block

--- a/iio-private.h
+++ b/iio-private.h
@@ -164,7 +164,7 @@ struct iio_context_info {
 
 struct iio_scan_result {
 	size_t size;
-	struct iio_context_info **info;
+	struct iio_context_info *info;
 };
 
 struct iio_module * iio_open_module(const char *path);

--- a/iio-private.h
+++ b/iio-private.h
@@ -200,6 +200,8 @@ int iio_device_get_poll_fd(const struct iio_device *dev);
 int read_double(const char *str, double *val);
 int write_double(char *buf, size_t len, double val);
 
+bool iio_list_has_elem(const char *list, const char *elem);
+
 struct iio_context * xml_create_context_mem(const struct iio_context_params *params,
 					    const char *xml, size_t len);
 struct iio_context *

--- a/iio.h
+++ b/iio.h
@@ -92,9 +92,6 @@ struct iio_channel;
 struct iio_buffer;
 struct iio_scan;
 
-struct iio_context_info;
-struct iio_scan_context;
-
 /**
  * @enum iio_log_level
  * @brief Level of verbosity of libiio's log output.
@@ -251,12 +248,6 @@ enum iio_modifier {
  * @{
  * @struct iio_scan
  * @brief Structure holding scanning information
- *
- * @struct iio_scan_context
- * @brief The scanning context
- *
- * @struct iio_context_info
- * @brief The information related to a discovered context
  */
 
 /** @brief Scan backends for IIO contexts
@@ -302,58 +293,6 @@ iio_scan_get_description(const struct iio_scan *ctx, size_t idx);
  * @return If the index is invalid, NULL is returned */
 __api __check_ret __pure const char *
 iio_scan_get_uri(const struct iio_scan *ctx, size_t idx);
-
-
-/** @brief Create a scan context
- * @param backend A NULL-terminated string containing the backend(s) to use for
- * scanning (example: pre version 0.20 :  "local", "ip", or "usb"; post version
- * 0.20 can handle multiple, including "local:usb:", "ip:usb:", "local:usb:ip:").
- * If NULL, all the available backends are used.
- * @param flags Unused for now. Set to 0.
- * @return on success, a pointer to a iio_scan_context structure
- * @return On failure, NULL is returned and errno is set appropriately */
-__api __check_ret struct iio_scan_context * iio_create_scan_context(
-		const char *backend, unsigned int flags);
-
-
-/** @brief Destroy the given scan context
- * @param ctx A pointer to an iio_scan_context structure
- *
- * <b>NOTE:</b> After that function, the iio_scan_context pointer shall be invalid. */
-__api void iio_scan_context_destroy(struct iio_scan_context *ctx);
-
-
-/** @brief Enumerate available contexts
- * @param ctx A pointer to an iio_scan_context structure
- * @param info A pointer to a 'const struct iio_context_info **' typed variable.
- * The pointed variable will be initialized on success.
- * @returns On success, the number of contexts found.
- * @returns On failure, a negative error number.
- */
-__api __check_ret ssize_t iio_scan_context_get_info_list(struct iio_scan_context *ctx,
-		struct iio_context_info ***info);
-
-
-/** @brief Free a context info list
- * @param info A pointer to a 'const struct iio_context_info *' typed variable
- */
-__api void iio_context_info_list_free(struct iio_context_info **info);
-
-
-/** @brief Get a description of a discovered context
- * @param info A pointer to an iio_context_info structure
- * @return A pointer to a static NULL-terminated string
- */
-__api __check_ret __pure const char * iio_context_info_get_description(
-		const struct iio_context_info *info);
-
-
-/** @brief Get the URI of a discovered context
- * @param info A pointer to an iio_context_info structure
- * @return A pointer to a static NULL-terminated string
- */
-__api __check_ret __pure const char * iio_context_info_get_uri(
-		const struct iio_context_info *info);
 
 
 /** @} *//* ------------------------------------------------------------------*/

--- a/iio.h
+++ b/iio.h
@@ -94,7 +94,6 @@ struct iio_scan;
 
 struct iio_context_info;
 struct iio_scan_context;
-struct iio_scan_block;
 
 /**
  * @enum iio_log_level
@@ -355,48 +354,6 @@ __api __check_ret __pure const char * iio_context_info_get_description(
  */
 __api __check_ret __pure const char * iio_context_info_get_uri(
 		const struct iio_context_info *info);
-
-
-/** @brief Create a scan block
- * @param backend A NULL-terminated string containing the backend to use for
- * scanning. If NULL, all the available backends are used.
- * @param flags Unused for now. Set to 0.
- * @return on success, a pointer to a iio_scan_block structure
- * @return On failure, NULL is returned and errno is set appropriately
- *
- * Introduced in version 0.20. */
-__api struct iio_scan_block * iio_create_scan_block(
-		const char *backend, unsigned int flags);
-
-
-/** @brief Destroy the given scan block
- * @param blk A pointer to an iio_scan_block structure
- *
- * <b>NOTE:</b> After that function, the iio_scan_block pointer shall be invalid.
- *
- * Introduced in version 0.20. */
-__api void iio_scan_block_destroy(struct iio_scan_block *blk);
-
-
-/** @brief Enumerate available contexts via scan block
- * @param blk A pointer to a iio_scan_block structure.
- * @returns On success, the number of contexts found.
- * @returns On failure, a negative error number.
- *
- * Introduced in version 0.20. */
-__api ssize_t iio_scan_block_scan(struct iio_scan_block *blk);
-
-
-/** @brief Get the iio_context_info for a particular context
- * @param blk A pointer to an iio_scan_block structure
- * @param index The index corresponding to the context.
- * @return A pointer to the iio_context_info for the context
- * @returns On success, a pointer to the specified iio_context_info
- * @returns On failure, NULL is returned and errno is set appropriately
- *
- * Introduced in version 0.20. */
-__api struct iio_context_info *iio_scan_block_get_info(
-		struct iio_scan_block *blk, unsigned int index);
 
 
 /** @} *//* ------------------------------------------------------------------*/

--- a/iio.h
+++ b/iio.h
@@ -90,6 +90,7 @@ struct iio_context;
 struct iio_device;
 struct iio_channel;
 struct iio_buffer;
+struct iio_scan;
 
 struct iio_context_info;
 struct iio_scan_context;
@@ -249,12 +250,59 @@ enum iio_modifier {
 /* ------------------------- Scan functions ----------------------------------*/
 /** @defgroup Scan Functions for scanning available contexts
  * @{
+ * @struct iio_scan
+ * @brief Structure holding scanning information
+ *
  * @struct iio_scan_context
  * @brief The scanning context
  *
  * @struct iio_context_info
  * @brief The information related to a discovered context
  */
+
+/** @brief Scan backends for IIO contexts
+ * @param params A pointer to a iio_context_params structure that contains
+ *   context creation information; can be NULL
+ * @param backends a NULL-terminated string containing a comma-separated list
+ *   of the backends to be scanned for contexts. If NULL, all the available
+ *   backends are scanned.
+ * @return On success, a pointer to an iio_scan structure
+ * @return On failure, NULL is returned and errno is set appropriately */
+__api __check_ret struct iio_scan *
+iio_scan(const struct iio_context_params *params, const char *backends);
+
+
+/** @brief Destroy the given scan context
+ * @param ctx A pointer to an iio_scan structure
+ *
+ * <b>NOTE:</b> After that function, the iio_scan pointer shall be invalid. */
+__api void iio_scan_destroy(struct iio_scan *ctx);
+
+
+/** @brief Get number of results of a scan operation
+ * @param ctx A pointer to an iio_scan structure
+ * @return The number of results of the scan operation
+ */
+__api __check_ret __pure size_t
+iio_scan_get_results_count(const struct iio_scan *ctx);
+
+
+/** @brief Get description of scanned context
+ * @param ctx A pointer to an iio_scan structure
+ * @param idx The index of the scanned context
+ * @return On success, a pointer to a NULL-terminated string
+ * @return If the index is invalid, NULL is returned */
+__api __check_ret __pure const char *
+iio_scan_get_description(const struct iio_scan *ctx, size_t idx);
+
+
+/** @brief Get URI of scanned context
+ * @param ctx A pointer to an iio_scan structure
+ * @param idx The index of the scanned context
+ * @return On success, a pointer to a NULL-terminated string
+ * @return If the index is invalid, NULL is returned */
+__api __check_ret __pure const char *
+iio_scan_get_uri(const struct iio_scan *ctx, size_t idx);
 
 
 /** @brief Create a scan context

--- a/scan.c
+++ b/scan.c
@@ -20,7 +20,7 @@ struct iio_scan {
 struct iio_context_info *
 iio_scan_result_add(struct iio_scan_result *scan_result)
 {
-	struct iio_context_info **info;
+	struct iio_context_info *info;
 	size_t size = scan_result->size;
 
 	info = realloc(scan_result->info, (size + 1) * sizeof(*info));
@@ -30,11 +30,7 @@ iio_scan_result_add(struct iio_scan_result *scan_result)
 	scan_result->info = info;
 	scan_result->size = size + 1;
 
-	info[size] = zalloc(sizeof(**info));
-	if (!info[size])
-		return NULL;
-
-	return info[size];
+	return &info[size];
 }
 
 static bool has_backend(const char *backends, const char *backend)
@@ -89,11 +85,11 @@ void iio_scan_destroy(struct iio_scan *ctx)
 	unsigned int i;
 
 	for (i = 0; i < ctx->scan_result.size; i++) {
-		free(ctx->scan_result.info[i]->description);
-		free(ctx->scan_result.info[i]->uri);
-		free(ctx->scan_result.info[i]);
+		free(ctx->scan_result.info[i].description);
+		free(ctx->scan_result.info[i].uri);
 	}
 
+	free(ctx->scan_result.info);
 	free(ctx);
 }
 
@@ -108,7 +104,7 @@ iio_scan_get_description(const struct iio_scan *ctx, size_t idx)
 	if (idx >= ctx->scan_result.size)
 		return NULL;
 
-	return ctx->scan_result.info[idx]->description;
+	return ctx->scan_result.info[idx].description;
 }
 
 const char * iio_scan_get_uri(const struct iio_scan *ctx, size_t idx)
@@ -116,5 +112,5 @@ const char * iio_scan_get_uri(const struct iio_scan *ctx, size_t idx)
 	if (idx >= ctx->scan_result.size)
 		return NULL;
 
-	return ctx->scan_result.info[idx]->uri;
+	return ctx->scan_result.info[idx].uri;
 }

--- a/scan.c
+++ b/scan.c
@@ -147,57 +147,6 @@ void iio_scan_context_destroy(struct iio_scan_context *ctx)
 	free(ctx);
 }
 
-struct iio_scan_block {
-	struct iio_scan_context *ctx;
-	struct iio_context_info **info;
-	ssize_t ctx_cnt;
-};
-
-ssize_t iio_scan_block_scan(struct iio_scan_block *blk)
-{
-	iio_context_info_list_free(blk->info);
-	blk->info = NULL;
-	blk->ctx_cnt = iio_scan_context_get_info_list(blk->ctx, &blk->info);
-	return blk->ctx_cnt;
-}
-
-struct iio_context_info *iio_scan_block_get_info(
-		struct iio_scan_block *blk, unsigned int index)
-{
-	if (!blk->info || (ssize_t)index >= blk->ctx_cnt) {
-		errno = EINVAL;
-		return NULL;
-	}
-	return blk->info[index];
-}
-
-struct iio_scan_block *iio_create_scan_block(
-		const char *backend, unsigned int flags)
-{
-	struct iio_scan_block *blk;
-
-	blk = calloc(1, sizeof(*blk));
-	if (!blk) {
-		errno = ENOMEM;
-		return NULL;
-	}
-
-	blk->ctx = iio_create_scan_context(backend, flags);
-	if (!blk->ctx) {
-		free(blk);
-		return NULL;
-	}
-
-	return blk;
-}
-
-void iio_scan_block_destroy(struct iio_scan_block *blk)
-{
-	iio_context_info_list_free(blk->info);
-	iio_scan_context_destroy(blk->ctx);
-	free(blk);
-}
-
 static bool has_backend(const char *backends, const char *backend)
 {
 	return !backends || iio_list_has_elem(backends, backend);

--- a/scan.c
+++ b/scan.c
@@ -19,6 +19,10 @@ struct iio_scan_context {
 	bool scan_local;
 };
 
+struct iio_scan {
+	struct iio_scan_result scan_result;
+};
+
 const char * iio_context_info_get_description(
 		const struct iio_context_info *info)
 {
@@ -192,4 +196,86 @@ void iio_scan_block_destroy(struct iio_scan_block *blk)
 	iio_context_info_list_free(blk->info);
 	iio_scan_context_destroy(blk->ctx);
 	free(blk);
+}
+
+static bool has_backend(const char *backends, const char *backend)
+{
+	return !backends || iio_list_has_elem(backends, backend);
+}
+
+struct iio_scan * iio_scan(const struct iio_context_params *params,
+			   const char *backends)
+{
+	struct iio_scan *ctx;
+	int ret;
+
+	if (!params)
+		params = get_default_params();
+
+	ctx = calloc(1, sizeof(*ctx));
+	if (!ctx) {
+		errno = ENOMEM;
+		return NULL;
+	}
+
+	if (WITH_LOCAL_BACKEND && has_backend(backends, "local")) {
+		ret = local_context_scan(&ctx->scan_result);
+		if (ret < 0) {
+			prm_perror(params, -ret,
+				   "Unable to scan local context(s)");
+		}
+	}
+
+	if (WITH_USB_BACKEND && has_backend(backends, "usb")) {
+		ret = usb_context_scan(&ctx->scan_result);
+		if (ret < 0) {
+			prm_perror(params, -ret,
+				   "Unable to scan USB context(s)");
+		}
+	}
+
+	if (HAVE_DNS_SD && has_backend(backends, "ip")) {
+		ret = dnssd_context_scan(&ctx->scan_result);
+		if (ret < 0) {
+			prm_perror(params, -ret,
+				   "Unable to scan network context(s)");
+		}
+	}
+
+	return ctx;
+}
+
+void iio_scan_destroy(struct iio_scan *ctx)
+{
+	unsigned int i;
+
+	for (i = 0; i < ctx->scan_result.size; i++) {
+		free(ctx->scan_result.info[i]->description);
+		free(ctx->scan_result.info[i]->uri);
+		free(ctx->scan_result.info[i]);
+	}
+
+	free(ctx);
+}
+
+size_t iio_scan_get_results_count(const struct iio_scan *ctx)
+{
+	return ctx->scan_result.size;
+}
+
+const char *
+iio_scan_get_description(const struct iio_scan *ctx, size_t idx)
+{
+	if (idx >= ctx->scan_result.size)
+		return NULL;
+
+	return ctx->scan_result.info[idx]->description;
+}
+
+const char * iio_scan_get_uri(const struct iio_scan *ctx, size_t idx)
+{
+	if (idx >= ctx->scan_result.size)
+		return NULL;
+
+	return ctx->scan_result.info[idx]->uri;
 }

--- a/tests/iio_common.c
+++ b/tests/iio_common.c
@@ -72,36 +72,30 @@ char *cmn_strndup(const char *str, size_t n)
 
 struct iio_context * autodetect_context(bool rtn, const char * name, const char * scan)
 {
-	struct iio_scan_context *scan_ctx;
-	struct iio_context_info **info;
+	struct iio_scan *scan_ctx;
 	struct iio_context *ctx = NULL;
 	unsigned int i;
-	ssize_t ret;
+	size_t results;
 	FILE *out;
 
-	scan_ctx = iio_create_scan_context(scan, 0);
+	scan_ctx = iio_scan(NULL, scan);
 	if (!scan_ctx) {
-		fprintf(stderr, "Unable to create scan context\n");
+		char *err_str = xmalloc(BUF_SIZE, name);
+		iio_strerror(errno, err_str, BUF_SIZE);
+		fprintf(stderr, "Scanning for IIO contexts failed: %s\n", err_str);
+		free (err_str);
 		return NULL;
 	}
 
-	ret = iio_scan_context_get_info_list(scan_ctx, &info);
-	if (ret < 0) {
-		char *err_str = xmalloc(BUF_SIZE, name);
-		iio_strerror(-(int)ret, err_str, BUF_SIZE);
-		fprintf(stderr, "Scanning for IIO contexts failed: %s\n", err_str);
-		free (err_str);
+	results = iio_scan_get_results_count(scan_ctx);
+	if (results == 0) {
+		fprintf(stderr, "No IIO context found.\n");
 		goto err_free_ctx;
 	}
-
-	if (ret == 0) {
-		fprintf(stderr, "No IIO context found.\n");
-		goto err_free_info_list;
-	}
-	if (rtn && ret == 1) {
+	if (rtn && results == 1) {
 		fprintf(stderr, "Using auto-detected IIO context at URI \"%s\"\n",
-		iio_context_info_get_uri(info[0]));
-		ctx = iio_create_context(NULL, iio_context_info_get_uri(info[0]));
+			iio_scan_get_uri(scan_ctx, 0));
+		ctx = iio_create_context(NULL, iio_scan_get_uri(scan_ctx, 0));
 	} else {
 		if (rtn) {
 			out = stderr;
@@ -110,17 +104,15 @@ struct iio_context * autodetect_context(bool rtn, const char * name, const char 
 			out = stdout;
 			fprintf(out, "Available contexts:\n");
 		}
-		for (i = 0; i < (size_t) ret; i++) {
-			fprintf(out, "\t%u: %s [%s]\n",
-					i, iio_context_info_get_description(info[i]),
-					iio_context_info_get_uri(info[i]));
+		for (i = 0; i < results; i++) {
+			fprintf(out, "\t%u: %s [%s]\n", i,
+					iio_scan_get_description(scan_ctx, i),
+					iio_scan_get_uri(scan_ctx, i));
 		}
 	}
 
-err_free_info_list:
-	iio_context_info_list_free(info);
 err_free_ctx:
-	iio_scan_context_destroy(scan_ctx);
+	iio_scan_destroy(scan_ctx);
 
 	return ctx;
 }

--- a/utilities.c
+++ b/utilities.c
@@ -330,3 +330,24 @@ ssize_t __iio_printf iio_snprintf(char *buf, size_t len, const char *fmt, ...)
 
 	return (ssize_t)ret;
 }
+
+bool iio_list_has_elem(const char *list, const char *elem)
+{
+	const char *ptr;
+
+	if (!list)
+		return false;
+
+	while (true) {
+		ptr = strchr(list, ',');
+		if (!ptr)
+			return !strcmp(list, elem);
+
+		if (!strncmp(list, elem,
+			     (uintptr_t) ptr - (uintptr_t) list)) {
+			return true;
+		}
+
+		list = ptr + 1;
+	}
+}


### PR DESCRIPTION
This PR introduces a new API for scanning for IIO contexts in Libiio 1.x.

The old API has three data types and 10 API functions, which is too complicated for many people, me included. The new API has only one data type and 5 API functions.

The old API is moved to the compatibility library so that old applications will still work. It is now implemented on top of the new API.