### PR TITLE
iio.h: Remove constant common with linux kernel include files

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -146,7 +146,7 @@ void iio_channel_init_finalize(struct iio_channel *chn)
 				(chn->id[len] < '0' || chn->id[len] > '9'))
 			continue;
 
-		chn->type = (enum iio_chan_type) i;
+		chn->type = (enum libiio_chan_type) i;
 	}
 
 	mod = strchr(chn->id, '_');
@@ -162,7 +162,7 @@ void iio_channel_init_finalize(struct iio_channel *chn)
 		if (strncmp(modifier_names[i], mod, len) != 0)
 			continue;
 
-		chn->modifier = (enum iio_modifier) i;
+		chn->modifier = (enum libiio_modifier) i;
 		break;
 	}
 }
@@ -275,12 +275,12 @@ bool iio_channel_is_scan_element(const struct iio_channel *chn)
 	return chn->is_scan_element;
 }
 
-enum iio_modifier iio_channel_get_modifier(const struct iio_channel *chn)
+enum libiio_modifier iio_channel_get_modifier(const struct iio_channel *chn)
 {
 	return chn->modifier;
 }
 
-enum iio_chan_type iio_channel_get_type(const struct iio_channel *chn)
+enum libiio_chan_type iio_channel_get_type(const struct iio_channel *chn)
 {
 	return chn->type;
 }

--- a/iio-private.h
+++ b/iio-private.h
@@ -160,8 +160,8 @@ struct iio_channel {
 	struct iio_data_format format;
 	char *name, *id;
 	long index;
-	enum iio_modifier modifier;
-	enum iio_chan_type type;
+	enum libiio_modifier modifier;
+	enum libiio_chan_type type;
 
 	struct iio_channel_attr *attrs;
 	unsigned int nb_attrs;

--- a/iio.h
+++ b/iio.h
@@ -85,13 +85,17 @@ struct iio_scan_context;
 struct iio_scan_block;
 
 /**
- * @enum iio_chan_type
+ * @enum libiio_chan_type
  * @brief IIO channel type
  *
  * A IIO channel has a type specifying the type of data associated with the
  * channel.
+ *
+ * This is a copy of iio_chan_type found in the kernel include file
+ * 'usr/include/linux/iio/types.h'. It may not be an exact copy when the kernel
+ * includes are way older or newer than libiio.
  */
-enum iio_chan_type {
+enum libiio_chan_type {
 	IIO_VOLTAGE,
 	IIO_CURRENT,
 	IIO_POWER,
@@ -131,13 +135,17 @@ enum iio_chan_type {
 };
 
 /**
- * @enum iio_modifier
+ * @enum libiio_modifier
  * @brief IIO channel modifier
  *
  * In a addition to a type a IIO channel can optionally have a channel modifier
  * further specifying the data type of of the channel.
+ *
+ * This is a copy of iio_modifier found in the kernel include file
+ * 'usr/include/linux/iio/types.h'. It may not be an exact copy when the kernel
+ * includes are way older or newer than libiio.
  */
-enum iio_modifier {
+enum libiio_modifier {
 	IIO_NO_MOD,
 	IIO_MOD_X,
 	IIO_MOD_Y,
@@ -1356,14 +1364,14 @@ __api void * iio_channel_get_data(const struct iio_channel *chn);
 /** @brief Get the type of the given channel
  * @param chn A pointer to an iio_channel structure
  * @return The type of the channel */
-__api __check_ret __pure enum iio_chan_type iio_channel_get_type(
+__api __check_ret __pure enum libiio_chan_type iio_channel_get_type(
 		const struct iio_channel *chn);
 
 
 /** @brief Get the modifier type of the given channel
  * @param chn A pointer to an iio_channel structure
  * @return The modifier type of the channel */
-__api __check_ret __pure enum iio_modifier iio_channel_get_modifier(
+__api __check_ret __pure enum libiio_modifier iio_channel_get_modifier(
 		const struct iio_channel *chn);
 
 


### PR DESCRIPTION
To prevent conflicts when iio.h and /usr/include/linux/iio/types.h
are both included, rename iio_chan_type libiio_chan_type.

Check CI/travis/check_kernel.sh still works.

Fixes #758.

Signed-off-by: Gwendal Grignou <gwendal@chromium.org>