### PR TITLE
CI: push windows setup.exe to SWDownloads

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -221,6 +221,7 @@ stages:
           targetPath: '$(Build.ArtifactStagingDirectory)'
           artifactName: 'Libiio-Setup-Exe'
   - job: PushToSWDownloads
+    dependsOn: GenerateSetupExe
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     pool:
       vmImage: 'ubuntu-latest'


### PR DESCRIPTION
For Windows builds, setup.exe file is generated for each modification on master.
With this modification, setup.exe file will be saved on SWDownloads with the other artifacts.

Signed-off-by: Raluca Chis <raluca.chis@analog.com>