### PR TITLE
C#: public fields with getters/setters cannot be marked readonly

### DIFF
--- a/bindings/csharp/Device.cs
+++ b/bindings/csharp/Device.cs
@@ -208,7 +208,7 @@ namespace iio
         public readonly string name;
 
         /// <summary>The label of this device.</summary>
-        public readonly string label { get; private set; }
+        public string label { get; private set; }
 
         /// <summary>A <c>list</c> of all the attributes that this device has.</summary>
         public readonly List<Attr> attrs;


### PR DESCRIPTION
MSVC would fail with the following error:
error CS0106: The modifier 'readonly' is not valid for this item

Reported-by: Raluca Chis <raluca.chis@analog.com>
Signed-off-by: Paul Cercueil <paul@crapouillou.net>