### PR TITLE
Local context fixes

### DIFF
--- a/context.c
+++ b/context.c
@@ -155,17 +155,17 @@ static char * iio_context_create_xml(const struct iio_context *ctx)
 
 	len = iio_snprintf_context_xml(NULL, 0, ctx);
 	if (len < 0)
-		return ERR_TO_PTR(len);
+		return ERR_PTR((int) len);
 
 	len++; /* room for terminating NULL */
 	str = malloc(len);
 	if (!str)
-		return ERR_TO_PTR(-ENOMEM);
+		return ERR_PTR(-ENOMEM);
 
 	len = iio_snprintf_context_xml(str, len, ctx);
 	if (len < 0) {
 		free(str);
-		return ERR_TO_PTR(len);
+		return ERR_PTR((int) len);
 	}
 
 	return str;
@@ -328,7 +328,7 @@ int iio_context_init(struct iio_context *ctx)
 	if (!ctx->xml) {
 		ctx->xml = iio_context_create_xml(ctx);
 		if (IS_ERR(ctx->xml))
-			return PTR_TO_ERR(ctx->xml);
+			return PTR_ERR(ctx->xml);
 	}
 
 	return 0;

--- a/iio-private.h
+++ b/iio-private.h
@@ -106,14 +106,14 @@ static inline __check_ret bool IS_ERR(const void *ptr)
 	return (uintptr_t)ptr >= (uintptr_t)-4095;
 }
 
-static inline __check_ret intptr_t PTR_TO_ERR(const void *ptr)
+static inline __check_ret int PTR_ERR(const void *ptr)
 {
-	return (intptr_t)ptr;
+	return (int)(intptr_t) ptr;
 }
 
-static inline __check_ret void * ERR_TO_PTR(intptr_t err)
+static inline __check_ret void * ERR_PTR(int err)
 {
-	return (void *)err;
+	return (void *)(intptr_t) err;
 }
 
 /*

--- a/local.c
+++ b/local.c
@@ -1799,7 +1799,10 @@ static int create_device(void *d, const char *path)
 	for (i = 0; i < dev->nb_channels; i++) {
 		struct iio_channel *chn = dev->channels[i];
 
-		set_channel_name(chn);
+		ret = set_channel_name(chn);
+		if (ret < 0)
+			goto err_free_scan_elements;
+
 		ret = handle_scan_elements(chn);
 		free_protected_attrs(chn);
 		if (ret < 0)

--- a/local.c
+++ b/local.c
@@ -1491,8 +1491,7 @@ static int add_channel(struct iio_device *dev, const char *name,
 
 	ret = add_channel_to_device(dev, chn);
 	if (ret) {
-		free(chn->pdata->enable_fn);
-		free(chn->pdata);
+		local_free_channel_pdata(chn);
 		free_channel(chn);
 	}
 	return ret;

--- a/xml.c
+++ b/xml.c
@@ -176,7 +176,7 @@ static struct iio_channel * create_channel(struct iio_device *dev, xmlNode *n)
 
 	chn = zalloc(sizeof(*chn));
 	if (!chn)
-		return ERR_TO_PTR(-ENOMEM);
+		return ERR_PTR(-ENOMEM);
 
 	chn->dev = dev;
 
@@ -234,7 +234,7 @@ static struct iio_channel * create_channel(struct iio_device *dev, xmlNode *n)
 
 err_free_channel:
 	free_channel(chn);
-	return ERR_TO_PTR(err);
+	return ERR_PTR(err);
 }
 
 static struct iio_device * create_device(struct iio_context *ctx, xmlNode *n)
@@ -245,7 +245,7 @@ static struct iio_device * create_device(struct iio_context *ctx, xmlNode *n)
 
 	dev = zalloc(sizeof(*dev));
 	if (!dev)
-		return ERR_TO_PTR(-ENOMEM);
+		return ERR_PTR(-ENOMEM);
 
 	dev->ctx = ctx;
 
@@ -280,7 +280,7 @@ static struct iio_device * create_device(struct iio_context *ctx, xmlNode *n)
 			struct iio_channel **chns,
 					   *chn = create_channel(dev, n);
 			if (IS_ERR(chn)) {
-				err = PTR_TO_ERR(chn);
+				err = PTR_ERR(chn);
 				IIO_ERROR("Unable to create channel: %d\n", err);
 				goto err_free_device;
 			}
@@ -328,7 +328,8 @@ static struct iio_device * create_device(struct iio_context *ctx, xmlNode *n)
 
 err_free_device:
 	free_device(dev);
-	return ERR_TO_PTR(err);
+
+	return ERR_PTR(err);
 }
 
 static struct iio_context * xml_clone(const struct iio_context *ctx)
@@ -389,7 +390,7 @@ static int iio_populate_xml_context_helper(struct iio_context *ctx, xmlNode *roo
 
 		dev = create_device(ctx, n);
 		if (IS_ERR(dev)) {
-			err = PTR_TO_ERR(dev);
+			err = PTR_ERR(dev);
 			IIO_ERROR("Unable to create device: %d\n", err);
 			return err;
 		}


### PR DESCRIPTION
Some simple fixes to the local context, mainly to avoid error codes being lost.

I also renamed the PTR_TO_ERR / ERR_TO_PTR macros to just PTR_ERR / ERR_PTR since people are more familiar with them, and the error code is now just "int" instead of "intptr_t" which prevents warnings about implicit casts to a type of a different size.