### PR TITLE
IIOD: Remove EXIT command

### DIFF
--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -1400,8 +1400,10 @@ ssize_t read_line(struct parser_pdata *pdata, char *buf, size_t len)
 			poll_nointr(pfd, 2);
 
 			if (pfd[1].revents & POLLIN ||
-					pfd[0].revents & POLLRDHUP)
+					pfd[0].revents & POLLRDHUP) {
+				pdata->stop = true;
 				return 0;
+			}
 
 			/* First read from the socket, without advancing the
 			 * read offset */

--- a/network.c
+++ b/network.c
@@ -389,8 +389,6 @@ static int network_close(const struct iio_device *dev)
 			ret = iiod_client_close_unlocked(
 					ctx_pdata->iiod_client,
 					&pdata->io_ctx, dev);
-
-			write_command(&pdata->io_ctx, "\r\nEXIT\r\n");
 		} else {
 			ret = 0;
 		}
@@ -827,10 +825,7 @@ static void network_shutdown(struct iio_context *ctx)
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 	unsigned int i;
 
-	iiod_client_mutex_lock(pdata->iiod_client);
-	write_command(&pdata->io_ctx, "\r\nEXIT\r\n");
 	close(pdata->io_ctx.fd);
-	iiod_client_mutex_unlock(pdata->iiod_client);
 
 	for (i = 0; i < iio_context_get_devices_count(ctx); i++) {
 		struct iio_device *dev = iio_context_get_device(ctx, i);


### PR DESCRIPTION
In an effort to simplify the current iiod/client protocol, so that the new async protocol will be easier to implement, remove the EXIT command of IIOD, which was sent by the client right before sockets were closed, and instead exit IIOD's client thread when the sockets are actually detected as closed.