### PR TITLE
Enable scan support in module backends

### DIFF
--- a/context.c
+++ b/context.c
@@ -390,7 +390,7 @@ struct iio_context * iio_create_context_from_uri(const char *uri)
 	return iio_create_context(NULL, uri);
 }
 
-static const struct iio_backend *iio_backends[] = {
+const struct iio_backend *iio_backends[] = {
 	IF_ENABLED(WITH_LOCAL_BACKEND, &iio_local_backend),
 	IF_ENABLED(WITH_NETWORK_BACKEND, &iio_ip_backend),
 	IF_ENABLED(WITH_SERIAL_BACKEND && !WITH_SERIAL_BACKEND_DYNAMIC,
@@ -398,6 +398,7 @@ static const struct iio_backend *iio_backends[] = {
 	IF_ENABLED(WITH_USB_BACKEND, &iio_usb_backend),
 	IF_ENABLED(WITH_XML_BACKEND, &iio_xml_backend),
 };
+const unsigned int iio_backends_size = ARRAY_SIZE(iio_backends);
 
 struct iio_context * iio_create_context(const struct iio_context_params *params,
 					const char *uri)

--- a/dns_sd.h
+++ b/dns_sd.h
@@ -36,6 +36,7 @@ struct addrinfo;
 struct AvahiSimplePoll;
 struct AvahiAddress;
 struct iio_context_params;
+struct iio_scan;
 
 /* Common structure which all dns_sd_[*] files fill out
  * Anything that is dynamically allocated (malloc) needs to be managed
@@ -87,5 +88,8 @@ void port_knock_discovery_data(const struct iio_context_params *params,
 /* Use dnssd to resolve a given hostname */
 int dnssd_resolve_host(const struct iio_context_params *params,
 		       const char *hostname, char *ip_addr, const int addr_len);
+
+int dnssd_context_scan(const struct iio_context_params *params,
+		       struct iio_scan *ctx);
 
 #endif /* __IIO_DNS_SD_H */

--- a/dynamic-windows.c
+++ b/dynamic-windows.c
@@ -6,9 +6,16 @@
  * Author: Paul Cercueil <paul.cercueil@analog.com>
  */
 
+#include "iio-backend.h"
 #include "iio-private.h"
 
+#include <errno.h>
 #include <windows.h>
+
+struct iio_directory {
+	char *lastpath;
+	HANDLE file;
+};
 
 struct iio_module * iio_open_module(const char *path)
 {
@@ -24,4 +31,53 @@ const struct iio_backend *
 iio_module_get_backend(struct iio_module *module, const char *symbol)
 {
 	return (const void *) GetProcAddress((void *) module, symbol);
+}
+
+struct iio_directory * iio_open_dir(const char *path)
+{
+	struct iio_directory *dir;
+	WIN32_FIND_DATA fdata;
+	char buf[PATH_MAX];
+
+	dir = zalloc(sizeof(*dir));
+	if (!dir)
+		return ERR_TO_PTR(-ENOMEM);
+
+	iio_snprintf(buf, sizeof(buf), "%s\\*", path);
+
+	/* FindFirstFileA will always return the '.' folder if the directory
+	 * exists, so we don't care if the related fdata is lost. */
+	dir->file = FindFirstFileA(buf, &fdata);
+	if (dir->file == INVALID_HANDLE_VALUE) {
+		if (GetLastError() == ERROR_FILE_NOT_FOUND)
+			return ERR_TO_PTR(-ENOENT);
+		else
+			return ERR_TO_PTR(-EIO);
+	}
+
+	return dir;
+}
+
+void iio_close_dir(struct iio_directory *dir)
+{
+	if (dir->file)
+		FindClose(dir->file);
+	free (dir->lastpath);
+	free(dir);
+}
+
+const char * iio_dir_get_next_file_name(struct iio_directory *dir)
+{
+	WIN32_FIND_DATA fdata;
+
+	free(dir->lastpath);
+
+	do {
+		if (!FindNextFileA(dir->file, &fdata))
+			return NULL;
+	} while (fdata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY);
+
+	dir->lastpath = _strdup(fdata.cFileName);
+
+	return dir->lastpath;
 }

--- a/dynamic.c
+++ b/dynamic.c
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/types.h>
 
 static const struct iio_backend *
 get_iio_backend(const struct iio_context_params *params,
@@ -97,4 +98,73 @@ iio_create_dynamic_context(const struct iio_context_params *params,
 out_release_module:
 	iio_release_module(lib);
 	return NULL;
+}
+
+int iio_dynamic_scan(const struct iio_context_params *params,
+		     struct iio_scan *ctx, const char *backends)
+{
+	struct iio_context_params params2 = *params;
+	const struct iio_backend *backend;
+	const char *path, *endchar, *startchar;
+	struct iio_module *lib;
+	struct iio_directory *dir;
+	char buf[256];
+	int ret = 0;
+
+	dir = iio_open_dir(IIO_MODULES_DIR);
+	if (IS_ERR(dir)) {
+		ret = (int) PTR_TO_ERR(dir);
+
+		if (ret != -ENOENT)
+			prm_perror(params, -ret, "Unable to open modules directory");
+		return ret;
+	}
+
+	prm_dbg(params, "Opened directory " IIO_MODULES_DIR "\n");
+
+	while (true) {
+		path = iio_dir_get_next_file_name(dir);
+		if (!path)
+			break;
+
+		endchar = strrchr(path, '.');
+		if (!endchar || strcmp(endchar, IIO_LIBRARY_SUFFIX) ||
+		    strncmp(path, "libiio-", sizeof("libiio-") - 1))
+			continue;
+
+		startchar = path + sizeof("libiio-") - 1;
+
+		iio_snprintf(buf, sizeof(buf), "%.*s",
+			     (int) (endchar - startchar), startchar);
+
+		if (backends && !iio_list_has_elem(backends, buf))
+			continue;
+
+		backend = get_iio_backend(params, buf, &lib);
+		if (IS_ERR(backend)) {
+			iio_close_dir(dir);
+			return (int) PTR_TO_ERR(backend);
+		}
+
+		prm_dbg(params, "Found backend: %s\n", backend->name);
+
+		if (params->timeout_ms)
+			params2.timeout_ms = params->timeout_ms;
+		else
+			params2.timeout_ms = backend->default_timeout_ms;
+
+		if (backend->ops && backend->ops->scan) {
+			ret = backend->ops->scan(&params2, ctx);
+			if (ret < 0) {
+				prm_perror(params, -ret,
+					   "Unable to scan %s context(s)", buf);
+			}
+		}
+
+		iio_release_module(lib);
+	}
+
+	iio_close_dir(dir);
+
+	return 0;
 }

--- a/iio-backend.h
+++ b/iio-backend.h
@@ -156,6 +156,9 @@ iio_channel_get_pdata(const struct iio_channel *chn);
 __api void
 iio_channel_set_pdata(struct iio_channel *chn, struct iio_channel_pdata *data);
 
+__api int
+iio_scan_add_result(struct iio_scan *ctx, const char *desc, const char *uri);
+
 #if defined(__MINGW32__)
 #   define __iio_printf __attribute__((__format__(gnu_printf, 3, 4)))
 #elif defined(__GNUC__)

--- a/iio-backend.h
+++ b/iio-backend.h
@@ -71,6 +71,8 @@ enum iio_attr_type {
 };
 
 struct iio_backend_ops {
+	int (*scan)(const struct iio_context_params *params,
+		    struct iio_scan *ctx);
 	struct iio_context * (*create)(const struct iio_context_params *params,
 				       const char *uri);
 	struct iio_context * (*clone)(const struct iio_context *ctx);

--- a/iio-config.h.cmakein
+++ b/iio-config.h.cmakein
@@ -41,4 +41,6 @@
 #cmakedefine NO_THREADS
 #cmakedefine HAS_LIBUSB_GETVERSION
 
+#define IF_ENABLED(cfg, ptr) ((cfg) ? (ptr) : NULL)
+
 #endif /* IIO_CONFIG_H */

--- a/iio-private.h
+++ b/iio-private.h
@@ -208,8 +208,6 @@ struct iio_context *
 iio_create_dynamic_context(const struct iio_context_params *params,
 			   const char *uri);
 
-int local_context_scan(struct iio_scan_result *scan_result);
-
 int dnssd_context_scan(struct iio_scan_result *scan_result);
 
 ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,

--- a/iio-private.h
+++ b/iio-private.h
@@ -208,8 +208,6 @@ struct iio_context *
 iio_create_dynamic_context(const struct iio_context_params *params,
 			   const char *uri);
 
-int dnssd_context_scan(struct iio_scan_result *scan_result);
-
 ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 		const uint32_t *mask, size_t words);
 

--- a/iio-private.h
+++ b/iio-private.h
@@ -77,6 +77,7 @@ static inline __check_ret void * ERR_TO_PTR(intptr_t err)
 struct iio_context_pdata;
 struct iio_device_pdata;
 struct iio_channel_pdata;
+struct iio_directory;
 struct iio_module;
 
 struct iio_channel_attr {
@@ -162,6 +163,10 @@ void iio_release_module(struct iio_module *module);
 
 const struct iio_backend *
 iio_module_get_backend(struct iio_module *module, const char *symbol);
+
+struct iio_directory * iio_open_dir(const char *path);
+void iio_close_dir(struct iio_directory *dir);
+const char * iio_dir_get_next_file_name(struct iio_directory *dir);
 
 void free_channel(struct iio_channel *chn);
 void free_device(struct iio_device *dev);

--- a/iio-private.h
+++ b/iio-private.h
@@ -173,9 +173,6 @@ void iio_release_module(struct iio_module *module);
 const struct iio_backend *
 iio_module_get_backend(struct iio_module *module, const char *symbol);
 
-struct iio_context_info *
-iio_scan_result_add(struct iio_scan_result *scan_result);
-
 void free_channel(struct iio_channel *chn);
 void free_device(struct iio_device *dev);
 

--- a/iio-private.h
+++ b/iio-private.h
@@ -162,11 +162,6 @@ struct iio_context_info {
 	char *uri;
 };
 
-struct iio_scan_result {
-	size_t size;
-	struct iio_context_info *info;
-};
-
 struct iio_module * iio_open_module(const char *path);
 void iio_release_module(struct iio_module *module);
 

--- a/iio-private.h
+++ b/iio-private.h
@@ -238,4 +238,7 @@ extern const struct iio_backend iio_serial_backend;
 extern const struct iio_backend iio_usb_backend;
 extern const struct iio_backend iio_xml_backend;
 
+extern const struct iio_backend *iio_backends[];
+extern const unsigned int iio_backends_size;
+
 #endif /* __IIO_PRIVATE_H__ */

--- a/iio-private.h
+++ b/iio-private.h
@@ -157,11 +157,6 @@ struct iio_buffer {
 	bool is_output, dev_is_high_speed;
 };
 
-struct iio_context_info {
-	char *description;
-	char *uri;
-};
-
 struct iio_module * iio_open_module(const char *path);
 void iio_release_module(struct iio_module *module);
 

--- a/iio-private.h
+++ b/iio-private.h
@@ -210,8 +210,6 @@ iio_create_dynamic_context(const struct iio_context_params *params,
 
 int local_context_scan(struct iio_scan_result *scan_result);
 
-int usb_context_scan(struct iio_scan_result *scan_result);
-
 int dnssd_context_scan(struct iio_scan_result *scan_result);
 
 ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,

--- a/iio-private.h
+++ b/iio-private.h
@@ -199,6 +199,8 @@ struct iio_context * xml_create_context_mem(const struct iio_context_params *par
 struct iio_context *
 iio_create_dynamic_context(const struct iio_context_params *params,
 			   const char *uri);
+int iio_dynamic_scan(const struct iio_context_params *params,
+		     struct iio_scan *ctx, const char *backends);
 
 ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 		const uint32_t *mask, size_t words);

--- a/network.c
+++ b/network.c
@@ -904,6 +904,7 @@ static struct iio_context * network_clone(const struct iio_context *ctx)
 }
 
 static const struct iio_backend_ops network_ops = {
+	.scan = IF_ENABLED(HAVE_DNS_SD, dnssd_context_scan),
 	.create = network_create_context,
 	.clone = network_clone,
 	.open = network_open,

--- a/scan.c
+++ b/scan.c
@@ -13,6 +13,11 @@
 #include <stdbool.h>
 #include <string.h>
 
+struct iio_context_info {
+	char *description;
+	char *uri;
+};
+
 struct iio_scan {
 	struct iio_context_info *info;
 	size_t count;

--- a/scan.c
+++ b/scan.c
@@ -14,7 +14,8 @@
 #include <string.h>
 
 struct iio_scan {
-	struct iio_scan_result scan_result;
+	struct iio_context_info *info;
+	size_t count;
 };
 
 static bool has_backend(const char *backends, const char *backend)
@@ -77,48 +78,48 @@ void iio_scan_destroy(struct iio_scan *ctx)
 {
 	unsigned int i;
 
-	for (i = 0; i < ctx->scan_result.size; i++) {
-		free(ctx->scan_result.info[i].description);
-		free(ctx->scan_result.info[i].uri);
+	for (i = 0; i < ctx->count; i++) {
+		free(ctx->info[i].description);
+		free(ctx->info[i].uri);
 	}
 
-	free(ctx->scan_result.info);
+	free(ctx->info);
 	free(ctx);
 }
 
 size_t iio_scan_get_results_count(const struct iio_scan *ctx)
 {
-	return ctx->scan_result.size;
+	return ctx->count;
 }
 
 const char *
 iio_scan_get_description(const struct iio_scan *ctx, size_t idx)
 {
-	if (idx >= ctx->scan_result.size)
+	if (idx >= ctx->count)
 		return NULL;
 
-	return ctx->scan_result.info[idx].description;
+	return ctx->info[idx].description;
 }
 
 const char * iio_scan_get_uri(const struct iio_scan *ctx, size_t idx)
 {
-	if (idx >= ctx->scan_result.size)
+	if (idx >= ctx->count)
 		return NULL;
 
-	return ctx->scan_result.info[idx].uri;
+	return ctx->info[idx].uri;
 }
 
 int iio_scan_add_result(struct iio_scan *ctx, const char *desc, const char *uri)
 {
 	struct iio_context_info *info;
-	size_t size = ctx->scan_result.size;
+	size_t size = ctx->count;
 
-	info = realloc(ctx->scan_result.info, (size + 1) * sizeof(*info));
+	info = realloc(ctx->info, (size + 1) * sizeof(*info));
 	if (!info)
 		return -ENOMEM;
 
-	ctx->scan_result.info = info;
-	ctx->scan_result.size = size + 1;
+	ctx->info = info;
+	ctx->count = size + 1;
 
 	info = &info[size];
 	info->description = iio_strdup(desc);

--- a/scan.c
+++ b/scan.c
@@ -86,14 +86,6 @@ struct iio_scan * iio_scan(const struct iio_context_params *params,
 		}
 	}
 
-	if (HAVE_DNS_SD && has_backend(backends, "ip")) {
-		ret = dnssd_context_scan(&ctx->scan_result);
-		if (ret < 0) {
-			prm_perror(params, -ret,
-				   "Unable to scan network context(s)");
-		}
-	}
-
 	return ctx;
 }
 

--- a/scan.c
+++ b/scan.c
@@ -147,3 +147,25 @@ const char * iio_scan_get_uri(const struct iio_scan *ctx, size_t idx)
 
 	return ctx->scan_result.info[idx].uri;
 }
+
+int iio_scan_add_result(struct iio_scan *ctx, const char *desc, const char *uri)
+{
+	struct iio_context_info *info;
+	size_t size = ctx->scan_result.size;
+
+	info = realloc(ctx->scan_result.info, (size + 1) * sizeof(*info));
+	if (!info)
+		return -ENOMEM;
+
+	ctx->scan_result.info = info;
+	ctx->scan_result.size = size + 1;
+
+	info = &info[size];
+	info->description = iio_strdup(desc);
+	info->uri = iio_strdup(uri);
+
+	if (!info->description || !info->uri)
+		return -ENOMEM;
+
+	return 0;
+}

--- a/scan.c
+++ b/scan.c
@@ -94,14 +94,6 @@ struct iio_scan * iio_scan(const struct iio_context_params *params,
 		}
 	}
 
-	if (WITH_USB_BACKEND && has_backend(backends, "usb")) {
-		ret = usb_context_scan(&ctx->scan_result);
-		if (ret < 0) {
-			prm_perror(params, -ret,
-				   "Unable to scan USB context(s)");
-		}
-	}
-
 	if (HAVE_DNS_SD && has_backend(backends, "ip")) {
 		ret = dnssd_context_scan(&ctx->scan_result);
 		if (ret < 0) {

--- a/scan.c
+++ b/scan.c
@@ -17,22 +17,6 @@ struct iio_scan {
 	struct iio_scan_result scan_result;
 };
 
-struct iio_context_info *
-iio_scan_result_add(struct iio_scan_result *scan_result)
-{
-	struct iio_context_info *info;
-	size_t size = scan_result->size;
-
-	info = realloc(scan_result->info, (size + 1) * sizeof(*info));
-	if (!info)
-		return NULL;
-
-	scan_result->info = info;
-	scan_result->size = size + 1;
-
-	return &info[size];
-}
-
 static bool has_backend(const char *backends, const char *backend)
 {
 	return !backends || iio_list_has_elem(backends, backend);

--- a/scan.c
+++ b/scan.c
@@ -76,6 +76,16 @@ struct iio_scan * iio_scan(const struct iio_context_params *params,
 		}
 	}
 
+	if (WITH_MODULES) {
+		params2.timeout_ms = params->timeout_ms;
+
+		ret = iio_dynamic_scan(&params2, ctx, backends);
+		if (ret < 0) {
+			prm_perror(&params2, -ret,
+				   "Error while scanning dynamic context(s)");
+		}
+	}
+
 	return ctx;
 }
 

--- a/scan.c
+++ b/scan.c
@@ -86,14 +86,6 @@ struct iio_scan * iio_scan(const struct iio_context_params *params,
 		}
 	}
 
-	if (WITH_LOCAL_BACKEND && has_backend(backends, "local")) {
-		ret = local_context_scan(&ctx->scan_result);
-		if (ret < 0) {
-			prm_perror(params, -ret,
-				   "Unable to scan local context(s)");
-		}
-	}
-
 	if (HAVE_DNS_SD && has_backend(backends, "ip")) {
 		ret = dnssd_context_scan(&ctx->scan_result);
 		if (ret < 0) {


### PR DESCRIPTION
This PR adds a mechanism to support scanning IIO contexts in built-in and module backends. This will later allow the network and USB backends to be compiled as modules.

It adds a `.scan` callback to the iio_backend structure, which will now be called by the core when scanning for the backends' available IIO contexts. It also updates the dynamic.c file to support scanning, by browsing the libiio modules directory, opening each module and calling its .scan function if the module's URI matches one of the requested backends.