### PR TITLE
local: ignore "permission denied" error on accessing watermark

### DIFF
--- a/local.c
+++ b/local.c
@@ -930,7 +930,7 @@ static int local_open(const struct iio_device *dev,
 	 */
 	ret = local_write_dev_attr(dev, "buffer/watermark",
 				   buf, strlen(buf) + 1, false);
-	if (ret < 0 && ret != -ENOENT)
+	if (ret < 0 && ret != -ENOENT && ret != -EACCES)
 		return ret;
 
 	pdata->cancel_fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);


### PR DESCRIPTION
The watermark attribute may be set to read-only by the kernel. In that
case, trying to open it for writing will return -EACCES, aka.
"permission denied".

Therefore, the -EACCES error needs to be ignored. This is a bit
annoying, since we cannot know if it happens because the attribute
itself was set read-only by the kernel, or because the user simply
doesn't have the necesary access rights to write the file. But it is
rather safe to assume it is not the latter, as the "buffer/length"
attribute was written just a bit before without returning an error.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>