### PR TITLE
Support specifying VID/PID for scanning + steamline scanning in tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,7 @@ include(CheckSymbolExists)
 check_symbol_exists(strdup "string.h" HAS_STRDUP)
 check_symbol_exists(strndup "string.h" HAS_STRNDUP)
 check_symbol_exists(strerror_r "string.h" HAS_STRERROR_R)
+check_symbol_exists(strtok_r "string.h" HAS_STRTOK_R)
 check_symbol_exists(newlocale "locale.h" HAS_NEWLOCALE)
 
 option(ENABLE_IPV6 "Define if you want to enable IPv6 support" ON)

--- a/iio-config.h.cmakein
+++ b/iio-config.h.cmakein
@@ -28,6 +28,7 @@
 #cmakedefine HAS_PIPE2
 #cmakedefine HAS_STRDUP
 #cmakedefine HAS_STRNDUP
+#cmakedefine HAS_STRTOK_R
 #cmakedefine HAS_STRERROR_R
 #cmakedefine HAS_NEWLOCALE
 #cmakedefine HAS_PTHREAD_SETNAME_NP

--- a/iio-private.h
+++ b/iio-private.h
@@ -249,7 +249,7 @@ struct iio_context * serial_create_context_from_uri(const char *uri);
 
 int local_context_scan(struct iio_scan_result *scan_result);
 
-int usb_context_scan(struct iio_scan_result *scan_result);
+int usb_context_scan(struct iio_scan_result *scan_result, const char *args);
 
 int dnssd_context_scan(struct iio_scan_result *scan_result);
 

--- a/iio-private.h
+++ b/iio-private.h
@@ -261,6 +261,7 @@ unsigned int find_channel_modifier(const char *s, size_t *len_p);
 
 char *iio_strdup(const char *str);
 char *iio_strndup(const char *str, size_t n);
+char *iio_strtok_r(char *str, const char *delim, char **saveptr);
 size_t iio_strlcpy(char * __restrict dst, const char * __restrict src, size_t dsize);
 char * iio_getenv (char * envvar);
 

--- a/iio-private.h
+++ b/iio-private.h
@@ -260,6 +260,7 @@ void iio_channel_init_finalize(struct iio_channel *chn);
 unsigned int find_channel_modifier(const char *s, size_t *len_p);
 
 char *iio_strdup(const char *str);
+char *iio_strndup(const char *str, size_t n);
 size_t iio_strlcpy(char * __restrict dst, const char * __restrict src, size_t dsize);
 char * iio_getenv (char * envvar);
 

--- a/iio.h
+++ b/iio.h
@@ -236,13 +236,18 @@ enum iio_event_direction {
 
 
 /** @brief Create a scan context
- * @param backend A NULL-terminated string containing the backend(s) to use for
- * scanning (example: pre version 0.20 :  "local", "ip", or "usb"; post version
- * 0.20 can handle multiple, including "local:usb:", "ip:usb:", "local:usb:ip:").
- * If NULL, all the available backends are used.
+ * @param backend A NULL-terminated string containing a comma-separated
+ * list of the backend(s) to use for scanning.
  * @param flags Unused for now. Set to 0.
  * @return on success, a pointer to a iio_scan_context structure
- * @return On failure, NULL is returned and errno is set appropriately */
+ * @return On failure, NULL is returned and errno is set appropriately
+ *
+ * <b>NOTE:</b> Libiio version 0.20 and above can handle multiple
+ * strings, for instance "local:usb:", "ip:usb:", "local:usb:ip:", and
+ * require a colon as the delimiter. If NULL, the local, USB and IP
+ * backends will be scanned.
+ * Libiio version 0.24 and above prefer a comma instead of colon as the
+ * delimiter. */
 __api __check_ret struct iio_scan_context * iio_create_scan_context(
 		const char *backend, unsigned int flags);
 

--- a/iio.h
+++ b/iio.h
@@ -244,10 +244,14 @@ enum iio_event_direction {
  *
  * <b>NOTE:</b> Libiio version 0.20 and above can handle multiple
  * strings, for instance "local:usb:", "ip:usb:", "local:usb:ip:", and
- * require a colon as the delimiter. If NULL, the local, USB and IP
- * backends will be scanned.
+ * require a colon as the delimiter.
  * Libiio version 0.24 and above prefer a comma instead of colon as the
- * delimiter. */
+ * delimiter, and handle specifying backend-specific information. For
+ * instance, "local,usb=0456:*" will scan the local backend and limit
+ * scans on USB to vendor ID 0x0456, and accept all product IDs. The
+ * "usb=0456:b673" string would limit the scan to the device with this
+ * particular VID/PID. Both IDs are expected in hexadecimal, no 0x
+ * prefix needed. */
 __api __check_ret struct iio_scan_context * iio_create_scan_context(
 		const char *backend, unsigned int flags);
 

--- a/libiio.rules.cmakein
+++ b/libiio.rules.cmakein
@@ -1,1 +1,1 @@
-SUBSYSTEM=="usb", PROGRAM=="/bin/sh -c '@CMAKE_INSTALL_FULL_BINDIR@/iio_info -S usb | grep %s{idVendor}:%s{idProduct}'", RESULT!="", MODE="666"
+SUBSYSTEM=="usb", PROGRAM=="/bin/sh -c '@CMAKE_INSTALL_FULL_BINDIR@/iio_info -S usb=%s{idVendor}:%s{idProduct} | grep %s{idVendor}:%s{idProduct}'", RESULT!="", MODE="666"

--- a/man/iio_attr.1.in
+++ b/man/iio_attr.1.in
@@ -83,8 +83,11 @@ Read and Write IIO Context attributes
 .B \-D \-\-debug-attr
 Read and Write IIO Debug attributes
 .TP
-.B \-S, \-\-Scan
-Scan for available IIO contexts, optional arg of specific backend(s) 'ip', 'usb' or 'ip:usb'. If no argument is given, it checks all that are availble.
+.B \-S, \-\-scan
+Scan for available IIO contexts, optional arg of specific backend(s) 'ip', 'usb' or 'ip,usb'.
+Specific options for USB include Vendor ID, Product ID to limit scanning to specific devices 'usb=0456:b673'.
+vid,pid are hexadecimal numbers (no prefix needed), "*" (match any for pid only)
+If no argument is given, it checks all that are availble.
 .TP
 .B \-h, \-\-help
 Tells

--- a/man/iio_info.1.in
+++ b/man/iio_info.1.in
@@ -79,7 +79,10 @@ with no address part
 .RE
 .TP
 .B \-S, \-\-scan
-Scan for available backends
+Scan for available IIO contexts, optional arg of specific backend(s) 'ip', 'usb' or 'ip,usb'.
+Specific options for USB include Vendor ID, Product ID to limit scanning to specific devices 'usb=0456:b673'.
+vid,pid are hexadecimal numbers (no prefix needed), "*" (match any for pid only)
+If no argument is given, it checks all that are availble.
 .TP
 .B \-a, \-\-auto
 Scan for available contexts and if only one is available use it.

--- a/man/iio_readdev.1.in
+++ b/man/iio_readdev.1.in
@@ -76,7 +76,12 @@ Buffer timeout in milliseconds. 0 = no timeout. Default is 0.
 .TP
 .B \-a, \-\-auto
 Scan for available contexts and if only one is available use it.
-
+.TP
+.B \-S, \-\-scan
+Scan for available IIO contexts, optional arg of specific backend(s) 'ip', 'usb' or 'ip,usb'.
+Specific options for USB include Vendor ID, Product ID to limit scanning to specific devices 'usb=0456:b673'.
+vid,pid are hexadecimal numbers (no prefix needed), "*" (match any for pid only)
+If no argument is given, it checks all that are availble.
 .SH RETURN VALUE
 If the specified device is not found, a non-zero exit code is returned.
 

--- a/man/iio_writedev.1.in
+++ b/man/iio_writedev.1.in
@@ -60,6 +60,12 @@ normally returned from
 .IP serial:[port]
 .IP local
 with no address part
+.TP
+.B \-S, \-\-scan
+Scan for available IIO contexts, optional arg of specific backend(s) 'ip', 'usb' or 'ip,usb'.
+Specific options for USB include Vendor ID, Product ID to limit scanning to specific devices 'usb=0456:b673'.
+vid,pid are hexadecimal numbers (no prefix needed), "*" (match any for pid only)
+If no argument is given, it checks all that are availble.
 .RE
 .TP
 .B \-t \-\-trigger

--- a/scan.c
+++ b/scan.c
@@ -36,8 +36,8 @@ ssize_t iio_scan_context_get_info_list(struct iio_scan_context *ctx,
 	char *token, *rest=NULL;
 	ssize_t ret;
 
-	for (token = iio_strtok_r(ctx->backendopts, ":", &rest);
-			token; token = iio_strtok_r(NULL, ":", &rest)) {
+	for (token = iio_strtok_r(ctx->backendopts, ",", &rest);
+			token; token = iio_strtok_r(NULL, ",", &rest)) {
 
 		/* Since tokens are all null terminated, it's safe to use strcmp on them */
 		if (WITH_LOCAL_BACKEND && !strcmp(token, "local")) {
@@ -108,6 +108,7 @@ struct iio_scan_context * iio_create_scan_context(
 		const char *backend, unsigned int flags)
 {
 	struct iio_scan_context *ctx;
+	unsigned int i, len;
 
 	/* "flags" must be zero for now */
 	if (flags != 0) {
@@ -121,11 +122,19 @@ struct iio_scan_context * iio_create_scan_context(
 		return NULL;
 	}
 
-	ctx->backendopts = iio_strndup(backend ? backend : "local:usb:ip", PATH_MAX);
+	ctx->backendopts = iio_strndup(backend ? backend : "local,usb,ip", PATH_MAX);
 	if (!ctx->backendopts) {
 		free(ctx);
 		errno = ENOMEM;
 		return NULL;
+	}
+
+	if (backend) {
+		/* Replace the colon separator with a comma. */
+		len = strlen(ctx->backendopts);
+		for (i = 0; i < len; i++)
+			if (ctx->backendopts[i] == ':')
+				ctx->backendopts[i] = ',';
 	}
 
 	return ctx;

--- a/sort.c
+++ b/sort.c
@@ -81,3 +81,20 @@ int iio_buffer_attr_compare(const void *p1, const void *p2)
 	return strcmp(tmp1, tmp2);
 }
 
+int iio_context_info_compare(const void *p1, const void *p2)
+{
+	int ret;
+	const struct iio_context_info *tmp1 = *(struct iio_context_info **)p1;
+	const struct iio_context_info *tmp2 = *(struct iio_context_info **)p2;
+
+	if(!tmp1->uri)
+		return 1;
+	if (!tmp2->uri)
+		return 0;
+
+	ret = strcmp(tmp1->uri, tmp2->uri);
+	if (ret)
+		return ret;
+
+	return strcmp(tmp1->description, tmp2->description);
+}

--- a/sort.h
+++ b/sort.h
@@ -14,5 +14,6 @@ int iio_channel_attr_compare(const void *p1, const void *p2);
 int iio_device_compare(const void *p1, const void *p2);
 int iio_device_attr_compare(const void *p1, const void *p2);
 int iio_buffer_attr_compare(const void *p1, const void *p2);
+int iio_context_info_compare(const void *p1, const void *p2);
 
 #endif /* __IIO_QSORT_H__ */

--- a/tests/iio_adi_xflow_check.c
+++ b/tests/iio_adi_xflow_check.c
@@ -168,6 +168,7 @@ int main(int argc, char **argv)
 	char unit;
 	int ret;
 	struct option *opts;
+	bool do_scan = false;
 
 	argw = dup_argv(MY_NAME, argc, argv);
 
@@ -188,6 +189,8 @@ int main(int argc, char **argv)
 		case 'T':
 			break;
 		case 'S':
+			do_scan = true;
+			/* FALLTHROUGH */
 		case 'a':
 			if (!optarg && argc > optind && argv[optind] != NULL
 					&& argv[optind][0] != '-')
@@ -214,6 +217,9 @@ int main(int argc, char **argv)
 		}
 	}
 	free(opts);
+
+	if (do_scan)
+		return EXIT_SUCCESS;
 
 	if (optind + 1 != argc) {
 		fprintf(stderr, "Incorrect number of arguments.\n\n");

--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -195,7 +195,7 @@ static ssize_t print_sample(const struct iio_channel *chn,
 int main(int argc, char **argv)
 {
 	char **argw;
-	unsigned int i, nb_channels;
+	unsigned int i, j, nb_channels;
 	unsigned int nb_active_channels = 0;
 	unsigned int buffer_size = SAMPLES_PER_READ;
 	unsigned int refill_per_benchmark = REFILL_PER_BENCHMARK;
@@ -263,7 +263,7 @@ int main(int argc, char **argv)
 	}
 	free(opts);
 
-	if (argc == optind) {
+	if (argc < optind || argc > optind + 2) {
 		fprintf(stderr, "Incorrect number of arguments.\n\n");
 		usage(MY_NAME, options, options_descriptions);
 		return EXIT_FAILURE;
@@ -271,6 +271,48 @@ int main(int argc, char **argv)
 
 	if (!ctx)
 		return EXIT_FAILURE;
+
+	if (!argw[optind]) {
+		unsigned int nb_devices = iio_context_get_devices_count(ctx);
+
+		for (i = 0; i < nb_devices; i++) {
+			const char *dev_id, *label, *name;
+			bool hit;
+
+			dev = iio_context_get_device(ctx, i);
+			nb_channels = iio_device_get_channels_count(dev);
+
+			if (!nb_channels)
+				continue;
+
+			hit = false;
+			for (j = 0; j < nb_channels; j++) {
+				struct iio_channel *ch = iio_device_get_channel(dev, j);
+
+				if (!iio_channel_is_scan_element(ch) ||
+						iio_channel_is_output(ch))
+					continue;
+
+				hit = true;
+
+				dev_id = iio_device_get_id(dev);
+				label = iio_device_get_label(dev);
+				name = iio_device_get_name(dev);
+
+				printf("Example : " MY_NAME " -u %s -b 256 -s 1024 %s %s\n",
+						iio_context_get_attr_value(ctx, "uri"),
+						label ? label : name ? name : dev_id,
+						iio_channel_get_id(ch));
+			}
+			if (hit)
+				printf("Example : " MY_NAME " -u %s -b 256 -s 1024 %s\n",
+						iio_context_get_attr_value(ctx, "uri"),
+						label ? label : name ? name : dev_id);
+		}
+		iio_context_destroy(ctx);
+		usage(MY_NAME, options, options_descriptions);
+		return EXIT_FAILURE;
+	}
 
 	setup_sig_handler();
 
@@ -332,7 +374,6 @@ int main(int argc, char **argv)
 		}
 	} else {
 		for (i = 0; i < nb_channels; i++) {
-			unsigned int j;
 			struct iio_channel *ch = iio_device_get_channel(dev, i);
 			for (j = optind + 1; j < (unsigned int) argc; j++) {
 				const char *n = iio_channel_get_name(ch);

--- a/tests/iio_reg.c
+++ b/tests/iio_reg.c
@@ -82,6 +82,7 @@ int main(int argc, char **argv)
 	int c;
 	char * name;
 	struct option *opts;
+	bool do_scan = false;
 
 	argw = dup_argv(MY_NAME, argc, argv);
 
@@ -102,6 +103,8 @@ int main(int argc, char **argv)
 		case 'T':
 			break;
 		case 'S':
+			do_scan = true;
+			/* FALLTHRU */
 		case 'a':
 			if (!optarg && argc > optind && argv[optind] != NULL
 					&& argv[optind][0] != '-')
@@ -113,6 +116,9 @@ int main(int argc, char **argv)
 		}
 	}
 	free(opts);
+
+	if (do_scan)
+		return EXIT_SUCCESS;
 
 	if ((argc - optind) < 2 || (argc - optind) > 3) {
 		usage(MY_NAME, options, options_descriptions);

--- a/tests/iio_writedev.c
+++ b/tests/iio_writedev.c
@@ -206,7 +206,7 @@ static ssize_t read_sample(const struct iio_channel *chn,
 int main(int argc, char **argv)
 {
 	char **argw;
-	unsigned int i, nb_channels;
+	unsigned int i, j, nb_channels;
 	unsigned int nb_active_channels = 0;
 	unsigned int buffer_size = SAMPLES_PER_READ;
 	unsigned int refill_per_benchmark = REFILL_PER_BENCHMARK;
@@ -276,7 +276,7 @@ int main(int argc, char **argv)
 	}
 	free(opts);
 
-	if (argc == optind) {
+	if (argc < optind || argc > optind + 2) {
 		fprintf(stderr, "Incorrect number of arguments.\n\n");
 		usage(MY_NAME, options, options_descriptions);
 		return EXIT_FAILURE;
@@ -284,6 +284,48 @@ int main(int argc, char **argv)
 
 	if (!ctx)
 		return EXIT_FAILURE;
+
+	if (!argw[optind]) {
+		unsigned int nb_devices = iio_context_get_devices_count(ctx);
+
+		for (i = 0; i < nb_devices; i++) {
+			const char *dev_id, *label, *name;
+			bool hit;
+
+			dev = iio_context_get_device(ctx, i);
+			nb_channels = iio_device_get_channels_count(dev);
+
+			if (!nb_channels)
+				continue;
+
+			hit = false;
+			for (j = 0; j < nb_channels; j++) {
+				struct iio_channel *ch = iio_device_get_channel(dev, j);
+
+				if (!iio_channel_is_scan_element(ch) ||
+						!iio_channel_is_output(ch))
+					continue;
+
+				hit = true;
+
+				dev_id = iio_device_get_id(dev);
+				label = iio_device_get_label(dev);
+				name = iio_device_get_name(dev);
+
+				printf("Example : " MY_NAME " -u %s -b 256 -s 1024 %s %s\n",
+						iio_context_get_attr_value(ctx, "uri"),
+						label ? label : name ? name : dev_id,
+						iio_channel_get_id(ch));
+			}
+			if (hit)
+				printf("Example : " MY_NAME " -u %s -b 256 -s 1024 %s\n",
+						iio_context_get_attr_value(ctx, "uri"),
+						label ? label : name ? name : dev_id);
+		}
+		iio_context_destroy(ctx);
+		usage(MY_NAME, options, options_descriptions);
+		return EXIT_FAILURE;
+	}
 
 	if (benchmark && cyclic_buffer) {
 		fprintf(stderr, "Cannot benchmark in cyclic mode.\n");
@@ -351,7 +393,6 @@ int main(int argc, char **argv)
 		}
 	} else {
 		for (i = 0; i < nb_channels; i++) {
-			unsigned int j;
 			struct iio_channel *ch = iio_device_get_channel(dev, i);
 			for (j = optind + 1; j < (unsigned int) argc; j++) {
 				const char *n = iio_channel_get_name(ch);

--- a/utilities.c
+++ b/utilities.c
@@ -213,6 +213,17 @@ void iio_strerror(int err, char *buf, size_t len)
 	}
 }
 
+char *iio_strtok_r(char *str, const char *delim, char **saveptr)
+{
+#if defined(_WIN32)
+	return strtok_s(str, delim, saveptr);
+#elif defined(HAS_STRTOK_R)
+	return strtok_r(str, delim, saveptr);
+#else
+#error Need a implentation of strtok_r for this platform
+#endif
+}
+
 char *iio_strdup(const char *str)
 {
 #if defined(_WIN32)

--- a/utilities.c
+++ b/utilities.c
@@ -229,6 +229,24 @@ char *iio_strdup(const char *str)
 #endif
 }
 
+/* strndup conforms to POSIX.1-2008; but Windows does not provided it
+ */
+char *iio_strndup(const char *str, size_t n)
+{
+#ifdef HAS_STRNDUP
+	return strndup(str, n);
+#else
+	size_t len = strnlen(str, n + 1);
+	char *buf = malloc(len + 1);
+	if (buf) {
+		/* len = size of buf, so memcpy is OK */
+		memcpy(buf, str, len); /* Flawfinder: ignore */
+		buf[len] = 0;
+	}
+	return buf;
+#endif
+}
+
 /* strlcpy is designed to be safer, more consistent, and less error prone
  * replacements for strncpy, since it guarantees to NUL-terminate the result.
  *


### PR DESCRIPTION
A rewrite of #764.

This PR does a few things.
* Change the separator in the backends scan string from a colon to a comma (colon still supported for backwards-compatibility)
* Rework scanning to support having backends listed multiple times in the list
* Add support for specifying backend params, currently only for the USB backend: e.g. `usb=0456:b672`
* Update the libiio udev rule to only scan for the detected USB device
* Unify tools on the `--scan` (aka `-S`) option and updated the documentation and man pages
* Print usage examples on iio_readdev / iio_writedev.

The possibility to specify a USB device's VID/PID on the backends scan string makes it possible to only target a specific device, instead of probing all devices on the USB bus. This is useful for applications built around particular pieces of hardware. It also avoids disrupting the functionality of other USB devices on the bus.