### PR TITLE
CI: drop centOS 8 build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,11 +25,6 @@ stages:
           OS_TYPE: 'centos_docker'
           OS_VERSION: centos7
           artifactName: 'Linux-CentOS-7-x86_64'
-        centos_8_x86_64:
-          imageName: 'ubuntu-latest'
-          OS_TYPE: 'centos_docker'
-          OS_VERSION: centos8
-          artifactName: 'Linux-CentOS-8-x86_64'
         ubuntu_16_04_x86_64:
           imageName: 'ubuntu-latest'
           OS_TYPE: 'ubuntu_docker'


### PR DESCRIPTION
This is a temporary solution until the new update of the CI.

Signed-off-by: Raluca Chis <raluca.chis@analog.com>