### PR TITLE
Add iio_device_is_hwmon() and iio.Device.hwmon property in bindings

### DIFF
--- a/bindings/csharp/Device.cs
+++ b/bindings/csharp/Device.cs
@@ -210,6 +210,9 @@ namespace iio
         /// <summary>The label of this device.</summary>
         public string label { get; private set; }
 
+        /// <summary>True if the device is a hardware monitoring device, False if it is a IIO device.</summary>
+        public bool hwmon { get; private set; }
+
         /// <summary>A <c>list</c> of all the attributes that this device has.</summary>
         public readonly List<Attr> attrs;
 
@@ -271,6 +274,7 @@ namespace iio
             IntPtr label_ptr = iio_device_get_label(dev);
 
             label = label_ptr == IntPtr.Zero ? "" : Marshal.PtrToStringAnsi(label_ptr);
+            hwmon = id[0] == 'h';
         }
 
         /// <summary>Get the <see cref="iio.Channel"/> object of the specified name.</summary>

--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -1325,6 +1325,10 @@ class Device(_DeviceOrTrigger):
         None,
         "Contains the configured trigger for this IIO device.\n\ttype=iio.Trigger",
     )
+    hwmon = property(
+        lambda self: self._id[:5] == "hwmon", None, None,
+        "Contains True if the device is a hardware-monitoring device, False if it is a IIO device.\n\ttype=bool",
+    )
 
     @property
     def context(self):

--- a/channel.c
+++ b/channel.c
@@ -177,7 +177,7 @@ void iio_channel_init_finalize(struct iio_channel *chn)
 	char *mod;
 	int type;
 
-	if (iio_device_is_hwmon(chn->dev)) {
+	if (WITH_HWMON && iio_device_is_hwmon(chn->dev)) {
 		type = iio_channel_find_type(chn->id, hwmon_chan_type_name_spec,
 					ARRAY_SIZE(hwmon_chan_type_name_spec));
 	} else {

--- a/iio-private.h
+++ b/iio-private.h
@@ -291,9 +291,4 @@ static inline void iio_update_xml_indexes(ssize_t ret, char **ptr, ssize_t *len,
 
 bool iio_channel_is_hwmon(const char *id);
 
-static inline bool iio_device_is_hwmon(const struct iio_device *dev)
-{
-	return WITH_HWMON && dev->id[0] == 'h';
-}
-
 #endif /* __IIO_PRIVATE_H__ */

--- a/iio.h
+++ b/iio.h
@@ -1620,6 +1620,18 @@ hwmon_channel_get_type(const struct iio_channel *chn)
 	return (enum hwmon_chan_type) iio_channel_get_type(chn);
 }
 
+/**
+ * @brief Get whether or not the device is a hardware monitoring device
+ * @param dev A pointer to an iio_device structure
+ * @return True if the device is a hardware monitoring device,
+ * false if it is a IIO device */
+static inline bool iio_device_is_hwmon(const struct iio_device *dev)
+{
+	const char *id = iio_device_get_id(dev);
+
+	return id[0] == 'h';
+}
+
 
 /** @} *//* ------------------------------------------------------------------*/
 /* ------------------------- Low-level functions -----------------------------*/

--- a/local.c
+++ b/local.c
@@ -676,7 +676,7 @@ static ssize_t local_read_dev_attr(const struct iio_device *dev,
 
 	switch (type) {
 		case IIO_ATTR_TYPE_DEVICE:
-			if (iio_device_is_hwmon(dev)) {
+			if (WITH_HWMON && iio_device_is_hwmon(dev)) {
 				iio_snprintf(buf, sizeof(buf), "/sys/class/hwmon/%s/%s",
 							dev->id, attr);
 			} else {
@@ -730,7 +730,7 @@ static ssize_t local_write_dev_attr(const struct iio_device *dev,
 
 	switch (type) {
 		case IIO_ATTR_TYPE_DEVICE:
-			if (iio_device_is_hwmon(dev)) {
+			if (WITH_HWMON && iio_device_is_hwmon(dev)) {
 				iio_snprintf(buf, sizeof(buf), "/sys/class/hwmon/%s/%s",
 					dev->id, attr);
 			} else {
@@ -1144,7 +1144,7 @@ static bool is_channel(const struct iio_device *dev, const char *attr, bool stri
 {
 	char *ptr = NULL;
 
-	if (iio_device_is_hwmon(dev))
+	if (WITH_HWMON && iio_device_is_hwmon(dev))
 		return iio_channel_is_hwmon(attr);
 	if (!strncmp(attr, "in_timestamp_", sizeof("in_timestamp_") - 1))
 		return true;
@@ -1169,7 +1169,7 @@ static char * get_channel_id(struct iio_device *dev, const char *attr)
 	char *res, *ptr = strchr(attr, '_');
 	size_t len;
 
-	if (!iio_device_is_hwmon(dev)) {
+	if (!WITH_HWMON || !iio_device_is_hwmon(dev)) {
 		attr = ptr + 1;
 		ptr = strchr(attr, '_');
 		if (find_channel_modifier(ptr + 1, &len) != IIO_NO_MOD)
@@ -1196,7 +1196,7 @@ static char * get_short_attr_name(struct iio_channel *chn, const char *attr)
 	char *ptr = strchr(attr, '_');
 	size_t len;
 
-	if (iio_device_is_hwmon(chn->dev)) {
+	if (WITH_HWMON && iio_device_is_hwmon(chn->dev)) {
 		/*
 		 * PWM hwmon devices can have an attribute named directly after
 		 * the channel's ID; in that particular case we don't need to
@@ -1457,7 +1457,7 @@ static struct iio_channel *create_channel(struct iio_device *dev,
 	if (!chn->pdata)
 		goto err_free_chn;
 
-	if (!iio_device_is_hwmon(dev)) {
+	if (!WITH_HWMON || !iio_device_is_hwmon(dev)) {
 		if (!strncmp(attr, "out_", 4)) {
 			chn->is_output = true;
 		} else if (strncmp(attr, "in_", 3)) {


### PR DESCRIPTION
These read-only properties will be True if the iio.Device is a hardware monitoring device, and False if it is a IIO device.