### PR TITLE
CMakelists.txt: add support for Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,7 +402,7 @@ endif()
 
 option(NO_THREADS "Disable multi-threading support" OFF)
 if (NEED_THREADS)
-	if (NOT NO_THREADS AND NOT WIN32)
+	if (NOT NO_THREADS AND NOT WIN32 AND NOT ANDROID)
 		find_library(PTHREAD_LIBRARIES pthread)
 
 		if (NOT PTHREAD_LIBRARIES)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,7 +46,7 @@ target_link_libraries(iio_writedev iio iio_tests_helper)
 
 set(IIO_TESTS_TARGETS iio_genxml iio_info iio_attr iio_readdev iio_reg iio_writedev)
 
-if(PTHREAD_LIBRARIES)
+if(PTHREAD_LIBRARIES OR ANDROID)
 	project(iio_adi_xflow_check C)
 	project(iio_stresstest C)
 	add_executable(iio_adi_xflow_check iio_adi_xflow_check.c)


### PR DESCRIPTION
Android does not use discrete pthread library but it is
contained in the standard C library https://developer.android.com/ndk/guides/stable_apis#c_library

Signed-off-by: Adrian Suciu <adrian.suciu@analog.com>