### PR TITLE
iiod: iiod-serial: Fix memory leak

### DIFF
--- a/iiod/serial.c
+++ b/iiod/serial.c
@@ -262,6 +262,8 @@ int start_serial_daemon(struct iio_context *ctx, const char *uart_params,
 	if (err)
 		goto err_close_fd;
 
+	free(dev);
+
 	return 0;
 
 err_close_fd:

--- a/iiod/serial.c
+++ b/iiod/serial.c
@@ -258,7 +258,11 @@ int start_serial_daemon(struct iio_context *ctx, const char *uart_params,
 	IIO_DEBUG("Serving over UART on %s at %u bps, %u bits\n",
 		  dev, uart_bps, uart_bits);
 
-	return thread_pool_add_thread(pool, serial_main, pdata, "iiod_serial_thd");
+	err = thread_pool_add_thread(pool, serial_main, pdata, "iiod_serial_thd");
+	if (err)
+		goto err_close_fd;
+
+	return 0;
 
 err_close_fd:
 	close(fd);


### PR DESCRIPTION
In the function start_serial_daemon, the "dev" variable was never freed
if the thread couldn't be created.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>