### PR TITLE
bindings: csharp: Fix iio.Version()

### DIFF
--- a/bindings/csharp/Context.cs
+++ b/bindings/csharp/Context.cs
@@ -38,15 +38,15 @@ namespace iio
         }
 
         internal Version(IntPtr ctx)
-        {
-            Version(iio_context_get_version_major(ctx),
-                    iio_context_get_version_minor(ctx),
-                    Marshal.PtrToStringAnsi(iio_context_get_version_tag(ctx)));
+	    : this(iio_context_get_version_major(ctx),
+                   iio_context_get_version_minor(ctx),
+                   Marshal.PtrToStringAnsi(iio_context_get_version_tag(ctx)))
+	{
         }
 
         internal Version()
+	    : this(IntPtr.Zero)
         {
-            Version(IntPtr.Zero);
         }
     }
 


### PR DESCRIPTION
Recent versions of the C# compiler would complain about the way the
iio.Version() constructors were implemented.

Rewrite them to fix these build errors.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>