### PR TITLE
azure-pipelines: Update libusb and libxml2 version for Windows builds.

### DIFF
--- a/CI/build_win.ps1
+++ b/CI/build_win.ps1
@@ -10,7 +10,7 @@ if ($ARCH -eq "Win32") {
 	cp .\libiio.iss.cmakein .\build-win32
 	cd build-win32
 
-	cmake -G "$COMPILER" -A "$ARCH" -DCMAKE_SYSTEM_PREFIX_PATH="C:" -DENABLE_IPV6=OFF -DWITH_USB_BACKEND=ON -DWITH_SERIAL_BACKEND=ON -DPYTHON_BINDINGS=ON -DCSHARP_BINDINGS:BOOL=ON -DLIBXML2_LIBRARIES="C:\\libs\\32\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\32\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\32\\libserialport.dll.a" ..
+	cmake -G "$COMPILER" -A "$ARCH" -DCMAKE_SYSTEM_PREFIX_PATH="C:" -DENABLE_IPV6=OFF -DWITH_USB_BACKEND=ON -DWITH_SERIAL_BACKEND=ON -DPYTHON_BINDINGS=ON -DCSHARP_BINDINGS:BOOL=ON -DLIBXML2_LIBRARIES="C:\\libs\\32\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\32\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\32\\libserialport.dll.a" -DLIBUSB_INCLUDE_DIR="C:\\include\\libusb-1.0" -DLIBXML2_INCLUDE_DIR="C:\\include\\libxml2" ..
 	cmake --build . --config Release
 	cp .\libiio.iss $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 
@@ -25,7 +25,7 @@ if ($ARCH -eq "Win32") {
 	cp .\libiio.iss.cmakein .\build-x64
         cd build-x64
 
-        cmake -G "$COMPILER" -A "$ARCH" -DCMAKE_SYSTEM_PREFIX_PATH="C:" -DENABLE_IPV6=OFF -DWITH_USB_BACKEND=ON -DWITH_SERIAL_BACKEND=ON -DPYTHON_BINDINGS=ON -DCSHARP_BINDINGS:BOOL=ON -DLIBXML2_LIBRARIES="C:\\libs\\64\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\64\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\64\\libserialport.dll.a" ..
+        cmake -G "$COMPILER" -A "$ARCH" -DCMAKE_SYSTEM_PREFIX_PATH="C:" -DENABLE_IPV6=OFF -DWITH_USB_BACKEND=ON -DWITH_SERIAL_BACKEND=ON -DPYTHON_BINDINGS=ON -DCSHARP_BINDINGS:BOOL=ON -DLIBXML2_LIBRARIES="C:\\libs\\64\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\64\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\64\\libserialport.dll.a" -DLIBUSB_INCLUDE_DIR="C:\\include\\libusb-1.0" -DLIBXML2_INCLUDE_DIR="C:\\include\\libxml2" ..
         cmake --build . --config Release
 	cp .\libiio.iss $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 

--- a/CI/install_deps_win.ps1
+++ b/CI/install_deps_win.ps1
@@ -20,7 +20,7 @@ rm libxml.7z
 
 echo "Downloading deps..."
 cd C:\
-wget http://swdownloads.analog.com/cse/build/libiio-win-deps.zip -OutFile "libiio-win-deps.zip"
+wget http://swdownloads.analog.com/cse/build/libiio-win-deps-libusb1.0.24.zip -OutFile "libiio-win-deps.zip"
 7z x -y "C:\libiio-win-deps.zip"
 
 # Note: InnoSetup is already installed on Azure images; so don't run this step

--- a/CI/publish_deps.ps1
+++ b/CI/publish_deps.ps1
@@ -13,7 +13,7 @@ if ($ARCH -eq "Win32") {
 cd $src_dir
 mkdir dependencies
 cd dependencies
-wget http://swdownloads.analog.com/cse/build/libiio-win-deps.zip -OutFile "libiio-win-deps.zip"
+wget http://swdownloads.analog.com/cse/build/libiio-win-deps-libusb1.0.24.zip -OutFile "libiio-win-deps.zip"
 7z x -y "libiio-win-deps.zip"
 
 if ($ARCH -eq "Win32") {


### PR DESCRIPTION
Old libusb and libxml2 were linking to a Visual Studio DLL from 2013 which
is no longer available on CI images. The new archive contains the latest
versions for both libusb and libxml2 and are now built using MSVC 2019.

A new zip archive, containing these updated libraries, was added to swdownloads. We can either change the link to the zip file in the build scripts or just create a backup of the old archive and replace it with the new one.

Ran the iio_genxml test and the output is:
`Context re-creation from generated XML succeeded!`

Signed-off-by: Alexandra Trifan <Alexandra.Trifan@analog.com>