### PR TITLE
Improve error handling in public API

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -26,24 +26,19 @@ static bool device_is_high_speed(const struct iio_device *dev)
 struct iio_buffer * iio_device_create_buffer(const struct iio_device *dev,
 		size_t samples_count, bool cyclic)
 {
-	ssize_t ret = -EINVAL;
 	struct iio_buffer *buf;
-	ssize_t sample_size = iio_device_get_sample_size(dev, NULL);
+	ssize_t ret, sample_size = iio_device_get_sample_size(dev, NULL);
 	size_t mask_size;
 
 	if (!sample_size || !samples_count)
-		goto err_set_errno;
+		return iio_ptr(-EINVAL);
 
-	if (sample_size < 0) {
-		ret = sample_size;
-		goto err_set_errno;
-	}
+	if (sample_size < 0)
+		return iio_ptr((int) sample_size);
 
 	buf = malloc(sizeof(*buf));
-	if (!buf) {
-		ret = -ENOMEM;
-		goto err_set_errno;
-	}
+	if (!buf)
+		return iio_ptr(-ENOMEM);
 
 	buf->dev_sample_size = (unsigned int) sample_size;
 	buf->length = sample_size * samples_count;
@@ -100,9 +95,7 @@ err_free_mask:
 	free(buf->mask);
 err_free_buf:
 	free(buf);
-err_set_errno:
-	errno = -(int)ret;
-	return NULL;
+	return iio_ptr((int) ret);
 }
 
 void iio_buffer_destroy(struct iio_buffer *buffer)

--- a/context.c
+++ b/context.c
@@ -184,17 +184,17 @@ static char * iio_context_create_xml(const struct iio_context *ctx)
 
 	len = iio_snprintf_context_xml(NULL, 0, ctx);
 	if (len < 0)
-		return ERR_PTR((int) len);
+		return iio_ptr((int) len);
 
 	len++; /* room for terminating NULL */
 	str = malloc(len);
 	if (!str)
-		return ERR_PTR(-ENOMEM);
+		return iio_ptr(-ENOMEM);
 
 	len = iio_snprintf_context_xml(str, len, ctx);
 	if (len < 0) {
 		free(str);
-		return ERR_PTR((int) len);
+		return iio_ptr((int) len);
 	}
 
 	return str;
@@ -377,13 +377,12 @@ int iio_context_init(struct iio_context *ctx)
 	for (i = 0; i < ctx->nb_devices; i++)
 		reorder_channels(ctx->devices[i]);
 
-	if (!ctx->xml) {
-		ctx->xml = iio_context_create_xml(ctx);
-		if (IS_ERR(ctx->xml))
-			return PTR_ERR(ctx->xml);
-	}
+	if (ctx->xml)
+		return 0;
 
-	return 0;
+	ctx->xml = iio_context_create_xml(ctx);
+
+	return iio_err(ctx->xml);
 }
 
 unsigned int iio_context_get_version_major(const struct iio_context *ctx)

--- a/dns_sd_avahi.c
+++ b/dns_sd_avahi.c
@@ -248,7 +248,7 @@ int dnssd_find_hosts(const struct iio_context_params *params,
 	struct dns_sd_cb_data adata;
 	AvahiClient *client;
 	AvahiServiceBrowser *browser;
-	int ret = 0;
+	int ret;
 
 	d = new_discovery_data();
 	if (!d)
@@ -258,9 +258,10 @@ int dnssd_find_hosts(const struct iio_context_params *params,
 	adata.d = d;
 
 	d->lock = iio_mutex_create();
-	if (!d->lock) {
+	ret = iio_err(d->lock);
+	if (ret) {
 		dnssd_free_all_discovery_data(params, d);
-		return -ENOMEM;
+		return ret;
 	}
 
 	d->poll = avahi_simple_poll_new();
@@ -357,7 +358,7 @@ int dnssd_resolve_host(const struct iio_context_params *params,
 {
 	struct dns_sd_discovery_data *d;
 	struct dns_sd_cb_data adata;
-	int ret = 0;
+	int ret;
 
 	if (!hostname || hostname[0] == '\0')
 		return -EINVAL;
@@ -367,10 +368,9 @@ int dnssd_resolve_host(const struct iio_context_params *params,
 		return -ENOMEM;
 
 	d->lock = iio_mutex_create();
-	if (!d->lock) {
-		ret = -ENOMEM;
+	ret = iio_err(d->lock);
+	if (ret)
 		goto err_free_data;
-	}
 
 	adata.params = params;
 	adata.d = d;

--- a/dns_sd_bonjour.c
+++ b/dns_sd_bonjour.c
@@ -176,7 +176,7 @@ int dnssd_find_hosts(const struct iio_context_params *params,
 	CFStringRef domain;
 	CFStreamError error;
 	Boolean result;
-	int ret = 0;
+	int ret;
 
 	prm_dbg(params, "DNS SD: Start service discovery.\n");
 
@@ -185,9 +185,10 @@ int dnssd_find_hosts(const struct iio_context_params *params,
 		return -ENOMEM;
 
 	d->lock = iio_mutex_create();
-	if (!d->lock) {
+	ret = iio_err(d->lock);
+	if (ret) {
 		dnssd_free_all_discovery_data(params, d);
-		return -ENOMEM;
+		return ret;
 	}
 
 	bdata.d = d;

--- a/iio-backend.h
+++ b/iio-backend.h
@@ -43,29 +43,6 @@
 #endif
 
 #define ARRAY_SIZE(x) (sizeof(x) ? sizeof(x) / sizeof((x)[0]) : 0)
-#define BIT(x) (1 << (x))
-#define BIT_MASK(bit) BIT((bit) % 32)
-#define BIT_WORD(bit) ((bit) / 32)
-
-static inline __check_ret bool IS_ERR(const void *ptr)
-{
-	return (uintptr_t) ptr >= (uintptr_t) -4095;
-}
-
-static inline __check_ret int PTR_ERR(const void *ptr)
-{
-	return (int)(intptr_t) ptr;
-}
-
-static inline __check_ret void * ERR_PTR(int err)
-{
-	return (void *)(intptr_t) err;
-}
-
-static inline __check_ret int PTR_ERR_OR_ZERO(const void *ptr)
-{
-	return IS_ERR(ptr) ? PTR_ERR(ptr) : 0;
-}
 
 struct iio_device;
 struct iio_context;

--- a/iio-private.h
+++ b/iio-private.h
@@ -33,6 +33,10 @@
 #define is_little_endian() (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 #endif
 
+#define BIT(x) (1 << (x))
+#define BIT_MASK(bit) BIT((bit) % 32)
+#define BIT_WORD(bit) ((bit) / 32)
+
 /* ntohl/htonl are a nightmare to use in cross-platform applications,
  * since they are defined in different headers on different platforms.
  * iio_be32toh/iio_htobe32 are just clones of ntohl/htonl. */

--- a/iio.h
+++ b/iio.h
@@ -282,6 +282,34 @@ enum iio_event_direction {
 #endif /* _IIO_TYPES_H_ */
 
 /* ---------------------------------------------------------------------------*/
+/* ---------------------------- Error handling -------------------------------*/
+/** @defgroup Functions for handling pointer-encoded errors
+ * @{
+ * @brief Encode an error code into a pointer
+ * @param err The error code to be encoded. Must be negative.
+ * @return The error-encoding pointer. */
+static inline __check_ret void *iio_ptr(int err)
+{
+	return (void *)(intptr_t) err;
+}
+
+/** @brief Returns the encoded error code if present, otherwise zero.
+ * @param ptr Pointer that is either valid or error-encoding
+ * @return The error code if present, otherwise zero. */
+static inline __check_ret int iio_err(const void *ptr)
+{
+	return (uintptr_t) ptr >= (uintptr_t) -4095 ? (int)(intptr_t) ptr : 0;
+}
+
+/** @brief Type-cast an error-encoding pointer.
+ * @param ptr Error-encoding pointer
+ * @return An error-encoding pointer that can be used as a different type. */
+static inline __check_ret void *iio_err_cast(const void *ptr)
+{
+	return (void *) ptr;
+}
+
+/** @} *//* ------------------------------------------------------------------*/
 /* ------------------------- Scan functions ----------------------------------*/
 /** @defgroup Scan Functions for scanning available contexts
  * @{

--- a/iio.h
+++ b/iio.h
@@ -1452,7 +1452,7 @@ __api __check_ret __pure const struct iio_device * iio_buffer_get_device(
  * @param samples_count The number of samples that the buffer should contain
  * @param cyclic If True, enable cyclic mode
  * @return On success, a pointer to an iio_buffer structure
- * @return On error, NULL is returned, and errno is set to the error code
+ * @return On failure, NULL is returned and errno is set appropriately
  *
  * <b>NOTE:</b> Channels that have to be written to / read from must be enabled
  * before creating the buffer. */

--- a/iio.h
+++ b/iio.h
@@ -324,7 +324,7 @@ static inline __check_ret void *iio_err_cast(const void *ptr)
  *   of the backends to be scanned for contexts. If NULL, all the available
  *   backends are scanned.
  * @return On success, a pointer to an iio_scan structure
- * @return On failure, NULL is returned and errno is set appropriately
+ * @return On failure, a pointer-encoded error is returned
  *
  * <b>NOTE:</b> It is possible to provide backend-specific information.
  * For instance, "local,usb=0456:*" will scan the local backend and

--- a/iio.h
+++ b/iio.h
@@ -419,7 +419,7 @@ __api __check_ret __cnst const char * iio_get_backend(unsigned int index);
  * @param xml Pointer to the XML data in memory
  * @param len Length of the XML string in memory (excluding the final \0)
  * @return On success, A pointer to an iio_context structure
- * @return On failure, NULL is returned and errno is set appropriately
+ * @return On failure, a pointer-encoded error is returned
  *
  * <b>NOTE:</b> The format of the XML must comply to the one returned by
  * iio_context_get_xml */
@@ -434,7 +434,7 @@ __api __check_ret struct iio_context * iio_create_xml_context_mem(
  *   be created using the URI string present in the IIOD_REMOTE environment
  *   variable, or if not set, a local backend is created.
  * @return On success, a pointer to a iio_context structure
- * @return On failure, NULL is returned and errno is set appropriately
+ * @return On failure, a pointer-encoded error is returned
  *
  * <b>NOTE:</b> The following URIs are supported based on compile time backend
  * support:
@@ -468,7 +468,7 @@ iio_create_context(const struct iio_context_params *params, const char *uri);
 /** @brief Duplicate a pre-existing IIO context
  * @param ctx A pointer to an iio_context structure
  * @return On success, A pointer to an iio_context structure
- * @return On failure, NULL is returned and errno is set appropriately
+ * @return On failure, a pointer-encoded error is returned
  *
  * <b>NOTE:</b> This function is not supported on 'usb:' contexts, since libusb
  * can only claim the interface once. "Function not implemented" is the expected errno.

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -155,17 +155,13 @@ struct iiod_client * iiod_client_new(const struct iio_context_params *params,
 	int err;
 
 	client = malloc(sizeof(*client));
-	if (!client) {
-		errno = ENOMEM;
-		return NULL;
-	}
+	if (!client)
+		return iio_ptr(-ENOMEM);
 
 	client->lock = iio_mutex_create();
 	err = iio_err(client->lock);
-	if (err) {
-		errno = -err;
+	if (err)
 		goto err_free_client;
-	}
 
 	client->params = params;
 	client->ops = ops;
@@ -175,7 +171,7 @@ struct iiod_client * iiod_client_new(const struct iio_context_params *params,
 
 err_free_client:
 	free(client);
-	return NULL;
+	return iio_ptr(err);
 }
 
 void iiod_client_destroy(struct iiod_client *client)
@@ -567,9 +563,7 @@ out_free_xml:
 	free(xml);
 out_unlock:
 	iio_mutex_unlock(client->lock);
-	if (!ctx)
-		errno = -ret;
-	return ctx;
+	return ctx ? ctx : iio_ptr(ret);
 }
 
 struct iio_context * iiod_client_create_context(struct iiod_client *client,

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -621,7 +621,7 @@ iiod_client_open_unlocked(struct iiod_client *client,
 
 	io = iiod_client_create_io_context(client, dev, samples_count, cyclic);
 	if (!io)
-		return ERR_PTR(-ENOMEM);
+		return iio_ptr(-ENOMEM);
 
 	len = sizeof(buf);
 	len -= iio_snprintf(buf, len, "OPEN %s %lu ",
@@ -650,7 +650,7 @@ iiod_client_open_unlocked(struct iiod_client *client,
 err_destroy_io:
 	iiod_client_io_destroy(io);
 
-	return ERR_PTR(ret);
+	return iio_ptr(ret);
 }
 
 int iiod_client_close_unlocked(struct iiod_client_io *io)

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -550,8 +550,9 @@ iiod_client_create_context_private(struct iiod_client *client,
 	ctx = iio_create_context_from_xml(client->params, xml, xml_len,
 					  backend, description,
 					  ctx_attrs, ctx_values, nb_ctx_attrs);
-	if (!ctx) {
-		ret = -errno;
+	ret = iio_err(ctx);
+	if (ret) {
+		ctx = NULL;
 	} else {
 		/* If the context creation suceeded, update our "params" pointer
 		 * to point to the context's params, as we know their lifetime

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -152,6 +152,7 @@ struct iiod_client * iiod_client_new(const struct iio_context_params *params,
 				     const struct iiod_client_ops *ops)
 {
 	struct iiod_client *client;
+	int err;
 
 	client = malloc(sizeof(*client));
 	if (!client) {
@@ -160,8 +161,9 @@ struct iiod_client * iiod_client_new(const struct iio_context_params *params,
 	}
 
 	client->lock = iio_mutex_create();
-	if (!client->lock) {
-		errno = ENOMEM;
+	err = iio_err(client->lock);
+	if (err) {
+		errno = -err;
 		goto err_free_client;
 	}
 

--- a/local.c
+++ b/local.c
@@ -1453,7 +1453,7 @@ static struct iio_channel *create_channel(struct iio_device *dev,
 
 	chn = zalloc(sizeof(*chn));
 	if (!chn)
-		return ERR_PTR(-ENOMEM);
+		return iio_ptr(-ENOMEM);
 
 	chn->pdata = zalloc(sizeof(*chn->pdata));
 	if (!chn->pdata)
@@ -1484,7 +1484,7 @@ err_free_chn_pdata:
 	free(chn->pdata);
 err_free_chn:
 	free(chn);
-	return ERR_PTR(err);
+	return iio_ptr(err);
 }
 
 static int add_channel(struct iio_device *dev, const char *name,
@@ -1512,9 +1512,10 @@ static int add_channel(struct iio_device *dev, const char *name,
 	}
 
 	chn = create_channel(dev, channel_id, name, path, dir_is_scan_elements);
-	if (IS_ERR(chn)) {
+	ret = iio_err(chn);
+	if (ret) {
 		free(channel_id);
-		return PTR_ERR(chn);
+		return ret;
 	}
 
 	iio_channel_init_finalize(chn);

--- a/local.c
+++ b/local.c
@@ -2064,11 +2064,14 @@ local_create_context(const struct iio_context_params *params, const char *args)
 	bool no_iio;
 
 	description = local_get_description(NULL);
+	if (!description)
+		return iio_ptr(-ENOMEM);
 
 	ctx = iio_context_create_from_backend(&iio_local_backend, description);
 	free(description);
-	if (!ctx)
-		goto err_set_errno;
+	ret = iio_err(ctx);
+	if (ret)
+		return iio_err_cast(ctx);
 
 	ctx->params = *params;
 
@@ -2119,9 +2122,7 @@ local_create_context(const struct iio_context_params *params, const char *args)
 
 err_context_destroy:
 	iio_context_destroy(ctx);
-err_set_errno:
-	errno = -ret;
-	return NULL;
+	return iio_ptr(ret);
 }
 
 #define BUF_SIZE 128

--- a/lock-windows.c
+++ b/lock-windows.c
@@ -34,7 +34,7 @@ struct iio_mutex * iio_mutex_create(void)
 	struct iio_mutex *lock = malloc(sizeof(*lock));
 
 	if (!lock)
-		return NULL;
+		return iio_ptr(-ENOMEM);
 
 	InitializeCriticalSection(&lock->lock);
 
@@ -62,7 +62,7 @@ struct iio_cond * iio_cond_create(void)
 	struct iio_cond *cond = malloc(sizeof(*cond));
 
 	if (!cond)
-		return NULL;
+		return iio_ptr(-ENOMEM);
 
 	InitializeConditionVariable(&cond->cond);
 

--- a/lock-windows.c
+++ b/lock-windows.c
@@ -97,11 +97,11 @@ struct iio_thrd * iio_thrd_create(int (*thrd)(void *),
 	struct iio_thrd *iio_thrd;
 
 	if (!thrd)
-		return ERR_PTR(-EINVAL);
+		return iio_ptr(-EINVAL);
 
 	iio_thrd = malloc(sizeof(*iio_thrd));
 	if (!iio_thrd)
-		return ERR_PTR(-ENOMEM);
+		return iio_ptr(-ENOMEM);
 
 	iio_thrd->func = thrd;
 	iio_thrd->d = d;
@@ -111,7 +111,7 @@ struct iio_thrd * iio_thrd_create(int (*thrd)(void *),
 				      d, 0, NULL);
 	if (!iio_thrd->thid) {
 		free(iio_thrd);
-		return ERR_PTR(-(int) GetLastError());
+		return iio_ptr(-(int) GetLastError());
 	}
 
 	/* TODO: set name */

--- a/lock.c
+++ b/lock.c
@@ -128,11 +128,11 @@ struct iio_thrd * iio_thrd_create(int (*thrd)(void *),
 	int ret;
 
 	if (!thrd)
-		return ERR_PTR(-EINVAL);
+		return iio_ptr(-EINVAL);
 
 	iio_thrd = malloc(sizeof(*iio_thrd));
 	if (!iio_thrd)
-		return ERR_PTR(-ENOMEM);
+		return iio_ptr(-ENOMEM);
 
 	iio_thrd->d = d;
 	iio_thrd->func = thrd;
@@ -142,7 +142,7 @@ struct iio_thrd * iio_thrd_create(int (*thrd)(void *),
 			     iio_thrd_wrapper, iio_thrd);
 	if (ret) {
 		free(iio_thrd);
-		return ERR_PTR(ret);
+		return iio_ptr(ret);
 	}
 
 	/* TODO: Set name */

--- a/lock.c
+++ b/lock.c
@@ -46,7 +46,7 @@ struct iio_mutex * iio_mutex_create(void)
 	struct iio_mutex *lock = malloc(sizeof(*lock));
 
 	if (!lock)
-		return NULL;
+		return iio_ptr(-ENOMEM);
 
 #ifndef NO_THREADS
 	pthread_mutex_init(&lock->lock, NULL);
@@ -81,7 +81,7 @@ struct iio_cond * iio_cond_create(void)
 	struct iio_cond *cond = malloc(sizeof(*cond));
 
 	if (!cond)
-		return NULL;
+		return iio_ptr(-ENOMEM);
 
 #ifndef NO_THREADS
 	pthread_cond_init(&cond->cond, NULL);

--- a/network.c
+++ b/network.c
@@ -293,8 +293,8 @@ static int network_open(const struct iio_device *dev,
 
 	ppdata->client_io = iiod_client_open_unlocked(client, dev,
 						      samples_count, cyclic);
-	if (IS_ERR(ppdata->client_io)) {
-		ret = PTR_ERR(ppdata->client_io);
+	ret = iio_err(ppdata->client_io);
+	if (ret) {
 		dev_perror(dev, -ret, "Unable to open device");
 		goto err_close_socket;
 	}

--- a/network.c
+++ b/network.c
@@ -732,7 +732,8 @@ static struct iio_context * network_create_context(const struct iio_context_para
 
 	iiod_client = iiod_client_new(params, &pdata->io_ctx,
 				      &network_iiod_client_ops);
-	if (!iiod_client)
+	ret = iio_err(iiod_client);
+	if (ret)
 		goto err_free_description;
 
 	pdata->iiod_client = iiod_client;
@@ -761,7 +762,8 @@ static struct iio_context * network_create_context(const struct iio_context_para
 					 &iio_ip_backend, description,
 					 ctx_attrs, ctx_values,
 					 ARRAY_SIZE(ctx_values));
-	if (!ctx)
+	ret = iio_err(ctx);
+	if (ret)
 		goto err_destroy_iiod_client;
 
 	iio_context_set_pdata(ctx, pdata);
@@ -790,10 +792,9 @@ static struct iio_context * network_create_context(const struct iio_context_para
 
 		ppdata->iiod_client = iiod_client_new(params, &ppdata->io_ctx,
 						      &network_iiod_client_ops);
-		if (!ppdata->iiod_client) {
-			ret = -ENOMEM;
+		ret = iio_err(ppdata->iiod_client);
+		if (ret)
 			goto err_network_shutdown;
-		}
 	}
 
 	iiod_client_set_timeout(pdata->iiod_client,

--- a/scan.c
+++ b/scan.c
@@ -86,11 +86,11 @@ struct iio_scan * iio_scan(const struct iio_context_params *params,
 			backend_name = iio_strtok_r(token, "=", &rest2);
 
 			module = iio_open_module(&params2, backend_name);
-			if (IS_ERR(module)) {
+			if (iio_err(module)) {
 				module = NULL;
 			} else {
 				backend = iio_module_get_backend(module);
-				if (IS_ERR(backend)) {
+				if (iio_err(backend)) {
 					iio_release_module(module);
 					backend = NULL;
 					module = NULL;

--- a/scan.c
+++ b/scan.c
@@ -42,10 +42,8 @@ struct iio_scan * iio_scan(const struct iio_context_params *params,
 		params2.stderr_level = default_params->stderr_level;
 
 	ctx = calloc(1, sizeof(*ctx));
-	if (!ctx) {
-		errno = ENOMEM;
-		return NULL;
-	}
+	if (!ctx)
+		return iio_ptr(-ENOMEM);
 
 	if (!backends)
 		backends = LIBIIO_SCAN_BACKENDS;

--- a/serial.c
+++ b/serial.c
@@ -437,10 +437,8 @@ static struct iio_context * serial_create_context(
 
 	uri_len = sizeof("serial:,1000000,8n1n") + strnlen(port_name, PATH_MAX);
 	uri = malloc(uri_len);
-	if (!uri) {
-		errno = ENOMEM;
-		return NULL;
-	}
+	if (!uri)
+		return iio_ptr(-ENOMEM);
 
 	ret = libserialport_to_errno(sp_get_port_by_name(port_name, &port));
 	if (ret)
@@ -511,8 +509,7 @@ static struct iio_context * serial_create_context(
 err_context_destroy:
 	free(uri);
 	iio_context_destroy(ctx);
-	errno = -ret;
-	return NULL;
+	return iio_ptr(ret);
 
 err_destroy_iiod_client:
 	iiod_client_destroy(pdata->iiod_client);
@@ -526,8 +523,7 @@ err_free_port:
 	sp_free_port(port);
 err_free_uri:
 	free(uri);
-	errno = -ret;
-	return NULL;
+	return iio_ptr(ret);
 }
 
 /* Take string, in "[baud rate],[data bits][parity][stop bits][flow control]"
@@ -665,10 +661,8 @@ serial_create_context_from_args(const struct iio_context_params *params,
 	int ret;
 
 	uri_dup = iio_strdup(args);
-	if (!uri_dup) {
-		errno = ENOMEM;
-		return NULL;
-	}
+	if (!uri_dup)
+		return iio_ptr(-ENOMEM);
 
 	comma = strchr(uri_dup, ',');
 	if (comma) {
@@ -693,6 +687,5 @@ serial_create_context_from_args(const struct iio_context_params *params,
 err_free_dup:
 	free(uri_dup);
 	prm_err(params, "Bad URI: \'serial:%s\'\n", args);
-	errno = EINVAL;
-	return NULL;
+	return iio_ptr(-EINVAL);
 }

--- a/serial.c
+++ b/serial.c
@@ -135,7 +135,7 @@ static int serial_open(const struct iio_device *dev,
 	pdata->client_io = iiod_client_open_unlocked(ctx_pdata->iiod_client,
 						     dev, samples_count,
 						     cyclic);
-	ret = PTR_ERR_OR_ZERO(pdata->client_io);
+	ret = iio_err(pdata->client_io);
 	pdata->opened = !ret;
 
 out_unlock:

--- a/tests/iio_common.c
+++ b/tests/iio_common.c
@@ -78,11 +78,13 @@ struct iio_context * autodetect_context(bool rtn, const char * name, const char 
 	unsigned int i;
 	size_t results;
 	FILE *out;
+	int err;
 
 	scan_ctx = iio_scan(NULL, scan);
-	if (!scan_ctx) {
+	err = iio_err(scan_ctx);
+	if (err) {
 		char *err_str = xmalloc(BUF_SIZE, name);
-		iio_strerror(errno, err_str, BUF_SIZE);
+		iio_strerror(err, err_str, BUF_SIZE);
 		fprintf(stderr, "Scanning for IIO contexts failed: %s\n", err_str);
 		free (err_str);
 		return NULL;

--- a/usb.c
+++ b/usb.c
@@ -1098,12 +1098,14 @@ usb_create_context_from_args(const struct iio_context_params *params,
 	/* keep MSVS happy by setting these to NULL */
 	struct iio_scan *scan_ctx = NULL;
 	bool scan;
+	int err;
 
 	/* if uri is just "usb:" that means search for the first one */
 	scan = !*ptr;
 	if (scan) {
 		scan_ctx = iio_scan(params, "usb");
-		if (!scan_ctx)
+		err = iio_err(scan_ctx);
+		if (err)
 			goto err_bad_uri;
 
 		if (iio_scan_get_results_count(scan_ctx) != 1) {

--- a/usb.c
+++ b/usb.c
@@ -115,10 +115,8 @@ static ssize_t read_data_sync(struct iiod_client_pdata *ep,
 static int usb_io_context_init(struct iiod_client_pdata *io_ctx)
 {
 	io_ctx->lock = iio_mutex_create();
-	if (!io_ctx->lock)
-		return -ENOMEM;
 
-	return 0;
+	return iio_err(io_ctx->lock);
 }
 
 static void usb_io_context_exit(struct iiod_client_pdata *io_ctx)
@@ -883,9 +881,9 @@ static struct iio_context * usb_create_context(const struct iio_context_params *
 	}
 
 	pdata->ep_lock = iio_mutex_create();
-	if (!pdata->ep_lock) {
+	ret = iio_err(pdata->ep_lock);
+	if (ret) {
 		prm_err(params, "Unable to create mutex\n");
-		ret = -ENOMEM;
 		goto err_free_pdata;
 	}
 

--- a/usb.c
+++ b/usb.c
@@ -288,10 +288,9 @@ static int usb_open(const struct iio_device *dev,
 
 	pdata->client_io = iiod_client_open_unlocked(client, dev,
 						     samples_count, cyclic);
-	if (IS_ERR(pdata->client_io)) {
-		ret = PTR_ERR(pdata->client_io);
+	ret = iio_err(pdata->client_io);
+	if (ret)
 		goto err_unlock_client;
-	}
 
 	timeout = usb_calculate_remote_timeout(ctx_pdata->timeout_ms);
 

--- a/usb.c
+++ b/usb.c
@@ -279,7 +279,8 @@ static int usb_open(const struct iio_device *dev,
 	}
 
 	client = iiod_client_new(params, &pdata->io_ctx, &usb_iiod_client_ops);
-	if (!client)
+	ret = iio_err(client);
+	if (ret)
 		goto err_close_pipe;
 
 	iiod_client_mutex_lock(client);
@@ -1010,9 +1011,9 @@ static struct iio_context * usb_create_context(const struct iio_context_params *
 
 	pdata->io_ctx.iiod_client = iiod_client_new(params, &pdata->io_ctx,
 						    &usb_iiod_client_ops);
-	if (!pdata->io_ctx.iiod_client) {
-		prm_err(params, "Unable to allocate memory\n");
-		ret = -ENOMEM;
+	ret = iio_err(pdata->io_ctx.iiod_client);
+	if (ret) {
+		prm_perror(params, -ret, "Unable to create IIOD client");
 		goto err_io_context_exit;
 	}
 
@@ -1029,10 +1030,9 @@ static struct iio_context * usb_create_context(const struct iio_context_params *
 	}
 
 	ctx = usb_create_context_with_attrs(usb_dev, pdata);
-	if (!ctx) {
-		ret = -errno;
+	ret = iio_err(ctx);
+	if (ret)
 		goto err_reset_pipes;
-	}
 
 	libusb_free_config_descriptor(conf_desc);
 

--- a/xml.c
+++ b/xml.c
@@ -180,7 +180,7 @@ static struct iio_channel * create_channel(struct iio_device *dev, xmlNode *n)
 
 	chn = zalloc(sizeof(*chn));
 	if (!chn)
-		return ERR_PTR(-ENOMEM);
+		return iio_ptr(-ENOMEM);
 
 	chn->dev = dev;
 
@@ -238,7 +238,7 @@ static struct iio_channel * create_channel(struct iio_device *dev, xmlNode *n)
 
 err_free_channel:
 	free_channel(chn);
-	return ERR_PTR(err);
+	return iio_ptr(err);
 }
 
 static struct iio_device * create_device(struct iio_context *ctx, xmlNode *n)
@@ -249,7 +249,7 @@ static struct iio_device * create_device(struct iio_context *ctx, xmlNode *n)
 
 	dev = zalloc(sizeof(*dev));
 	if (!dev)
-		return ERR_PTR(-ENOMEM);
+		return iio_ptr(-ENOMEM);
 
 	dev->ctx = ctx;
 
@@ -283,8 +283,8 @@ static struct iio_device * create_device(struct iio_context *ctx, xmlNode *n)
 		if (!strcmp((char *) n->name, "channel")) {
 			struct iio_channel **chns,
 					   *chn = create_channel(dev, n);
-			if (IS_ERR(chn)) {
-				err = PTR_ERR(chn);
+			err = iio_err(chn);
+			if (err) {
 				dev_perror(dev, -err, "Unable to create channel");
 				goto err_free_device;
 			}
@@ -324,7 +324,7 @@ static struct iio_device * create_device(struct iio_context *ctx, xmlNode *n)
 err_free_device:
 	free_device(dev);
 
-	return ERR_PTR(err);
+	return iio_ptr(err);
 }
 
 static struct iio_context * xml_clone(const struct iio_context *ctx)
@@ -385,8 +385,8 @@ static int iio_populate_xml_context_helper(struct iio_context *ctx, xmlNode *roo
 		}
 
 		dev = create_device(ctx, n);
-		if (IS_ERR(dev)) {
-			err = PTR_ERR(dev);
+		err = iio_err(dev);
+		if (err) {
 			ctx_perror(ctx, -err, "Unable to create device");
 			return err;
 		}


### PR DESCRIPTION
This set of commits introduce new public functions `iio_err`, `iio_ptr` and `iio_err_cast`, and changes the way errors are handled internally and in the API.

Instead of returning NULL and setting the `errno` variable, the policy is now to return an error encoded in a pointer. The error code can then be retrieved with `iio_err` (zero means no error), and a error-encoding pointer can be created from an error code with `iio_ptr`.

This is the first step needed to decouple libiio from using <errno.h> error codes, which are very limiting and don't allow to represent the spectrum of error cases that can happen in libiio and IIOD.