### PR TITLE
iiod: systemd: Add dependency on systemd-udev-settle.service

### DIFF
--- a/iiod/init/iiod.service.cmakein
+++ b/iiod/init/iiod.service.cmakein
@@ -6,7 +6,8 @@
 
 [Unit]
 Description=IIO Daemon
-After=network.target
+Requires=systemd-udev-settle.service
+After=network.target systemd-udev-settle.service
 ConditionPathExists=/sys/bus/iio
 
 [Service]


### PR DESCRIPTION
IIOD does not handle the hardware changing (in /dev or /sys) after it
has been started. Therefore, we must ensure that all modules have been
loaded before IIOD starts.

Note that this is explicitely marked as a bad practice in systemd docs,
which recommends the service to handle udev events instead. Since IIOD
and libiio don't support hardware hotplug we don't really have a choice
right now, but this workaround should be dropped as soon as hotplug
support has been added.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>