### PR TITLE
Update channels mask handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
-add_library(iio backend.c channel.c device.c context.c buffer.c utilities.c scan.c sort.c
+add_library(iio backend.c channel.c device.c context.c buffer.c mask.c utilities.c scan.c sort.c
 	${CMAKE_CURRENT_BINARY_DIR}/iio-config.h
 )
 

--- a/buffer.c
+++ b/buffer.c
@@ -136,8 +136,8 @@ ssize_t iio_buffer_refill(struct iio_buffer *buffer)
 		read = dev->ctx->ops->get_buffer(dev, &buffer->buffer,
 				buffer->length, buffer->mask->mask, mask->words);
 	} else {
-		read = iio_device_read_raw(dev, buffer->buffer, buffer->length,
-					   buffer->mask->mask, mask->words);
+		read = iio_device_read_raw(dev, buffer->buffer,
+					   buffer->length, mask);
 	}
 
 	if (read >= 0) {

--- a/buffer.c
+++ b/buffer.c
@@ -28,7 +28,7 @@ struct iio_buffer * iio_device_create_buffer(const struct iio_device *dev,
 {
 	ssize_t ret = -EINVAL;
 	struct iio_buffer *buf;
-	ssize_t sample_size = iio_device_get_sample_size(dev);
+	ssize_t sample_size = iio_device_get_sample_size(dev, NULL);
 	size_t words = dev->mask->words;
 	size_t mask_size;
 
@@ -87,7 +87,7 @@ struct iio_buffer * iio_device_create_buffer(const struct iio_device *dev,
 		}
 	}
 
-	ret = iio_device_get_sample_size_mask(dev, buf->mask->mask, words);
+	ret = iio_device_get_sample_size(dev, buf->mask);
 	if (ret < 0)
 		goto err_close_device;
 
@@ -142,7 +142,7 @@ ssize_t iio_buffer_refill(struct iio_buffer *buffer)
 
 	if (read >= 0) {
 		buffer->data_length = read;
-		ret = iio_device_get_sample_size_mask(dev, mask->mask, mask->words);
+		ret = iio_device_get_sample_size(dev, mask);
 		if (ret < 0)
 			return ret;
 		buffer->sample_size = (unsigned int)ret;

--- a/channel.c
+++ b/channel.c
@@ -400,19 +400,19 @@ const struct iio_data_format * iio_channel_get_data_format(
 bool iio_channel_is_enabled(const struct iio_channel *chn)
 {
 	return chn->index >= 0 && chn->dev->mask &&
-		TEST_BIT(chn->dev->mask, chn->number);
+		iio_channels_mask_test_bit(chn->dev->mask, chn->number);
 }
 
 void iio_channel_enable(struct iio_channel *chn)
 {
 	if (chn->is_scan_element && chn->index >= 0 && chn->dev->mask)
-		SET_BIT(chn->dev->mask, chn->number);
+		iio_channels_mask_set_bit(chn->dev->mask, chn->number);
 }
 
 void iio_channel_disable(struct iio_channel *chn)
 {
 	if (chn->index >= 0 && chn->dev->mask)
-		CLEAR_BIT(chn->dev->mask, chn->number);
+		iio_channels_mask_clear_bit(chn->dev->mask, chn->number);
 }
 
 void free_channel(struct iio_channel *chn)

--- a/context.c
+++ b/context.c
@@ -356,9 +356,23 @@ static void reorder_channels(struct iio_device *dev)
 		dev->channels[i]->number = i;
 }
 
+static int iio_device_alloc_mask(struct iio_device *dev)
+{
+	dev->mask = iio_create_channels_mask(dev->nb_channels);
+
+	return dev->mask ? 0 : -ENOMEM;
+}
+
 int iio_context_init(struct iio_context *ctx)
 {
 	unsigned int i;
+	int ret;
+
+	for (i = 0; i < ctx->nb_devices; i++) {
+		ret = iio_device_alloc_mask(ctx->devices[i]);
+		if (ret)
+			return ret;
+	}
 
 	for (i = 0; i < ctx->nb_devices; i++)
 		reorder_channels(ctx->devices[i]);

--- a/device.c
+++ b/device.c
@@ -287,11 +287,11 @@ int iio_device_set_blocking_mode(const struct iio_device *dev, bool blocking)
 		return -ENOSYS;
 }
 
-ssize_t iio_device_read_raw(const struct iio_device *dev,
-		void *dst, size_t len, uint32_t *mask, size_t words)
+ssize_t iio_device_read_raw(const struct iio_device *dev, void *dst, size_t len,
+			    struct iio_channels_mask *mask)
 {
 	if (dev->ctx->ops->read)
-		return dev->ctx->ops->read(dev, dst, len, mask, words);
+		return dev->ctx->ops->read(dev, dst, len, mask);
 	else
 		return -ENOSYS;
 }

--- a/device.c
+++ b/device.c
@@ -440,14 +440,16 @@ void free_device(struct iio_device *dev)
 	free(dev);
 }
 
-ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
-		const uint32_t *mask, size_t words)
+ssize_t iio_device_get_sample_size(const struct iio_device *dev,
+				   const struct iio_channels_mask *mask)
 {
 	ssize_t size = 0;
 	unsigned int i;
 	const struct iio_channel *prev = NULL;
 
-	if (words != (dev->nb_channels + 31) / 32)
+	if (!mask)
+		mask = dev->mask;
+	else if (mask->words != dev->mask->words)
 		return -EINVAL;
 
 	for (i = 0; i < dev->nb_channels; i++) {
@@ -457,7 +459,7 @@ ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 
 		if (chn->index < 0)
 			break;
-		if (!TEST_BIT(mask, chn->number))
+		if (!iio_channels_mask_test_bit(mask, chn->number))
 			continue;
 
 		if (prev && chn->index == prev->index) {
@@ -473,11 +475,6 @@ ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 		prev = chn;
 	}
 	return size;
-}
-
-ssize_t iio_device_get_sample_size(const struct iio_device *dev)
-{
-	return iio_device_get_sample_size_mask(dev, dev->mask->mask, dev->mask->words);
 }
 
 int iio_device_attr_read_longlong(const struct iio_device *dev,

--- a/device.c
+++ b/device.c
@@ -440,6 +440,12 @@ void free_device(struct iio_device *dev)
 	free(dev);
 }
 
+const struct iio_channels_mask *
+iio_device_get_channels_mask(const struct iio_device *dev)
+{
+	return dev->mask;
+}
+
 ssize_t iio_device_get_sample_size(const struct iio_device *dev,
 				   const struct iio_channels_mask *mask)
 {

--- a/device.c
+++ b/device.c
@@ -248,11 +248,12 @@ bool iio_device_is_tx(const struct iio_device *dev)
 int iio_device_open(const struct iio_device *dev,
 		size_t samples_count, bool cyclic)
 {
+	const struct iio_channels_mask *mask = dev->mask;
 	unsigned int i;
 	bool has_channels = false;
 
-	for (i = 0; !has_channels && i < dev->words; i++)
-		has_channels = !!dev->mask[i];
+	for (i = 0; !has_channels && i < mask->words; i++)
+		has_channels = !!mask->mask[i];
 	if (!has_channels)
 		return -EINVAL;
 
@@ -476,7 +477,7 @@ ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 
 ssize_t iio_device_get_sample_size(const struct iio_device *dev)
 {
-	return iio_device_get_sample_size_mask(dev, dev->mask, dev->words);
+	return iio_device_get_sample_size_mask(dev, dev->mask->mask, dev->mask->words);
 }
 
 int iio_device_attr_read_longlong(const struct iio_device *dev,

--- a/iio-backend.h
+++ b/iio-backend.h
@@ -46,12 +46,6 @@
 #define BIT(x) (1 << (x))
 #define BIT_MASK(bit) BIT((bit) % 32)
 #define BIT_WORD(bit) ((bit) / 32)
-#define TEST_BIT(addr, bit) (!!(*(((uint32_t *) addr) + BIT_WORD(bit)) \
-		& BIT_MASK(bit)))
-#define SET_BIT(addr, bit) \
-	*(((uint32_t *) addr) + BIT_WORD(bit)) |= BIT_MASK(bit)
-#define CLEAR_BIT(addr, bit) \
-	*(((uint32_t *) addr) + BIT_WORD(bit)) &= ~BIT_MASK(bit)
 
 static inline __check_ret bool IS_ERR(const void *ptr)
 {

--- a/iio-backend.h
+++ b/iio-backend.h
@@ -91,7 +91,7 @@ struct iio_backend_ops {
 				       const char *uri);
 	struct iio_context * (*clone)(const struct iio_context *ctx);
 	ssize_t (*read)(const struct iio_device *dev, void *dst, size_t len,
-			uint32_t *mask, size_t words);
+			struct iio_channels_mask *mask);
 	ssize_t (*write)(const struct iio_device *dev,
 			const void *src, size_t len);
 	int (*open)(const struct iio_device *dev,

--- a/iio-backend.h
+++ b/iio-backend.h
@@ -106,7 +106,7 @@ struct iio_backend_ops {
 			unsigned int nb_blocks);
 	ssize_t (*get_buffer)(const struct iio_device *dev,
 			void **addr_ptr, size_t bytes_used,
-			uint32_t *mask, size_t words);
+			struct iio_channels_mask *mask);
 
 	ssize_t (*read_device_attr)(const struct iio_device *dev,
 			const char *attr, char *dst, size_t len, enum iio_attr_type);

--- a/iio-private.h
+++ b/iio-private.h
@@ -202,7 +202,7 @@ int iio_device_open(const struct iio_device *dev,
 int iio_device_close(const struct iio_device *dev);
 int iio_device_set_blocking_mode(const struct iio_device *dev, bool blocking);
 ssize_t iio_device_read_raw(const struct iio_device *dev,
-		void *dst, size_t len, uint32_t *mask, size_t words);
+		void *dst, size_t len, struct iio_channels_mask *mask);
 ssize_t iio_device_write_raw(const struct iio_device *dev,
 		const void *src, size_t len);
 int iio_device_get_poll_fd(const struct iio_device *dev);

--- a/iio-private.h
+++ b/iio-private.h
@@ -132,8 +132,7 @@ struct iio_device {
 	struct iio_channel **channels;
 	unsigned int nb_channels;
 
-	uint32_t *mask;
-	size_t words;
+	struct iio_channels_mask *mask;
 };
 
 struct iio_buffer {

--- a/iio-private.h
+++ b/iio-private.h
@@ -220,9 +220,6 @@ iio_create_dynamic_context(const struct iio_context_params *params,
 int iio_dynamic_scan(const struct iio_context_params *params,
 		     struct iio_scan *ctx, const char *backends);
 
-ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
-		const uint32_t *mask, size_t words);
-
 void iio_channel_init_finalize(struct iio_channel *chn);
 unsigned int find_channel_modifier(const char *s, size_t *len_p);
 

--- a/iio-private.h
+++ b/iio-private.h
@@ -152,6 +152,35 @@ struct iio_context_info {
 	char *uri;
 };
 
+struct iio_channels_mask {
+	size_t words;
+	uint32_t mask[];
+};
+
+struct iio_channels_mask *iio_create_channels_mask(unsigned int nb_channels);
+
+int iio_channels_mask_copy(struct iio_channels_mask *dst,
+			   const struct iio_channels_mask *src);
+
+static inline bool
+iio_channels_mask_test_bit(const struct iio_channels_mask *mask,
+			   unsigned int bit)
+{
+	return mask->mask[BIT_WORD(bit)] & BIT_MASK(bit);
+}
+
+static inline void
+iio_channels_mask_set_bit(struct iio_channels_mask *mask, unsigned int bit)
+{
+	mask->mask[BIT_WORD(bit)] |= BIT_MASK(bit);
+}
+
+static inline void
+iio_channels_mask_clear_bit(struct iio_channels_mask *mask, unsigned int bit)
+{
+	mask->mask[BIT_WORD(bit)] &= ~BIT_MASK(bit);
+}
+
 struct iio_module * iio_open_module(const struct iio_context_params *params,
 				    const char *name);
 void iio_release_module(struct iio_module *module);

--- a/iio-private.h
+++ b/iio-private.h
@@ -140,7 +140,7 @@ struct iio_buffer {
 	void *buffer, *userdata;
 	size_t length, data_length;
 
-	uint32_t *mask;
+	struct iio_channels_mask *mask;
 	unsigned int dev_sample_size;
 	unsigned int sample_size;
 	bool dev_is_high_speed;

--- a/iio.h
+++ b/iio.h
@@ -1673,6 +1673,13 @@ struct iio_data_format {
 };
 
 
+/** @brief Get a mask of the currently enabled channels
+ * @param dev A pointer to an iio_device structure
+ * @return A pointer to an iio_channels_mask structure */
+__api __pure const struct iio_channels_mask *
+iio_device_get_channels_mask(const struct iio_device *dev);
+
+
 /** @brief Get the current sample size
  * @param dev A pointer to an iio_device structure
  * @param mask A pointer to an iio_channels_mask structure. If NULL, the current

--- a/iio.h
+++ b/iio.h
@@ -89,6 +89,7 @@ typedef ptrdiff_t ssize_t;
 struct iio_context;
 struct iio_device;
 struct iio_channel;
+struct iio_channels_mask;
 struct iio_buffer;
 struct iio_scan;
 
@@ -1674,12 +1675,16 @@ struct iio_data_format {
 
 /** @brief Get the current sample size
  * @param dev A pointer to an iio_device structure
+ * @param mask A pointer to an iio_channels_mask structure. If NULL, the current
+ *   channel mask of the iio_device object is used.
  * @return On success, the sample size in bytes
  * @return On error, a negative errno code is returned
  *
  * <b>NOTE:</b> The sample size is not constant and will change when channels
  * get enabled or disabled. */
-__api __check_ret ssize_t iio_device_get_sample_size(const struct iio_device *dev);
+__api __check_ret ssize_t
+iio_device_get_sample_size(const struct iio_device *dev,
+			   const struct iio_channels_mask *mask);
 
 
 /** @brief Get the index of the given channel

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -612,6 +612,7 @@ iiod_client_open_unlocked(struct iiod_client *client,
 			  const struct iio_device *dev,
 			  size_t samples_count, bool cyclic)
 {
+	const struct iio_channels_mask *mask = dev->mask;
 	struct iiod_client_io *io;
 	char buf[1024], *ptr;
 	size_t i;
@@ -627,9 +628,9 @@ iiod_client_open_unlocked(struct iiod_client *client,
 			iio_device_get_id(dev), (unsigned long) samples_count);
 	ptr = buf + strlen(buf);
 
-	for (i = dev->words; i > 0; i--, ptr += 8) {
+	for (i = mask->words; i > 0; i--, ptr += 8) {
 		len -= iio_snprintf(ptr, len, "%08" PRIx32,
-				dev->mask[i - 1]);
+				mask->mask[i - 1]);
 	}
 
 	len -= iio_strlcpy(ptr, cyclic ? " CYCLIC\r\n" : "\r\n", len);

--- a/iiod-client.h
+++ b/iiod-client.h
@@ -73,7 +73,7 @@ __api int iiod_client_close_unlocked(struct iiod_client_io *io);
 __api ssize_t iiod_client_read(struct iiod_client *client,
 			       const struct iio_device *dev,
 			       void *dst, size_t len,
-			       uint32_t *mask, size_t words);
+			       struct iio_channels_mask *mask);
 
 __api ssize_t iiod_client_write(struct iiod_client *client,
 				const struct iio_device *dev,

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -629,7 +629,7 @@ static void rw_thd(struct thread_pool *pool, void *d)
 				IIO_DEBUG("Mask[%i] = 0x%08x\n", i, entry->mask[i]);
 			entry->update_mask = false;
 
-			entry->sample_size = iio_device_get_sample_size(dev);
+			entry->sample_size = iio_device_get_sample_size(dev, NULL);
 			entry->samples_count = samples_count;
 			mask_updated = true;
 		}

--- a/local.c
+++ b/local.c
@@ -303,7 +303,8 @@ static int device_check_ready(const struct iio_device *dev, short events,
 }
 
 static ssize_t local_read(const struct iio_device *dev,
-		void *dst, size_t len, uint32_t *mask, size_t words)
+			  void *dst, size_t len,
+			  struct iio_channels_mask *mask)
 {
 	struct iio_device_pdata *pdata = dev->pdata;
 	uintptr_t ptr = (uintptr_t) dst;
@@ -313,10 +314,10 @@ static ssize_t local_read(const struct iio_device *dev,
 
 	if (pdata->fd == -1)
 		return -EBADF;
-	if (words != dev->mask->words)
-		return -EINVAL;
 
-	memcpy(mask, dev->mask->mask, words);
+	ret = iio_channels_mask_copy(mask, dev->mask);
+	if (ret < 0)
+		return ret;
 
 	if (len == 0)
 		return 0;

--- a/local.c
+++ b/local.c
@@ -313,10 +313,10 @@ static ssize_t local_read(const struct iio_device *dev,
 
 	if (pdata->fd == -1)
 		return -EBADF;
-	if (words != dev->words)
+	if (words != dev->mask->words)
 		return -EINVAL;
 
-	memcpy(mask, dev->mask, words);
+	memcpy(mask, dev->mask->mask, words);
 
 	if (len == 0)
 		return 0;
@@ -1795,7 +1795,6 @@ static int add_buffer_attributes(struct iio_device *dev, const char *devpath)
 
 static int create_device(void *d, const char *path)
 {
-	uint32_t *mask = NULL;
 	unsigned int i;
 	int ret;
 	struct iio_context *ctx = d;
@@ -1858,17 +1857,6 @@ static int create_device(void *d, const char *path)
 	}
 	qsort(dev->attrs.names, dev->attrs.num, sizeof(char *),
 		iio_device_attr_compare);
-
-	dev->words = (dev->nb_channels + 31) / 32;
-	if (dev->words) {
-		mask = calloc(dev->words, sizeof(*mask));
-		if (!mask) {
-			ret = -ENOMEM;
-			goto err_free_device;
-		}
-	}
-
-	dev->mask = mask;
 
 	ret = iio_context_add_device(ctx, dev);
 	if (!ret)

--- a/local.c
+++ b/local.c
@@ -429,7 +429,7 @@ static int local_set_kernel_buffers_count(const struct iio_device *dev,
 
 static ssize_t local_get_buffer(const struct iio_device *dev,
 		void **addr_ptr, size_t bytes_used,
-		uint32_t *mask, size_t words)
+		struct iio_channels_mask *mask)
 {
 	struct block block;
 	struct iio_device_pdata *pdata = dev->pdata;

--- a/local.c
+++ b/local.c
@@ -843,7 +843,7 @@ static int enable_high_speed(const struct iio_device *dev)
 
 	req.id = 0;
 	req.type = 0;
-	req.size = pdata->samples_count * iio_device_get_sample_size(dev);
+	req.size = pdata->samples_count * iio_device_get_sample_size(dev, NULL);
 	req.count = nb_blocks;
 
 	ret = ioctl_nointr(fd, BLOCK_ALLOC_IOCTL, &req);

--- a/mask.c
+++ b/mask.c
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * libiio - Library for interfacing industrial I/O (IIO) devices
+ *
+ * Copyright (C) 2022 Analog Devices, Inc.
+ * Author: Paul Cercueil <paul.cercueil@analog.com>
+ */
+
+#include "iio-private.h"
+
+#include <errno.h>
+#include <string.h>
+
+struct iio_channels_mask * iio_create_channels_mask(unsigned int nb_channels)
+{
+	struct iio_channels_mask *mask;
+	size_t nb_words = (nb_channels + 31) / 32;
+
+	mask = zalloc(sizeof(*mask) + nb_words * sizeof(uint32_t));
+	if (mask)
+		mask->words = nb_words;
+
+	return mask;
+}
+
+int iio_channels_mask_copy(struct iio_channels_mask *dst,
+			   const struct iio_channels_mask *src)
+{
+	if (dst->words != src->words)
+		return -EINVAL;
+
+	memcpy(dst->mask, src->mask, src->words * sizeof(uint32_t));
+
+	return 0;
+}

--- a/network.c
+++ b/network.c
@@ -344,11 +344,11 @@ static int network_close(const struct iio_device *dev)
 }
 
 static ssize_t network_read(const struct iio_device *dev, void *dst, size_t len,
-		uint32_t *mask, size_t words)
+			    struct iio_channels_mask *mask)
 {
 	struct iio_device_pdata *pdata = iio_device_get_pdata(dev);
 
-	return iiod_client_read(pdata->iiod_client, dev, dst, len, mask, words);
+	return iiod_client_read(pdata->iiod_client, dev, dst, len, mask);
 }
 
 static ssize_t network_write(const struct iio_device *dev,

--- a/serial.c
+++ b/serial.c
@@ -163,12 +163,12 @@ out_unlock:
 }
 
 static ssize_t serial_read(const struct iio_device *dev, void *dst, size_t len,
-		uint32_t *mask, size_t words)
+			   struct iio_channels_mask *mask)
 {
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
-	return iiod_client_read(pdata->iiod_client, dev, dst, len, mask, words);
+	return iiod_client_read(pdata->iiod_client, dev, dst, len, mask);
 }
 
 static ssize_t serial_write(const struct iio_device *dev,

--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -392,7 +392,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	sample_size = iio_device_get_sample_size(dev);
+	sample_size = iio_device_get_sample_size(dev, NULL);
 	/* Zero isn't normally an error code, but in this case it is an error */
 	if (sample_size == 0) {
 		fprintf(stderr, "Unable to get sample size, returned 0\n");

--- a/tests/iio_writedev.c
+++ b/tests/iio_writedev.c
@@ -411,7 +411,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	sample_size = iio_device_get_sample_size(dev);
+	sample_size = iio_device_get_sample_size(dev, NULL);
 	/* Zero isn't normally an error code, but in this case it is an error */
 	if (sample_size == 0) {
 		fprintf(stderr, "Unable to get sample size, returned 0\n");

--- a/usb.c
+++ b/usb.c
@@ -351,12 +351,12 @@ out_unlock:
 }
 
 static ssize_t usb_read(const struct iio_device *dev, void *dst, size_t len,
-		uint32_t *mask, size_t words)
+			struct iio_channels_mask *mask)
 {
 	struct iio_device_pdata *pdata = iio_device_get_pdata(dev);
 	struct iiod_client *client = pdata->io_ctx.iiod_client;
 
-	return iiod_client_read(client, dev, dst, len, mask, words);
+	return iiod_client_read(client, dev, dst, len, mask);
 }
 
 static ssize_t usb_write(const struct iio_device *dev,

--- a/xml.c
+++ b/xml.c
@@ -319,15 +319,6 @@ static struct iio_device * create_device(struct iio_context *ctx, xmlNode *n)
 		}
 	}
 
-	dev->words = (dev->nb_channels + 31) / 32;
-	if (dev->words) {
-		dev->mask = calloc(dev->words, sizeof(*dev->mask));
-		if (!dev->mask) {
-			err = -ENOMEM;
-			goto err_free_device;
-		}
-	}
-
 	return dev;
 
 err_free_device:


### PR DESCRIPTION
This PR changes how the channels mask are handled internally.

It also modifies the `iio_device_get_sample_size` API function to take an optional channel mask as argument, and exports a new API function `iio_device_get_channels_mask`.

This is in preparation of the new blocks API, where each block has its own channel mask.