### PR TITLE
xml: Silence warnings with unknown XML tags

### DIFF
--- a/xml.c
+++ b/xml.c
@@ -30,8 +30,8 @@ static int add_attr_to_channel(struct iio_channel *chn, xmlNode *n)
 			if (!filename)
 				goto err_free;
 		} else {
-			IIO_WARNING("Unknown field \'%s\' in channel %s\n",
-					attr->name, chn->id);
+			IIO_DEBUG("Unknown field \'%s\' in channel %s\n",
+				  attr->name, chn->id);
 		}
 	}
 
@@ -72,8 +72,8 @@ static int add_attr_to_device(struct iio_device *dev, xmlNode *n, enum iio_attr_
 		if (!strcmp((char *) attr->name, "name")) {
 			name = (char *) attr->children->content;
 		} else {
-			IIO_WARNING("Unknown field \'%s\' in device %s\n",
-					attr->name, dev->id);
+			IIO_DEBUG("Unknown field \'%s\' in device %s\n",
+				  attr->name, dev->id);
 		}
 	}
 
@@ -160,8 +160,8 @@ static int setup_scan_element(struct iio_channel *chn, xmlNode *n)
 			chn->format.with_scale = true;
 			chn->format.scale = value;
 		} else {
-			IIO_WARNING("Unknown attribute \'%s\' in <scan-element>\n",
-					name);
+			IIO_DEBUG("Unknown attribute \'%s\' in <scan-element>\n",
+				  name);
 		}
 	}
 
@@ -198,10 +198,10 @@ static struct iio_channel * create_channel(struct iio_device *dev, xmlNode *n)
 			if (!strcmp(content, "output"))
 				chn->is_output = true;
 			else if (strcmp(content, "input"))
-				IIO_WARNING("Unknown channel type %s\n", content);
+				IIO_DEBUG("Unknown channel type %s\n", content);
 		} else {
-			IIO_WARNING("Unknown attribute \'%s\' in <channel>\n",
-					name);
+			IIO_DEBUG("Unknown attribute \'%s\' in <channel>\n",
+				  name);
 		}
 	}
 
@@ -222,8 +222,8 @@ static struct iio_channel * create_channel(struct iio_device *dev, xmlNode *n)
 			if (err < 0)
 				goto err_free_channel;
 		} else if (strcmp((char *) n->name, "text")) {
-			IIO_WARNING("Unknown children \'%s\' in <channel>\n",
-					n->name);
+			IIO_DEBUG("Unknown children \'%s\' in <channel>\n",
+				  n->name);
 			continue;
 		}
 	}
@@ -264,8 +264,8 @@ static struct iio_device * create_device(struct iio_context *ctx, xmlNode *n)
 			if (!dev->id)
 				goto err_free_device;
 		} else {
-			IIO_WARNING("Unknown attribute \'%s\' in <device>\n",
-					attr->name);
+			IIO_DEBUG("Unknown attribute \'%s\' in <device>\n",
+				  attr->name);
 		}
 	}
 
@@ -309,8 +309,8 @@ static struct iio_device * create_device(struct iio_context *ctx, xmlNode *n)
 			if (err < 0)
 				goto err_free_device;
 		} else if (strcmp((char *) n->name, "text")) {
-			IIO_WARNING("Unknown children \'%s\' in <device>\n",
-					n->name);
+			IIO_DEBUG("Unknown children \'%s\' in <device>\n",
+				  n->name);
 			continue;
 		}
 	}
@@ -383,8 +383,8 @@ static int iio_populate_xml_context_helper(struct iio_context *ctx, xmlNode *roo
 			continue;
 		} else if (strcmp((char *) n->name, "device")) {
 			if (strcmp((char *) n->name, "text"))
-				IIO_WARNING("Unknown children \'%s\' in "
-						"<context>\n", n->name);
+				IIO_DEBUG("Unknown children \'%s\' in "
+					  "<context>\n", n->name);
 			continue;
 		}
 
@@ -438,8 +438,8 @@ static struct iio_context * iio_create_xml_context_helper(xmlDoc *doc)
 		} else if (!strcmp((char *) attr->name, "version-git")) {
 			git_tag = content;
 		} else if (strcmp((char *) attr->name, "name")) {
-			IIO_WARNING("Unknown parameter \'%s\' in <context>\n",
-				    content);
+			IIO_DEBUG("Unknown parameter \'%s\' in <context>\n",
+				  content);
 		}
 	}
 


### PR DESCRIPTION
Silence the warnings that used to appear when the XML backend
encountered XML tags it didn't know about. As long as the DTD verifies
the XML, we can assume that the XML is sane and unknown XML tags are
just tags that were added by newer versions of IIOD.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>