### PR TITLE
read|write_dev : fix bug & qualify channel names and err if bad name

### DIFF
--- a/tests/iio_common.c
+++ b/tests/iio_common.c
@@ -126,6 +126,21 @@ err_free_ctx:
 	return ctx;
 }
 
+int iio_device_enable_channel(const struct iio_device *dev, const char * channel, bool type)
+{
+	struct iio_channel *ch;
+
+	ch = iio_device_find_channel(dev, channel, type);
+	if (!ch)
+		return -ENXIO;
+
+	if (iio_channel_is_enabled(ch))
+		return -EBUSY;
+
+	iio_channel_enable(ch);
+	return 0;
+}
+
 unsigned long int sanitize_clamp(const char *name, const char *argv,
 	uint64_t min, uint64_t max)
 {

--- a/tests/iio_common.h
+++ b/tests/iio_common.h
@@ -47,6 +47,7 @@ char *cmn_strndup(const char *str, size_t n);
 struct iio_context * autodetect_context(bool rtn, const char *name, const char *scan);
 unsigned long int sanitize_clamp(const char *name, const char *argv,
 	uint64_t min, uint64_t max);
+int iio_device_enable_channel(const struct iio_device *dev, const char * channel, bool type);
 
 /* optstring is a string containing the legitimate option characters.
  * If such a character is followed by a colon, the option  requires  an  argument.

--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -373,17 +373,16 @@ int main(int argc, char **argv)
 			}
 		}
 	} else {
-		for (i = 0; i < nb_channels; i++) {
-			struct iio_channel *ch = iio_device_get_channel(dev, i);
-			for (j = optind + 1; j < (unsigned int) argc; j++) {
-				const char *n = iio_channel_get_name(ch);
-				if ((!strcmp(argw[j], iio_channel_get_id(ch)) ||
-						(n && !strcmp(n, argw[j]))) &&
-						!iio_channel_is_output(ch)) {
-					iio_channel_enable(ch);
-					nb_active_channels++;
-				}
+		for (j = optind + 1; j < (unsigned int) argc; j++) {
+			ret = iio_device_enable_channel(dev, argw[j], false);
+			if (ret < 0) {
+				char buf[256];
+				iio_strerror(-(int) ret, buf, sizeof(buf));
+				fprintf(stderr, "Bad channel name \"%s\" : %s\n", argw[j], buf);
+				iio_context_destroy(ctx);
+				return EXIT_FAILURE;
 			}
+			nb_active_channels++;
 		}
 	}
 

--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -263,8 +263,8 @@ int main(int argc, char **argv)
 	}
 	free(opts);
 
-	if (argc < optind || argc > optind + 2) {
-		fprintf(stderr, "Incorrect number of arguments.\n\n");
+	if (argc < optind) {
+		fprintf(stderr, "Too few arguments.\n\n");
 		usage(MY_NAME, options, options_descriptions);
 		return EXIT_FAILURE;
 	}

--- a/tests/iio_writedev.c
+++ b/tests/iio_writedev.c
@@ -392,17 +392,16 @@ int main(int argc, char **argv)
 			}
 		}
 	} else {
-		for (i = 0; i < nb_channels; i++) {
-			struct iio_channel *ch = iio_device_get_channel(dev, i);
-			for (j = optind + 1; j < (unsigned int) argc; j++) {
-				const char *n = iio_channel_get_name(ch);
-				if ((!strcmp(argw[j], iio_channel_get_id(ch)) ||
-						(n && !strcmp(n, argw[j]))) &&
-						iio_channel_is_output(ch)) {
-					iio_channel_enable(ch);
-					nb_active_channels++;
-				}
+		for (j = optind + 1; j < (unsigned int) argc; j++) {
+			ret = iio_device_enable_channel(dev, argw[j], true);
+			if (ret < 0) {
+				char buf[256];
+				iio_strerror(-(int) ret, buf, sizeof(buf));
+				fprintf(stderr, "Bad channel name \"%s\" : %s\n", argw[j], buf);
+				iio_context_destroy(ctx);
+				return EXIT_FAILURE;
 			}
+			nb_active_channels++;
 		}
 	}
 

--- a/tests/iio_writedev.c
+++ b/tests/iio_writedev.c
@@ -276,8 +276,8 @@ int main(int argc, char **argv)
 	}
 	free(opts);
 
-	if (argc < optind || argc > optind + 2) {
-		fprintf(stderr, "Incorrect number of arguments.\n\n");
+	if (argc < optind) {
+		fprintf(stderr, "Too few arguments.\n\n");
 		usage(MY_NAME, options, options_descriptions);
 		return EXIT_FAILURE;
 	}


### PR DESCRIPTION
Two small commits:

1. Fix a bug that Paul found that I introduced. in iio_read|write_dev - which was an oversight in a previous commit. allow multiple channels to be added on the command line.
2. In the past, you could put gibberish channel names, and read|write_dev would accept them (ignoring them). This sometimes lead to typos causing issues with "wrong" or "incorrect" data. Fix this by checking for a match, and errorring if there is something provided that doesn't match.
    
Signed-off-by: Robin Getz <robin.getz@analog.com>
