### PR TITLE
CMake: Fix build with NO_THREADS=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,8 +401,8 @@ elseif(NEED_LIBXML2)
 endif()
 
 option(NO_THREADS "Disable multi-threading support" OFF)
-if (NEED_THREADS AND NOT NO_THREADS)
-	if (NOT WIN32)
+if (NEED_THREADS)
+	if (NOT NO_THREADS AND NOT WIN32)
 		find_library(PTHREAD_LIBRARIES pthread)
 
 		if (NOT PTHREAD_LIBRARIES)


### PR DESCRIPTION
Even if NO_THREADS is set to ON, we do want to compile lock.c inside the
library, since it will provide the symbols, just with dummy
implementations.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>