### PR TITLE
iio-backend: Remove unused callback .get_description

### DIFF
--- a/iio-backend.h
+++ b/iio-backend.h
@@ -60,8 +60,6 @@ struct iio_backend_ops {
 
 	void (*shutdown)(struct iio_context *ctx);
 
-	char * (*get_description)(const struct iio_context *ctx);
-
 	int (*get_version)(const struct iio_context *ctx, unsigned int *major,
 			unsigned int *minor, char git_tag[8]);
 

--- a/local.c
+++ b/local.c
@@ -1976,7 +1976,6 @@ static const struct iio_backend_ops local_ops = {
 	.get_trigger = local_get_trigger,
 	.set_trigger = local_set_trigger,
 	.shutdown = local_shutdown,
-	.get_description = local_get_description,
 	.set_timeout = local_set_timeout,
 	.cancel = local_cancel,
 };

--- a/network.c
+++ b/network.c
@@ -282,7 +282,7 @@ int create_socket(const struct addrinfo *addrinfo)
 	return fd;
 }
 
-static char * __network_get_description(struct addrinfo *res)
+static char * network_get_description(struct addrinfo *res)
 {
 	char *description;
 	unsigned int len;
@@ -332,13 +332,6 @@ static char * __network_get_description(struct addrinfo *res)
 	}
 
 	return description;
-}
-
-static char *network_get_description(const struct iio_context *ctx)
-{
-	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
-
-	return __network_get_description(pdata->addrinfo);
 }
 
 static int network_open(const struct iio_device *dev,
@@ -926,7 +919,6 @@ static const struct iio_backend_ops network_ops = {
 	.get_trigger = network_get_trigger,
 	.set_trigger = network_set_trigger,
 	.shutdown = network_shutdown,
-	.get_description = network_get_description,
 	.get_version = network_get_version,
 	.set_timeout = network_set_timeout,
 	.set_kernel_buffers_count = network_set_kernel_buffers_count,
@@ -1144,7 +1136,7 @@ struct iio_context * network_create_context(const char *host)
 		goto err_close_socket;
 	}
 
-	description = __network_get_description(res);
+	description = network_get_description(res);
 	if (!description)
 		goto err_free_pdata;
 

--- a/serial.c
+++ b/serial.c
@@ -105,7 +105,7 @@ static int serial_get_version(const struct iio_context *ctx,
 			major, minor, git_tag);
 }
 
-static char * __serial_get_description(struct sp_port *port)
+static char * serial_get_description(struct sp_port *port)
 {
 	char *description, *name, *desc;
 	size_t desc_len;
@@ -123,13 +123,6 @@ static char * __serial_get_description(struct sp_port *port)
 	iio_snprintf(description, desc_len, "%s: %s", name, desc);
 
 	return description;
-}
-
-static char * serial_get_description(const struct iio_context *ctx)
-{
-	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
-
-	return __serial_get_description(pdata->port);
 }
 
 static int serial_open(const struct iio_device *dev,
@@ -385,7 +378,6 @@ static const struct iio_backend_ops serial_ops = {
 	.write_channel_attr = serial_write_chn_attr,
 	.set_kernel_buffers_count = serial_set_kernel_buffers_count,
 	.shutdown = serial_shutdown,
-	.get_description = serial_get_description,
 	.set_timeout = serial_set_timeout,
 	.get_trigger = serial_get_trigger,
 	.set_trigger = serial_set_trigger,
@@ -463,7 +455,7 @@ static struct iio_context * serial_create_context(const char *port_name,
 	/* Empty the buffers */
 	sp_flush(port, SP_BUF_BOTH);
 
-	description = __serial_get_description(port);
+	description = serial_get_description(port);
 	if (!description)
 		goto err_close_port;
 


### PR DESCRIPTION
This callback was introduced in commit d61f6296 ("iio: backend: add
get_description() backend op") but was never called anywhere, as the
backend's description string is also present in the XML directly.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>