### PR TITLE
CI: generate setup.exe in 'Build' stage and publish artifacts for PRs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,6 @@ stages:
       displayName: 'Documentation'
       condition: eq(variables['artifactName'], 'Linux-Fedora-34')
     - task: PublishPipelineArtifact@1
-      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
       inputs:
         targetPath: '$(Build.ArtifactStagingDirectory)'
         artifactName: '$(artifactName)'
@@ -151,10 +150,29 @@ stages:
         targetType: 'filePath'
         filePath: .\CI\publish_deps.ps1
     - task: PublishPipelineArtifact@1
-      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
       inputs:
         targetPath: '$(Build.ArtifactStagingDirectory)'
         artifactName: '$(artifactName)'
+
+  #############################################
+  - job: GenerateSetupExe
+    dependsOn: WindowsBuilds
+    pool:
+      vmImage: 'windows-2019'
+    steps:
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        path: '$(Build.ArtifactStagingDirectory)'
+    - task: PowerShell@2
+      inputs:
+        targetType: 'filePath'
+        filePath: .\CI\generate_exe.ps1
+      displayName: 'Generate libiio-setup.exe'
+    - task: PublishPipelineArtifact@1
+      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      inputs:
+        targetPath: '$(Build.ArtifactStagingDirectory)'
+        artifactName: 'Libiio-Setup-Exe'
 
   #############################################
   - job: macOSBuilds
@@ -208,7 +226,6 @@ stages:
         contents: '$(Agent.BuildDirectory)/s/build_tar/?(*.gz)'
         targetFolder: '$(Build.ArtifactStagingDirectory)'
     - task: PublishPipelineArtifact@1
-      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
       inputs:
         targetPath: '$(Build.ArtifactStagingDirectory)'
         artifactName: '$(artifactName)'
@@ -260,7 +277,6 @@ stages:
         contents: '$(Agent.BuildDirectory)/s/build/?(*.deb|*.gz)'
         targetFolder: '$(Build.ArtifactStagingDirectory)'
     - task: PublishPipelineArtifact@1
-      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
       inputs:
         targetPath: '$(Build.ArtifactStagingDirectory)'
         artifactName: '$(artifactName)'
@@ -272,28 +288,7 @@ stages:
   # Deploy
   #############################################
   jobs:
-  - job: GenerateSetupExe
-    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
-    pool:
-      vmImage: 'windows-2019'
-    steps:
-    - task: DownloadPipelineArtifact@2
-      inputs:
-        path: '$(Build.ArtifactStagingDirectory)'
-    - task: PowerShell@2
-      inputs:
-        targetType: 'filePath'
-        filePath: .\CI\generate_exe.ps1
-      displayName: 'Generate libiio-setup.exe'
-    - task: PublishPipelineArtifact@1
-      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-      inputs:
-        targetPath: '$(Build.ArtifactStagingDirectory)'
-        artifactName: 'Libiio-Setup-Exe'
-
-  #############################################
   - job: CheckArtifacts
-    dependsOn: GenerateSetupExe
     condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'], 'refs/tags/v')))
     # Host Box
     pool:


### PR DESCRIPTION
Setup.exe file will be generated during Build stage so can be tested before merging a PR.
Artifacts will be published for PR's builds too.

Signed-off-by: Raluca Chis <raluca.chis@analog.com>