### PR TITLE
iiod: replace sprintf with snprintf

### DIFF
--- a/iiod/lexer.l
+++ b/iiod/lexer.l
@@ -143,7 +143,7 @@ WORD (([[:alpha:]]+,)|(iio:))?(-|_|\.|[[:alnum:]])+
 	errno = 0;
 	yylval->value = strtol(yytext, &end, 10);
 	if (yytext == end || errno == ERANGE) {
-		sprintf(errstr,"lex : bad long constant: %s",(char*)yytext);
+		snprintf(errstr, sizeof(errstr), "lex : bad long constant: %s",(char*)yytext);
 		perror(errstr);
 	}
 	return VALUE;

--- a/iiod/parser.y
+++ b/iiod/parser.y
@@ -148,7 +148,7 @@ Line:
 		const char *xml = iio_context_get_xml(pdata->ctx);
 		if (!pdata->verbose) {
 			char buf[128];
-			sprintf(buf, "%lu\n", (unsigned long) strlen(xml));
+			snprintf(buf, sizeof(buf), "%lu\n", (unsigned long) strlen(xml));
 			output(pdata, buf);
 		}
 		output(pdata, xml);
@@ -160,7 +160,7 @@ Line:
 		if (pdata->xml_zstd) {
 			if (!pdata->verbose) {
 				char buf[128];
-				sprintf(buf, "%lu\n", (unsigned long)pdata->xml_zstd_len);
+				snprintf(buf, sizeof(buf), "%lu\n", (unsigned long)pdata->xml_zstd_len);
 				output(pdata, buf);
 			}
 			if (write_all(pdata, pdata->xml_zstd, pdata->xml_zstd_len) <= 0)
@@ -169,7 +169,7 @@ Line:
 			YYACCEPT;
 		} else {
 			char buf[128];
-			sprintf(buf, "%d\n", -EINVAL);
+			snprintf(buf, sizeof(buf), "%d\n", -EINVAL);
 			output(pdata, buf);
 			YYABORT;
 		}
@@ -452,7 +452,7 @@ void yyerror(yyscan_t scanner, const char *msg)
 		output(pdata, "\n");
 	} else {
 		char buf[128];
-		sprintf(buf, "%i\n", -EINVAL);
+		snprintf(buf, sizeof(buf), "%i\n", -EINVAL);
 		output(pdata, buf);
 	}
 }


### PR DESCRIPTION
This replaces sprintf with snprintf to ensure bounds checking inside
iiod. Since iiod is only on Linux, we don't have to use iio_snprintf.

Signed-off-by: Robin Getz <robin.getz@analog.com>