### PR TITLE
Put library version in XML string

### DIFF
--- a/context.c
+++ b/context.c
@@ -272,6 +272,7 @@ void iio_context_destroy(struct iio_context *ctx)
 	free(ctx->devices);
 	free(ctx->xml);
 	free(ctx->description);
+	free(ctx->git_tag);
 	free(ctx->pdata);
 	free(ctx);
 }

--- a/context.c
+++ b/context.c
@@ -366,9 +366,6 @@ int iio_context_get_version(const struct iio_context *ctx,
 		return 0;
 	}
 
-	if (ctx->ops->get_version)
-		return ctx->ops->get_version(ctx, major, minor, git_tag);
-
 	iio_library_get_version(major, minor, git_tag);
 	return 0;
 }

--- a/context.c
+++ b/context.c
@@ -102,14 +102,21 @@ static ssize_t iio_snprintf_context_xml(char *ptr, ssize_t len,
 	ssize_t ret, alen = 0;
 	unsigned int i;
 
-	if (ctx->description)
-		ret = iio_snprintf(ptr, len, "%s<context name=\"%s\" "
-				   "description=\"%s\" >",
-				   xml_header, ctx->name, ctx->description);
-	else
-		ret = iio_snprintf(ptr, len, "%s<context name=\"%s\" >",
-				   xml_header, ctx->name);
+	ret = iio_snprintf(ptr, len, "%s<context name=\"%s\" ",
+			   xml_header, ctx->name);
+	if (ret < 0)
+		return ret;
 
+	iio_update_xml_indexes(ret, &ptr, &len, &alen);
+
+	if (ctx->description) {
+		ret = iio_xml_print_and_sanitized_param(ptr, len,
+							"description=\"",
+							ctx->description,
+							"\" >");
+	} else {
+		ret = iio_snprintf(ptr, len, ">");
+	}
 	if (ret < 0)
 		return ret;
 

--- a/context.c
+++ b/context.c
@@ -24,7 +24,8 @@ static const char xml_header[] = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
 "<!ELEMENT scan-element EMPTY>"
 "<!ELEMENT debug-attribute EMPTY>"
 "<!ELEMENT buffer-attribute EMPTY>"
-"<!ATTLIST context name CDATA #REQUIRED description CDATA #IMPLIED>"
+"<!ATTLIST context name CDATA #REQUIRED version-major CDATA #REQUIRED "
+"version-minor CDATA #REQUIRED version-git CDATA #REQUIRED description CDATA #IMPLIED>"
 "<!ATTLIST context-attribute name CDATA #REQUIRED value CDATA #REQUIRED>"
 "<!ATTLIST device id CDATA #REQUIRED name CDATA #IMPLIED label CDATA #IMPLIED>"
 "<!ATTLIST channel id CDATA #REQUIRED type (input|output) #REQUIRED name CDATA #IMPLIED>"
@@ -100,10 +101,17 @@ static ssize_t iio_snprintf_context_xml(char *ptr, ssize_t len,
 					const struct iio_context *ctx)
 {
 	ssize_t ret, alen = 0;
-	unsigned int i;
+	unsigned int i, major, minor;
+	char git_tag[64];
 
-	ret = iio_snprintf(ptr, len, "%s<context name=\"%s\" ",
-			   xml_header, ctx->name);
+	ret = iio_context_get_version(ctx, &major, &minor, git_tag);
+	if (ret < 0)
+		return ret;
+
+	ret = iio_snprintf(ptr, len,
+			   "%s<context name=\"%s\" version-major=\"%u\" "
+			   "version-minor=\"%u\" version-git=\"%s\" ",
+			   xml_header, ctx->name, major, minor, git_tag);
 	if (ret < 0)
 		return ret;
 

--- a/context.c
+++ b/context.c
@@ -355,6 +355,17 @@ int iio_context_init(struct iio_context *ctx)
 int iio_context_get_version(const struct iio_context *ctx,
 		unsigned int *major, unsigned int *minor, char git_tag[8])
 {
+	if (ctx->git_tag) {
+		if (major)
+			*major = ctx->major;
+		if (minor)
+			*minor = ctx->minor;
+		if (git_tag)
+			iio_strlcpy(git_tag, ctx->git_tag, 8);
+
+		return 0;
+	}
+
 	if (ctx->ops->get_version)
 		return ctx->ops->get_version(ctx, major, minor, git_tag);
 

--- a/iio-backend.h
+++ b/iio-backend.h
@@ -62,9 +62,6 @@ struct iio_backend_ops {
 
 	char * (*get_description)(const struct iio_context *ctx);
 
-	int (*get_version)(const struct iio_context *ctx, unsigned int *major,
-			unsigned int *minor, char git_tag[8]);
-
 	int (*set_timeout)(struct iio_context *ctx, unsigned int timeout);
 };
 

--- a/iio-private.h
+++ b/iio-private.h
@@ -136,6 +136,10 @@ struct iio_context {
 	const char *name;
 	char *description;
 
+	unsigned int major;
+	unsigned int minor;
+	char *git_tag;
+
 	struct iio_device **devices;
 	unsigned int nb_devices;
 

--- a/iiod-client.h
+++ b/iiod-client.h
@@ -35,11 +35,6 @@ struct iiod_client * iiod_client_new(struct iio_context_pdata *pdata,
 				     const struct iiod_client_ops *ops);
 void iiod_client_destroy(struct iiod_client *client);
 
-int iiod_client_get_version(struct iiod_client *client,
-			    struct iiod_client_pdata *desc,
-			    unsigned int *major, unsigned int *minor,
-			    char *git_tag);
-
 int iiod_client_get_trigger(struct iiod_client *client,
 			    struct iiod_client_pdata *desc,
 			    const struct iio_device *dev,

--- a/network.c
+++ b/network.c
@@ -856,15 +856,6 @@ static void network_shutdown(struct iio_context *ctx)
 	freeaddrinfo(pdata->addrinfo);
 }
 
-static int network_get_version(const struct iio_context *ctx,
-		unsigned int *major, unsigned int *minor, char git_tag[8])
-{
-	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
-
-	return iiod_client_get_version(pdata->iiod_client,
-			&pdata->io_ctx, major, minor, git_tag);
-}
-
 static unsigned int calculate_remote_timeout(unsigned int timeout)
 {
 	/* XXX(pcercuei): We currently hardcode timeout / 2 for the backend used
@@ -927,7 +918,6 @@ static const struct iio_backend_ops network_ops = {
 	.set_trigger = network_set_trigger,
 	.shutdown = network_shutdown,
 	.get_description = network_get_description,
-	.get_version = network_get_version,
 	.set_timeout = network_set_timeout,
 	.set_kernel_buffers_count = network_set_kernel_buffers_count,
 

--- a/serial.c
+++ b/serial.c
@@ -96,15 +96,6 @@ static inline int libserialport_to_errno(enum sp_return ret)
 	}
 }
 
-static int serial_get_version(const struct iio_context *ctx,
-		unsigned int *major, unsigned int *minor, char git_tag[8])
-{
-	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
-
-	return iiod_client_get_version(pdata->iiod_client, NULL,
-			major, minor, git_tag);
-}
-
 static char * __serial_get_description(struct sp_port *port)
 {
 	char *description, *name, *desc;
@@ -356,7 +347,6 @@ static int serial_set_timeout(struct iio_context *ctx, unsigned int timeout)
 }
 
 static const struct iio_backend_ops serial_ops = {
-	.get_version = serial_get_version,
 	.open = serial_open,
 	.close = serial_close,
 	.read = serial_read,

--- a/usb.c
+++ b/usb.c
@@ -119,15 +119,6 @@ static void usb_io_context_exit(struct iiod_client_pdata *io_ctx)
 	}
 }
 
-static int usb_get_version(const struct iio_context *ctx,
-		unsigned int *major, unsigned int *minor, char git_tag[8])
-{
-	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
-
-	return iiod_client_get_version(pdata->iiod_client,
-			&pdata->io_ctx, major, minor, git_tag);
-}
-
 static unsigned int usb_calculate_remote_timeout(unsigned int timeout)
 {
 	/* XXX(pcercuei): We currently hardcode timeout / 2 for the backend used
@@ -539,7 +530,6 @@ static void usb_cancel(const struct iio_device *dev)
 }
 
 static const struct iio_backend_ops usb_ops = {
-	.get_version = usb_get_version,
 	.open = usb_open,
 	.close = usb_close,
 	.read = usb_read,

--- a/xml.c
+++ b/xml.c
@@ -407,10 +407,12 @@ static int iio_populate_xml_context_helper(struct iio_context *ctx, xmlNode *roo
 
 static struct iio_context * iio_create_xml_context_helper(xmlDoc *doc)
 {
-	const char *description = NULL;
+	const char *description = NULL, *git_tag = NULL, *content;
 	struct iio_context *ctx;
+	long major = 0, minor = 0;
 	xmlNode *root;
 	xmlAttr *attr;
+	char *end;
 	int err;
 
 	root = xmlDocGetRootElement(doc);
@@ -421,16 +423,41 @@ static struct iio_context * iio_create_xml_context_helper(xmlDoc *doc)
 	}
 
 	for (attr = root->properties; attr; attr = attr->next) {
-		if (!strcmp((char *) attr->name, "description"))
-			description = (const char *)attr->children->content;
-		else if (strcmp((char *) attr->name, "name"))
+		content = (const char *) attr->children->content;
+
+		if (!strcmp((char *) attr->name, "description")) {
+			description = content;
+		} else if (!strcmp((char *) attr->name, "version-major")) {
+			major = strtol(content, &end, 10);
+			if (*end != '\0')
+				IIO_WARNING("invalid format for major version\n");
+		} else if (!strcmp((char *) attr->name, "version-minor")) {
+			minor = strtol(content, &end, 10);
+			if (*end != '\0')
+				IIO_WARNING("invalid format for minor version\n");
+		} else if (!strcmp((char *) attr->name, "version-git")) {
+			git_tag = content;
+		} else if (strcmp((char *) attr->name, "name")) {
 			IIO_WARNING("Unknown parameter \'%s\' in <context>\n",
-					(char *) attr->children->content);
+				    content);
+		}
 	}
 
 	ctx = iio_context_create_from_backend(&xml_backend, description);
 	if (!ctx)
 		return NULL;
+
+	if (git_tag) {
+		ctx->major = major;
+		ctx->minor = minor;
+
+		ctx->git_tag = iio_strdup(git_tag);
+		if (!ctx->git_tag) {
+			iio_context_destroy(ctx);
+			errno = ENOMEM;
+			return NULL;
+		}
+	}
 
 	err = iio_populate_xml_context_helper(ctx, root);
 	if (err) {


### PR DESCRIPTION
Hi,

Since the library version on the remote side is not expected to change during a iio_context's life, it is static data and therefore should be passed as part of the XML string.

This PR makes it easier for me to introduce other changes (less code to update to the new APIs and protocols).

It has two notable implications:

- As usual when the XML string is updated, the version of the remote libiio must be equal or newer to the version of the PC (the inverse is not true).

- IIRC, iio-osc (or was it Scopy?) uses a thread that calls iio_context_get_version() in a loop with the sole purpose to detect broken communication. That won't work anymore. I think one safe replacement would be to use iio_device_get_trigger(), since this is guaranteed to be a call to IIOD.

Cheers,
-Paul