### PR TITLE
New context / library get_version API

### DIFF
--- a/bindings/csharp/Context.cs
+++ b/bindings/csharp/Context.cs
@@ -21,11 +21,32 @@ namespace iio
         public readonly uint minor;
         public readonly string git_tag;
 
+        [DllImport("libiio.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern uint iio_context_get_version_major(IntPtr ctx);
+
+        [DllImport("libiio.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern uint iio_context_get_version_minor(IntPtr ctx);
+
+        [DllImport("libiio.dll", CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr iio_context_get_version_tag(IntPtr ctx);
+
         internal Version(uint major, uint minor, string git_tag)
         {
             this.major = major;
             this.minor = minor;
             this.git_tag = git_tag;
+        }
+
+        internal Version(IntPtr ctx)
+        {
+            Version(iio_context_get_version_major(ctx),
+                    iio_context_get_version_minor(ctx),
+                    Marshal.PtrToStringAnsi(iio_context_get_version_tag(ctx)));
+        }
+
+        internal Version()
+        {
+            Version(IntPtr.Zero);
         }
     }
 
@@ -62,12 +83,6 @@ namespace iio
 
         [DllImport("libiio.dll", CallingConvention = CallingConvention.Cdecl)]
         private static extern IntPtr iio_context_get_xml(IntPtr ctx);
-
-        [DllImport("libiio.dll", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void iio_library_get_version(ref uint major, ref uint minor, [Out()] StringBuilder git_tag);
-
-        [DllImport("libiio.dll", CallingConvention = CallingConvention.Cdecl)]
-        private static extern int iio_context_get_version(IntPtr ctx, ref uint major, ref uint minor, [Out()] StringBuilder git_tag);
 
         [DllImport("libiio.dll", CallingConvention = CallingConvention.Cdecl)]
         private static extern uint iio_context_get_devices_count(IntPtr ctx);
@@ -171,22 +186,8 @@ namespace iio
             xml = Marshal.PtrToStringAnsi(iio_context_get_xml(ctx));
             name = Marshal.PtrToStringAnsi(iio_context_get_name(ctx));
             description = Marshal.PtrToStringAnsi(iio_context_get_description(ctx));
-
-            uint major = 0;
-            uint minor = 0;
-            StringBuilder builder = new StringBuilder(8);
-            iio_library_get_version(ref major, ref minor, builder);
-            library_version = new Version(major, minor, builder.ToString());
-
-            major = 0;
-            minor = 0;
-            builder.Clear();
-            int err = iio_context_get_version(ctx, ref major, ref minor, builder);
-            if (err < 0)
-            {
-                throw new Exception("Unable to read backend version");
-            }
-            backend_version = new Version(major, minor, builder.ToString());
+            library_version = new Version();
+            backend_version = new Version(ctx);
 
             attrs = new Dictionary<string, string>();
             uint nbAttrs = iio_context_get_attrs_count(ctx);

--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -283,22 +283,17 @@ _get_xml = _lib.iio_context_get_xml
 _get_xml.restype = c_char_p
 _get_xml.argtypes = (_ContextPtr,)
 
-_get_library_version = _lib.iio_library_get_version
-_get_library_version.argtypes = (
-    _POINTER(c_uint),
-    _POINTER(c_uint),
-    c_char_p,
-)
+_get_version_major = _lib.iio_context_get_version_major
+_get_version_major.restype = c_uint
+_get_version_major.argtypes = (_ContextPtr,)
 
-_get_version = _lib.iio_context_get_version
-_get_version.restype = c_int
-_get_version.argtypes = (
-    _ContextPtr,
-    _POINTER(c_uint),
-    _POINTER(c_uint),
-    c_char_p,
-)
-_get_version.errcheck = _check_negative
+_get_version_minor = _lib.iio_context_get_version_minor
+_get_version_minor.restype = c_uint
+_get_version_minor.argtypes = (_ContextPtr,)
+
+_get_version_tag = _lib.iio_context_get_version_tag
+_get_version_tag.restype = c_char_p
+_get_version_tag.argtypes = (_ContextPtr,)
 
 _get_attrs_count = _lib.iio_context_get_attrs_count
 _get_attrs_count.restype = c_uint
@@ -629,12 +624,9 @@ _buffer_set_blocking_mode.argtypes = (_BufferPtr, c_bool)
 # pylint: enable=invalid-name
 
 
-def _get_lib_version():
-    major = c_uint()
-    minor = c_uint()
-    buf = create_string_buffer(8)
-    _get_library_version(_byref(major), _byref(minor), buf)
-    return (major.value, minor.value, buf.value.decode("ascii"))
+def _get_lib_version(ctx = None):
+    return (_get_version_major(ctx), _get_version_minor(ctx),
+            _get_version_tag(ctx).decode("ascii"))
 
 
 def _has_backend(backend):
@@ -1355,12 +1347,7 @@ class Context(object):
         self._name = _get_name(self._context).decode("ascii")
         self._description = _get_description(self._context).decode("ascii")
         self._xml = _get_xml(self._context).decode("ascii")
-
-        major = c_uint()
-        minor = c_uint()
-        buf = create_string_buffer(8)
-        _get_version(self._context, _byref(major), _byref(minor), buf)
-        self._version = (major.value, minor.value, buf.value.decode("ascii"))
+        self._version = _get_lib_version(self._context)
 
     def __del__(self):
         """Destroy this context."""

--- a/compat.c
+++ b/compat.c
@@ -210,3 +210,25 @@ const char * iio_context_info_get_uri(const struct iio_context_info *info)
 {
 	return info->uri;
 }
+
+int iio_context_get_version(const struct iio_context *ctx,
+			    unsigned int *major, unsigned int *minor,
+			    char git_tag[8])
+{
+	const char *tag = iio_context_get_version_tag(ctx);
+
+	if (git_tag)
+		iio_strlcpy(git_tag, tag, 8);
+	if (major)
+		*major = iio_context_get_version_major(ctx);
+	if (minor)
+		*minor = iio_context_get_version_minor(ctx);
+
+	return 0;
+}
+
+void iio_library_get_version(unsigned int *major, unsigned int *minor,
+			     char git_tag[8])
+{
+	iio_context_get_version(NULL, major, minor, git_tag);
+}

--- a/context.c
+++ b/context.c
@@ -392,6 +392,30 @@ int iio_context_get_version(const struct iio_context *ctx,
 	return 0;
 }
 
+unsigned int iio_context_get_version_major(const struct iio_context *ctx)
+{
+	if (ctx && ctx->git_tag)
+		return ctx->major;
+
+	return LIBIIO_VERSION_MAJOR;
+}
+
+unsigned int iio_context_get_version_minor(const struct iio_context *ctx)
+{
+	if (ctx && ctx->git_tag)
+		return ctx->minor;
+
+	return LIBIIO_VERSION_MINOR;
+}
+
+const char * iio_context_get_version_tag(const struct iio_context *ctx)
+{
+	if (ctx && ctx->git_tag)
+		return ctx->git_tag;
+
+	return LIBIIO_VERSION_GIT;
+}
+
 int iio_context_set_timeout(struct iio_context *ctx, unsigned int timeout)
 {
 	if (ctx->ops->set_timeout)

--- a/context.c
+++ b/context.c
@@ -115,17 +115,15 @@ static ssize_t iio_snprintf_context_xml(char *ptr, ssize_t len,
 					const struct iio_context *ctx)
 {
 	ssize_t ret, alen = 0;
-	unsigned int i, major, minor;
-	char git_tag[64];
-
-	ret = iio_context_get_version(ctx, &major, &minor, git_tag);
-	if (ret < 0)
-		return ret;
+	unsigned int i;
 
 	ret = iio_snprintf(ptr, len,
 			   "%s<context name=\"%s\" version-major=\"%u\" "
 			   "version-minor=\"%u\" version-git=\"%s\" ",
-			   xml_header, ctx->name, major, minor, git_tag);
+			   xml_header, ctx->name,
+			   iio_context_get_version_major(ctx),
+			   iio_context_get_version_minor(ctx),
+			   iio_context_get_version_tag(ctx));
 	if (ret < 0)
 		return ret;
 
@@ -371,24 +369,6 @@ int iio_context_init(struct iio_context *ctx)
 			return PTR_ERR(ctx->xml);
 	}
 
-	return 0;
-}
-
-int iio_context_get_version(const struct iio_context *ctx,
-		unsigned int *major, unsigned int *minor, char git_tag[8])
-{
-	if (ctx->git_tag) {
-		if (major)
-			*major = ctx->major;
-		if (minor)
-			*minor = ctx->minor;
-		if (git_tag)
-			iio_strlcpy(git_tag, ctx->git_tag, 8);
-
-		return 0;
-	}
-
-	iio_library_get_version(major, minor, git_tag);
 	return 0;
 }
 

--- a/examples/dummy-iiostream.c
+++ b/examples/dummy-iiostream.c
@@ -229,10 +229,12 @@ int main (int argc, char **argv)
 	// Listen to ctrl+c and assert
 	signal(SIGINT, handle_sig);
 
-	unsigned int i, j, major, minor;
-	char git_tag[8];
-	iio_library_get_version(&major, &minor, git_tag);
-	printf("Library version: %u.%u (git tag: %s)\n", major, minor, git_tag);
+	unsigned int i, j,
+		     major = iio_context_get_version_major(NULL),
+		     minor = iio_context_get_version_minor(NULL);
+
+	printf("Library version: %u.%u (git tag: %s)\n", major, minor,
+	       iio_context_get_version_tag(NULL));
 
 	/* check for struct iio_data_format.repeat support
 	 * 0.8 has repeat support, so anything greater than that */

--- a/iio-compat.h
+++ b/iio-compat.h
@@ -195,6 +195,27 @@ __api struct iio_context_info *
 iio_scan_block_get_info(struct iio_scan_block *blk, unsigned int index);
 
 
+/** @brief Get the version of the libiio library
+ * @param major A pointer to an unsigned integer (NULL accepted)
+ * @param minor A pointer to an unsigned integer (NULL accepted)
+ * @param git_tag A pointer to a 8-characters buffer (NULL accepted) */
+__api void iio_library_get_version(unsigned int *major,
+		unsigned int *minor, char git_tag[8]);
+
+
+/** @brief Get the version of the backend in use
+ * @param ctx A pointer to an iio_context structure
+ * @param major A pointer to an unsigned integer (NULL accepted)
+ * @param minor A pointer to an unsigned integer (NULL accepted)
+ * @param git_tag A pointer to a 8-characters buffer (NULL accepted)
+ * @return On success, 0 is returned
+ * @return On error, a negative errno code is returned */
+__api __check_ret int iio_context_get_version(const struct iio_context *ctx,
+					      unsigned int *major,
+					      unsigned int *minor,
+					      char git_tag[8]);
+
+
 /** @} *//* ------------------------------------------------------------------*/
 
 #undef __api

--- a/iio.h
+++ b/iio.h
@@ -428,6 +428,33 @@ __api __check_ret int iio_context_get_version(const struct iio_context *ctx,
 		unsigned int *major, unsigned int *minor, char git_tag[8]);
 
 
+/** @brief Get the major number of the library version
+ * @param ctx Optional pointer to an iio_context structure
+ * @return The major number
+ *
+ * NOTE: If ctx is non-null, it will return the major version of the remote
+ * library, if running remotely. */
+__api __pure unsigned int iio_context_get_version_major(const struct iio_context *ctx);
+
+
+/** @brief Get the minor number of the library version
+ * @param ctx Optional pointer to an iio_context structure
+ * @return The minor number
+ *
+ * NOTE: If ctx is non-null, it will return the minor version of the remote
+ * library, if running remotely. */
+__api __pure unsigned int iio_context_get_version_minor(const struct iio_context *ctx);
+
+
+/** @brief Get the git hash string of the library version
+ * @param ctx Optional pointer to an iio_context structure
+ * @return A NULL-terminated string that contains the git tag or hash
+ *
+ * NOTE: If ctx is non-null, it will return the git tag or hash of the remote
+ * library, if running remotely. */
+__api __pure const char * iio_context_get_version_tag(const struct iio_context *ctx);
+
+
 /** @brief Obtain a XML representation of the given context
  * @param ctx A pointer to an iio_context structure
  * @return A pointer to a static NULL-terminated string */

--- a/iio.h
+++ b/iio.h
@@ -301,14 +301,6 @@ iio_scan_get_uri(const struct iio_scan *ctx, size_t idx);
  * @{ */
 
 
-/** @brief Get the version of the libiio library
- * @param major A pointer to an unsigned integer (NULL accepted)
- * @param minor A pointer to an unsigned integer (NULL accepted)
- * @param git_tag A pointer to a 8-characters buffer (NULL accepted) */
-__api void iio_library_get_version(unsigned int *major,
-		unsigned int *minor, char git_tag[8]);
-
-
 /** @brief Get a string description of an error code
  * @param err The error code
  * @param dst A pointer to the memory area where the NULL-terminated string
@@ -415,17 +407,6 @@ __api __check_ret struct iio_context * iio_context_clone(const struct iio_contex
  *
  * <b>NOTE:</b> After that function, the iio_context pointer shall be invalid. */
 __api void iio_context_destroy(struct iio_context *ctx);
-
-
-/** @brief Get the version of the backend in use
- * @param ctx A pointer to an iio_context structure
- * @param major A pointer to an unsigned integer (NULL accepted)
- * @param minor A pointer to an unsigned integer (NULL accepted)
- * @param git_tag A pointer to a 8-characters buffer (NULL accepted)
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_context_get_version(const struct iio_context *ctx,
-		unsigned int *major, unsigned int *minor, char git_tag[8]);
 
 
 /** @brief Get the major number of the library version

--- a/tests/iio_info.c
+++ b/tests/iio_info.c
@@ -65,16 +65,16 @@ int main(int argc, char **argv)
 {
 	char **argw;
 	struct iio_context *ctx;
-	int c;
-	unsigned int i, major, minor;
-	char git_tag[8];
-	int ret;
+	unsigned int i;
+	int ret, c;
 	struct option *opts;
 
 	argw = dup_argv(MY_NAME, argc, argv);
 
-	iio_library_get_version(&major, &minor, git_tag);
-	printf("Library version: %u.%u (git tag: %s)\n", major, minor, git_tag);
+	printf("Library version: %u.%u (git tag: %s)\n",
+	       iio_context_get_version_major(NULL),
+	       iio_context_get_version_minor(NULL),
+	       iio_context_get_version_tag(NULL));
 
 	printf("Compiled with backends:");
 	for (i = 0; i < iio_get_backends_count(); i++)
@@ -125,15 +125,10 @@ int main(int argc, char **argv)
 	printf("IIO context created with %s backend.\n",
 			iio_context_get_name(ctx));
 
-	ret = iio_context_get_version(ctx, &major, &minor, git_tag);
-	if (!ret)
-		printf("Backend version: %u.%u (git tag: %s)\n",
-				major, minor, git_tag);
-	else {
-		char err_str[1024];
-		iio_strerror(-ret, err_str, sizeof(err_str));
-		fprintf(stderr, "Unable to get backend version: %s\n", err_str);
-	}
+	printf("Backend version: %u.%u (git tag: %s)\n",
+	       iio_context_get_version_major(ctx),
+	       iio_context_get_version_minor(ctx),
+	       iio_context_get_version_tag(ctx));
 
 	printf("Backend description string: %s\n",
 			iio_context_get_description(ctx));

--- a/utilities.c
+++ b/utilities.c
@@ -183,18 +183,6 @@ int write_double(char *buf, size_t len, double val)
 #endif
 }
 
-void iio_library_get_version(unsigned int *major,
-		unsigned int *minor, char git_tag[8])
-{
-	if (major)
-		*major = LIBIIO_VERSION_MAJOR;
-	if (minor)
-		*minor = LIBIIO_VERSION_MINOR;
-	if (git_tag) {
-		iio_strlcpy(git_tag, LIBIIO_VERSION_GIT, 8);
-	}
-}
-
 void iio_strerror(int err, char *buf, size_t len)
 {
 #if defined(_WIN32)


### PR DESCRIPTION
This set of commits adds thee new functions `iio_context_get_version_major`, `iio_context_get_version_minor`, `iio_context_get_version_tag`, convert the examples / tests / bindings to this new API, and moves the old `iio_library_get_version` and `iio_context_get_version` functions to the compat library.

These two had a few major problems:
- They returned the values in their parameters; therefore, calling code
  had to define local variables, then call the function, then use these
  local variables in e.g. a printf() call. The new API is simpler, as
  the values are returned directly by each function.
- The "git_tag" parameter was defined in iio.h as an array of 8
  characters (7 ASCII characters + \0 byte). While it may not happen
  anytime soon, it is doomed to fail as soon as the number of commits in
  libiio causes the short hashes to change from being 7 chars to 8 or
  more chars.
- Arrays in function prototypes are really a bad idea in general, since
  it does not offer any guarantee that the buffer is at least the size
  it claims to be. It also misleads developers, since sizeof(foo) won't
  return the same value whether "foo" is an array listed in the
  parameters, or a local or global variable.

Note that the C# binding update was not tested.