### PR TITLE
CI: update macOS version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,19 +88,12 @@ stages:
   - job: macOSBuilds
     strategy:
       matrix:
-        macOS_10_14:
-          imageName: 'macOS-10.14'
-          artifactName: 'macOS-10.14'
         macOS_10_15:
           imageName: 'macOS-10.15'
           artifactName: 'macOS-10.15'
-# FIXME: uncomment after this is resolved:
-#        https://github.com/actions/virtual-environments/issues/2072
-# Mac OS X 11.0 is definitely a big thing (with their switch to ARM,
-# so we should be quick to have it)
-#      macOS_11_0:
-#        imageName: 'macOS-11.0'
-#        artifactName: 'macOS-11.0'
+        macOS_11:
+          imageName: 'macOS-11'
+          artifactName: 'macOS-11'
     pool:
       vmImage: $(imageName)
     steps:


### PR DESCRIPTION
In this pull request:
- macOS-10.14 is removed because is deprecated from Microsoft-hosted agents in Azure Pipelines
- macOS-11 is added to build

Signed-off-by: Raluca Chis <raluca.chis@analog.com>