### PR TITLE
network: Fix build under Clang

### DIFF
--- a/network.c
+++ b/network.c
@@ -1103,7 +1103,7 @@ struct iio_context * network_create_context(const char *host)
 		 * which might be not the case for some minimalist distros. In this case,
 		 * as a last resort, let's try to resolve the host with avahi...
 		 */
-		if (ret && HAVE_DNS_SD) {
+		if (HAVE_DNS_SD && ret) {
 			char addr_str[DNS_SD_ADDRESS_STR_MAX];
 
 			IIO_DEBUG("'getaddrinfo()' failed: %s. Trying dnssd as a last resort...\n",


### PR DESCRIPTION
If we have `#define HAVE_DNS_SD 0`, Clang 9 (and probably other versions)
will correctly detect that `if (HAVE_DNS_SD && ret)` is dead code,
but will fail to detect that `if (ret && HAVE_DNS_SD)` is dead code.
If the dead code calls symbols not provided at link time, then linking
will then fail.

Fix this by swapping the two expressions in the "if" block.

Stupid, right?

Signed-off-by: Paul Cercueil <paul@crapouillou.net>
Reported-by: Adrian Suciu <adrian.suciu@analog.com>