### PR TITLE
Release process automatization

### DIFF
--- a/CI/travis/archive_artifacts.sh
+++ b/CI/travis/archive_artifacts.sh
@@ -1,0 +1,36 @@
+#!/bin/bash -e
+
+archive_linux() {
+	local linux_dist='CentOS-7-x86_64 CentOS-8-x86_64 Ubuntu-16.04-x86_64
+		Ubuntu-18.04-x86_64 Ubuntu-20.04-x86_64 Debian-Buster-ARM Debian-Buster-ARM64'
+
+	cd "${SOURCE_DIRECTORY}"
+	for distribution in $linux_dist; do
+		tar -zcvf Linux-"${distribution}".tar.gz Linux-"${distribution}"
+		rm -r Linux-"${distribution}"
+	done
+}
+
+archive_macOS() {
+        local macOS_dist='10.14 10.15'
+
+        cd "${SOURCE_DIRECTORY}"
+        for distribution in $macOS_dist; do
+		tar -zcvf macOS-"${distribution}".tar.gz macOS-"${distribution}"
+		rm -r macOS-"${distribution}"
+        done
+}
+
+archive_windows() {
+        local windows_dist='Win32 x64'
+
+        cd "${SOURCE_DIRECTORY}"
+        for distribution in $windows_dist; do
+		zip -r Windows-VS-16-2019-"${distribution}".zip Windows-VS-16-2019-"${distribution}"
+		rm -r Windows-VS-16-2019-"${distribution}"
+        done
+}
+
+archive_linux
+archive_macOS
+archive_windows

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,8 +1,13 @@
 trigger:
-- main
-- master
-- staging/*
-- 20*
+  branches:
+    include:
+    - main
+    - master
+    - staging/*
+    - 20*
+  tags:
+    include:
+    - v*
 
 pr:
 - main
@@ -177,3 +182,27 @@ stages:
         env:
           MAPPED_VAR: $(SERVER_ADDRESS)
         displayName: "Push artifacts to SW Downloads"
+  - job: PushToGithubRelease
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          path: '$(Build.ArtifactStagingDirectory)'
+      - bash: ./CI/travis/archive_artifacts.sh
+        env:
+          SOURCE_DIRECTORY: $(Build.ArtifactStagingDirectory)
+        displayName: "Archive artifacts"
+      - task: GithubRelease@0
+        displayName: 'Attach artifacts to GitHub Release'
+        inputs:
+          gitHubConnection: libiio-release
+          repositoryName: $(Build.Repository.Name)
+          action: create
+          target: $(Build.SourceVersion)
+          tag: $(Build.SourceBranchName)
+          title: "$(Build.SourceBranchName): Version <edit>"
+          assets: $(Build.ArtifactStagingDirectory)/*
+          addChangeLog: true
+          isDraft: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -161,6 +161,7 @@ stages:
   dependsOn: Builds
   jobs:
   - job: PushToSWDownloads
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     pool:
       vmImage: 'ubuntu-latest'
     steps:
@@ -175,5 +176,4 @@ stages:
       - bash: chmod 600 $(key.secureFilePath) ; scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss -vv -i $(key.secureFilePath) -r /home/vsts/work/1/a/* $MAPPED_VAR
         env:
           MAPPED_VAR: $(SERVER_ADDRESS)
-        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
         displayName: "Push artifacts to SW Downloads"


### PR DESCRIPTION
Each new version tag will trigger "PushToGithubRelease" job to run on Azure Pipelines. The result of this job is a draft release on Github.

Draft release will contain:
    - buildartifacts
    - changelog
    - release title.

CI/travis/archive_artifacts.sh script was added in order to archive buildartifacts that will be pushed as assets in draft release.
