### PR TITLE
Fix hwmon channel type set to unknown if !WITH_HWMON

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -177,7 +177,7 @@ void iio_channel_init_finalize(struct iio_channel *chn)
 	char *mod;
 	int type;
 
-	if (WITH_HWMON && iio_device_is_hwmon(chn->dev)) {
+	if (iio_device_is_hwmon(chn->dev)) {
 		type = iio_channel_find_type(chn->id, hwmon_chan_type_name_spec,
 					ARRAY_SIZE(hwmon_chan_type_name_spec));
 	} else {


### PR DESCRIPTION
Libiio being compiled without support for hwmon devices means that the
local backend won't try to probe hwmon devices; but hwmon devices found
by a remote libiio should still be usable across the network or USB,
even if WITH_HWMON is disabled locally.

Until now if the host libiio was compiled without hwmon support, it
could see the target's hwmon devices but their type was wrong.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>
Reported-by: Adrian Suciu <adrian.suciu@analog.com>