### PR TITLE
local: Fix detection of scan-element channels

### DIFF
--- a/local.c
+++ b/local.c
@@ -1476,7 +1476,7 @@ static int add_channel(struct iio_device *dev, const char *name,
 			free(channel_id);
 			ret = add_attr_to_channel(chn, name, path,
 					dir_is_scan_elements);
-			chn->is_scan_element = dir_is_scan_elements && !ret;
+			chn->is_scan_element |= dir_is_scan_elements && !ret;
 			return ret;
 		}
 	}


### PR DESCRIPTION
Previously, the detection of buffer-capable channels would fail when the
channel had attributes outside the scan_elements/ folder, as the channel
would be correctly marked as buffer-capable when the first attribute
was found, but then overriden as non-buffer-capable as soon as an
attribute outside the scan_elements/ folder was found.

It went unnoticed until now, most likely because there is generally
either scan-elements attributes or non-scan-elements attributes, and
rarely both.

Fixes #740.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>