### PR TITLE
iiod/init/iiod.service.cmakein: Add support for extra iiod options

### DIFF
--- a/iiod/init/iiod.service.cmakein
+++ b/iiod/init/iiod.service.cmakein
@@ -1,6 +1,8 @@
+# SPDX-License-Identifier: LGPL-2.1+
+#
 # iiod - Systemd init script
 #
-# Copyright (C) 2016 Analog Devices Inc.
+# Copyright (C) 2016-2021 Analog Devices Inc.
 
 [Unit]
 Description=IIO Daemon

--- a/iiod/init/iiod.service.cmakein
+++ b/iiod/init/iiod.service.cmakein
@@ -8,7 +8,8 @@ After=network.target
 ConditionPathExists=/sys/bus/iio
 
 [Service]
-ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/iiod
+EnvironmentFile=-/etc/default/iiod
+ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/iiod $IIOD_EXTRA_OPTS
 KillMode=process
 Restart=on-failure
 


### PR DESCRIPTION
This patch adds support to source iiod options via /etc/default/iiod

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>