### PR TITLE
Update udev rule to only scan USB

### DIFF
--- a/libiio.rules.cmakein
+++ b/libiio.rules.cmakein
@@ -1,1 +1,1 @@
-SUBSYSTEM=="usb", PROGRAM=="/bin/sh -c '@CMAKE_INSTALL_FULL_BINDIR@/iio_info -s | grep %s{idVendor}:%s{idProduct}'", RESULT!="", MODE="666"
+SUBSYSTEM=="usb", PROGRAM=="/bin/sh -c '@CMAKE_INSTALL_FULL_BINDIR@/iio_info -S usb | grep %s{idVendor}:%s{idProduct}'", RESULT!="", MODE="666"


### PR DESCRIPTION
Having "iio_info -s" in the udev rule will scan all available backends,
and some (like the network backend) may take a while to process.

Run "iio_info -S usb" instead to specify that we only want to scan USB
contexts.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>

@AlexandraTrifan can I add you as Reported-By?