### PR TITLE
local: Add support for setting watermark

### DIFF
--- a/local.c
+++ b/local.c
@@ -104,6 +104,7 @@ static const char * const device_attrs_blacklist[] = {
 static const char * const buffer_attrs_reserved[] = {
 	"length",
 	"enable",
+	"watermark",
 };
 
 static int ioctl_nointr(int fd, unsigned long request, void *data)
@@ -922,6 +923,15 @@ static int local_open(const struct iio_device *dev,
 	ret = local_write_dev_attr(dev, "buffer/length",
 			buf, strlen(buf) + 1, false);
 	if (ret < 0)
+		return ret;
+
+	/*
+	 * Set watermark to the buffer size; the driver will adjust to its
+	 * maximum if it's too high without issueing an error.
+	 */
+	ret = local_write_dev_attr(dev, "buffer/watermark",
+				   buf, strlen(buf) + 1, false);
+	if (ret < 0 && ret != -ENOENT)
 		return ret;
 
 	pdata->cancel_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);


### PR DESCRIPTION
Add support for setting the watermark value, if the driver supports it.
The watermark value represents the number of samples that will be read
in one burst from the hardware. Since we read data at the granularity of
iio_buffer blocks, it makes sense to use the highest watermark value up
to the buffer's size. If the value is too high, the driver will
automatically adjust it to the maximum watermark value possible.

Fixes #780.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>