### PR TITLE
iio_info: Remove -s option

### DIFF
--- a/man/iio_info.1.in
+++ b/man/iio_info.1.in
@@ -78,7 +78,7 @@ normally returned from
 with no address part
 .RE
 .TP
-.B \-s, \-\-scan
+.B \-S, \-\-scan
 Scan for available backends
 .TP
 .B \-a, \-\-auto

--- a/tests/iio_info.c
+++ b/tests/iio_info.c
@@ -35,14 +35,12 @@
 #endif
 
 static const struct option options[] = {
-	{"scan", no_argument, 0, 's'},
 	{0, 0, 0, 0},
 };
 
 static const char *options_descriptions[] = {
 	"[-x <xml_file>]\n"
 		"\t\t\t\t[-u <uri>]",
-	"Scan for available backends.",
 };
 
 static int dev_is_buffer_capable(const struct iio_device *dev)
@@ -59,7 +57,7 @@ static int dev_is_buffer_capable(const struct iio_device *dev)
 	return false;
 }
 
-#define MY_OPTS "s"
+#define MY_OPTS ""
 
 int main(int argc, char **argv)
 {
@@ -87,7 +85,7 @@ int main(int argc, char **argv)
 		fprintf(stderr, "Failed to add common options\n");
 		return EXIT_FAILURE;
 	}
-	while ((c = getopt_long(argc, argw, "+" COMMON_OPTIONS MY_OPTS,	/* Flawfinder: ignore */
+	while ((c = getopt_long(argc, argw, "+" COMMON_OPTIONS MY_OPTS "s", /* Flawfinder: ignore */
 					opts, NULL)) != -1) {
 		switch (c) {
 			/* All these are handled in the common */


### PR DESCRIPTION
iio_info had two possible options to scan for contexts: -S (aka. --scan)
and -s, which did more or less the same thing, but -s didn't take an
argument and scanned all possible contexts.

Remove the -s option in the help text to reduce the confusion, while
still handling it for backwards-compatibility.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>