### PR TITLE
iio.h: Include iio/types.h when it exists

### DIFF
--- a/CI/travis/check_kernel.sh
+++ b/CI/travis/check_kernel.sh
@@ -25,7 +25,7 @@ do
 	echo looking for ${enum}
 	rm -f /tmp/kernel_${enum} /tmp/libiio_${enum}
 	sed "0,/${enum}/d" ${KERNEL_TYPES}  | sed -n '/}/q;p' > /tmp/kernel_${enum}
-	sed "0,/^enum.*${enum}/d" ${IIOH} | sed -n '/}/q;p' | grep -v IIO_CHAN_TYPE_UNKNOWN > /tmp/libiio_${enum}
+	sed "0,/^enum.*${enum}/d" ${IIOH} | sed -n '/}/q;p' > /tmp/libiio_${enum}
 	echo Differences in ${enum}
 	# diff exit status of 1 means a difference, not an error
 	set +e

--- a/iio.h
+++ b/iio.h
@@ -84,6 +84,16 @@ struct iio_context_info;
 struct iio_scan_context;
 struct iio_scan_block;
 
+#define	IIO_CHAN_TYPE_UNKNOWN INT_MAX
+
+#if defined __has_include
+#  if __has_include(<linux/iio/types.h>)
+#    include <linux/iio/types.h>
+#    define __IIO_TYPE_DEFINED__
+#  endif
+#endif
+
+#ifndef __IIO_TYPE_DEFINED__
 /**
  * @enum iio_chan_type
  * @brief IIO channel type
@@ -127,7 +137,6 @@ enum iio_chan_type {
 	IIO_POSITIONRELATIVE,
 	IIO_PHASE,
 	IIO_MASSCONCENTRATION,
-	IIO_CHAN_TYPE_UNKNOWN = INT_MAX
 };
 
 /**
@@ -184,6 +193,8 @@ enum iio_modifier {
 	IIO_MOD_H2,
 	IIO_MOD_O2,
 };
+
+#endif  /* !__IIO_TYPE_DEFINED__ */
 
 /* ---------------------------------------------------------------------------*/
 /* ------------------------- Scan functions ----------------------------------*/


### PR DESCRIPTION
enum iio_chan_type and iio_modifier are already defined in
/usr/include/linux/iio/types.h on linux systems.
If an application needs to include both (to support iio events for
instance), compiler will complains these enums are defined twice.

This patch is not without problem:
- it works only if compiler supports __has_include (C++17, not 11).
- linux system must have latest kernel-headers installed:
IIO_MOD_O2 modifier has been added to linux 5.9 kernel.

Alter CI/travis/check_kernel.sh accordingly, check it still passes.

Fixes #758.

Signed-off-by: Gwendal Grignou <gwendal@chromium.org>