### PR TITLE
usb: Fix goto to wrong label

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -843,7 +843,7 @@ static struct iio_context * usb_create_context(unsigned int bus,
 	if (ret < 0) {
 		ret = -(int) libusb_to_errno(ret);
 		IIO_ERROR("Unable to get usb device list: %i\n", ret);
-		goto err_destroy_iiod_client;
+		goto err_libusb_exit;
 	}
 
 	usb_dev = NULL;


### PR DESCRIPTION
The jump to the cleanup epilog pointed to the wrong label, which caused
the libusb context to never be freed on error.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>