### PR TITLE
CI: disable debug on the artifact deploy

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -234,7 +234,7 @@ stages:
         displayName: 'Download rsa key'
         inputs:
           secureFile: 'id_rsa'
-      - bash: chmod 600 $(key.secureFilePath) ; scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss -vv -i $(key.secureFilePath) -r /home/vsts/work/1/a/* $MAPPED_VAR
+      - bash: chmod 600 $(key.secureFilePath) ; scp -2 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o HostKeyAlgorithms=+ssh-dss -i $(key.secureFilePath) -r /home/vsts/work/1/a/* $MAPPED_VAR
         env:
           MAPPED_VAR: $(SERVER_ADDRESS)
         displayName: "Push artifacts to SW Downloads"


### PR DESCRIPTION
Disable debug on the artifact deploy in order to avoid displaying private data.

Signed-off-by: Raluca Chis <raluca.chis@analog.com>