### PR TITLE
Update attribute read/write functions

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -350,7 +350,7 @@ const char * iio_channel_find_attr(const struct iio_channel *chn,
 	return NULL;
 }
 
-ssize_t iio_channel_attr_read(const struct iio_channel *chn,
+ssize_t iio_channel_attr_read_raw(const struct iio_channel *chn,
 		const char *attr, char *dst, size_t len)
 {
 	if (!attr)
@@ -376,8 +376,8 @@ ssize_t iio_channel_attr_write_raw(const struct iio_channel *chn,
 		return -ENOSYS;
 }
 
-ssize_t iio_channel_attr_write(const struct iio_channel *chn,
-		const char *attr, const char *src)
+ssize_t iio_channel_attr_write_string(const struct iio_channel *chn,
+				      const char *attr, const char *src)
 {
 	return iio_channel_attr_write_raw(chn, attr, src, strlen(src) + 1);
 }
@@ -651,7 +651,9 @@ int iio_channel_attr_read_longlong(const struct iio_channel *chn,
 {
 	char *end, buf[1024];
 	long long value;
-	ssize_t ret = iio_channel_attr_read(chn, attr, buf, sizeof(buf));
+	ssize_t ret;
+
+	ret = iio_channel_attr_read_raw(chn, attr, buf, sizeof(buf));
 	if (ret < 0)
 		return (int) ret;
 
@@ -679,7 +681,9 @@ int iio_channel_attr_read_double(const struct iio_channel *chn,
 		const char *attr, double *val)
 {
 	char buf[1024];
-	ssize_t ret = iio_channel_attr_read(chn, attr, buf, sizeof(buf));
+	ssize_t ret;
+
+	ret = iio_channel_attr_read_raw(chn, attr, buf, sizeof(buf));
 	if (ret < 0)
 		return (int) ret;
 	else
@@ -692,7 +696,7 @@ int iio_channel_attr_write_longlong(const struct iio_channel *chn,
 	int ret;
 	char buf[1024];
 	iio_snprintf(buf, sizeof(buf), "%lld", val);
-	ret = (int) iio_channel_attr_write(chn, attr, buf);
+	ret = (int) iio_channel_attr_write_string(chn, attr, buf);
 	return ret < 0 ? ret : 0;
 }
 
@@ -704,7 +708,7 @@ int iio_channel_attr_write_double(const struct iio_channel *chn,
 
 	ret = write_double(buf, sizeof(buf), val);
 	if (!ret)
-		ret = (int) iio_channel_attr_write(chn, attr, buf);
+		ret = (int) iio_channel_attr_write_string(chn, attr, buf);
 	return ret < 0 ? ret : 0;
 }
 

--- a/device.c
+++ b/device.c
@@ -312,7 +312,7 @@ ssize_t iio_device_attr_read_raw(const struct iio_device *dev,
 		return -EINVAL;
 
 	if (dev->ctx->ops->read_device_attr)
-		return dev->ctx->ops->read_device_attr(dev,
+		return dev->ctx->ops->read_device_attr(dev, 0,
 				attr, dst, len, IIO_ATTR_TYPE_DEVICE);
 	else
 		return -ENOSYS;
@@ -325,7 +325,7 @@ ssize_t iio_device_attr_write_raw(const struct iio_device *dev,
 		return -EINVAL;
 
 	if (dev->ctx->ops->write_device_attr)
-		return dev->ctx->ops->write_device_attr(dev,
+		return dev->ctx->ops->write_device_attr(dev, 0,
 				attr, src, len, IIO_ATTR_TYPE_DEVICE);
 	else
 		return -ENOSYS;
@@ -344,7 +344,7 @@ ssize_t iio_device_buffer_attr_read_raw(const struct iio_device *dev,
 		return -EINVAL;
 
 	if (dev->ctx->ops->read_device_attr)
-		return dev->ctx->ops->read_device_attr(dev,
+		return dev->ctx->ops->read_device_attr(dev, 0,
 				attr, dst, len, IIO_ATTR_TYPE_BUFFER);
 	else
 		return -ENOSYS;
@@ -357,7 +357,7 @@ ssize_t iio_device_buffer_attr_write_raw(const struct iio_device *dev,
 		return -EINVAL;
 
 	if (dev->ctx->ops->write_device_attr)
-		return dev->ctx->ops->write_device_attr(dev,
+		return dev->ctx->ops->write_device_attr(dev, 0,
 				attr, src, len, IIO_ATTR_TYPE_BUFFER);
 	else
 		return -ENOSYS;
@@ -668,7 +668,7 @@ ssize_t iio_device_debug_attr_read_raw(const struct iio_device *dev,
 		return -EINVAL;
 
 	if (dev->ctx->ops->read_device_attr)
-		return dev->ctx->ops->read_device_attr(dev,
+		return dev->ctx->ops->read_device_attr(dev, 0,
 				attr, dst, len, IIO_ATTR_TYPE_DEBUG);
 	else
 		return -ENOSYS;
@@ -681,7 +681,7 @@ ssize_t iio_device_debug_attr_write_raw(const struct iio_device *dev,
 		return -EINVAL;
 
 	if (dev->ctx->ops->write_device_attr)
-		return dev->ctx->ops->write_device_attr(dev,
+		return dev->ctx->ops->write_device_attr(dev, 0,
 				attr, src, len, IIO_ATTR_TYPE_DEBUG);
 	else
 		return -ENOSYS;

--- a/device.c
+++ b/device.c
@@ -338,35 +338,39 @@ ssize_t iio_device_attr_write_string(const struct iio_device *dev,
 }
 
 ssize_t iio_device_buffer_attr_read_raw(const struct iio_device *dev,
-		const char *attr, char *dst, size_t len)
+					unsigned int buf_id, const char *attr,
+					char *dst, size_t len)
 {
 	if (!attr)
 		return -EINVAL;
 
 	if (dev->ctx->ops->read_device_attr)
-		return dev->ctx->ops->read_device_attr(dev, 0,
+		return dev->ctx->ops->read_device_attr(dev, buf_id,
 				attr, dst, len, IIO_ATTR_TYPE_BUFFER);
 	else
 		return -ENOSYS;
 }
 
 ssize_t iio_device_buffer_attr_write_raw(const struct iio_device *dev,
-		const char *attr, const void *src, size_t len)
+					 unsigned int buf_id, const char *attr,
+					 const void *src, size_t len)
 {
 	if (!attr)
 		return -EINVAL;
 
 	if (dev->ctx->ops->write_device_attr)
-		return dev->ctx->ops->write_device_attr(dev, 0,
+		return dev->ctx->ops->write_device_attr(dev, buf_id,
 				attr, src, len, IIO_ATTR_TYPE_BUFFER);
 	else
 		return -ENOSYS;
 }
 
 ssize_t iio_device_buffer_attr_write_string(const struct iio_device *dev,
+					    unsigned int buf_id,
 					    const char *attr, const char *src)
 {
-	return iio_device_buffer_attr_write_raw(dev, attr, src, strlen(src) + 1);
+	return iio_device_buffer_attr_write_raw(dev, buf_id, attr, src,
+						strlen(src) + 1);
 }
 
 void iio_device_set_data(struct iio_device *dev, void *data)
@@ -579,13 +583,15 @@ int iio_device_attr_write_bool(const struct iio_device *dev,
 }
 
 int iio_device_buffer_attr_read_longlong(const struct iio_device *dev,
-		const char *attr, long long *val)
+					 unsigned int buf_id,
+					 const char *attr, long long *val)
 {
 	char *end, buf[1024];
 	long long value;
 	ssize_t ret;
 
-	ret = iio_device_buffer_attr_read_raw(dev, attr, buf, sizeof(buf));
+	ret = iio_device_buffer_attr_read_raw(dev, buf_id, attr,
+					      buf, sizeof(buf));
 	if (ret < 0)
 		return (int) ret;
 
@@ -598,12 +604,13 @@ int iio_device_buffer_attr_read_longlong(const struct iio_device *dev,
 }
 
 int iio_device_buffer_attr_read_bool(const struct iio_device *dev,
-		const char *attr, bool *val)
+				     unsigned int buf_id,
+				     const char *attr, bool *val)
 {
 	long long value;
 	int ret;
 
-	ret = iio_device_buffer_attr_read_longlong(dev, attr, &value);
+	ret = iio_device_buffer_attr_read_longlong(dev, buf_id, attr, &value);
 	if (ret < 0)
 		return ret;
 
@@ -612,12 +619,14 @@ int iio_device_buffer_attr_read_bool(const struct iio_device *dev,
 }
 
 int iio_device_buffer_attr_read_double(const struct iio_device *dev,
-		const char *attr, double *val)
+				       unsigned int buf_id,
+				       const char *attr, double *val)
 {
 	char buf[1024];
 	ssize_t ret;
 
-	ret = iio_device_buffer_attr_read_raw(dev, attr, buf, sizeof(buf));
+	ret = iio_device_buffer_attr_read_raw(dev, buf_id, attr,
+					      buf, sizeof(buf));
 	if (ret < 0)
 		return (int) ret;
 	else
@@ -625,38 +634,40 @@ int iio_device_buffer_attr_read_double(const struct iio_device *dev,
 }
 
 int iio_device_buffer_attr_write_longlong(const struct iio_device *dev,
-		const char *attr, long long val)
+					  unsigned int buf_id,
+					  const char *attr, long long val)
 {
 	ssize_t ret;
 	char buf[1024];
 
 	iio_snprintf(buf, sizeof(buf), "%lld", val);
-	ret = iio_device_buffer_attr_write_string(dev, attr, buf);
+	ret = iio_device_buffer_attr_write_string(dev, buf_id, attr, buf);
 
 	return (int) (ret < 0 ? ret : 0);
 }
 
 int iio_device_buffer_attr_write_double(const struct iio_device *dev,
-		const char *attr, double val)
+					unsigned int buf_id,
+					const char *attr, double val)
 {
 	ssize_t ret;
 	char buf[1024];
 
 	ret = (ssize_t) write_double(buf, sizeof(buf), val);
 	if (!ret)
-		ret = iio_device_buffer_attr_write_string(dev, attr, buf);
+		ret = iio_device_buffer_attr_write_string(dev, buf_id,
+							  attr, buf);
 	return (int) (ret < 0 ? ret : 0);
 }
 
 int iio_device_buffer_attr_write_bool(const struct iio_device *dev,
-		const char *attr, bool val)
+				      unsigned int buf_id,
+				      const char *attr, bool val)
 {
 	ssize_t ret;
+	const char *value = val ? "1" : "0";
 
-	if (val)
-		ret = iio_device_buffer_attr_write_string(dev, attr, "1");
-	else
-		ret = iio_device_buffer_attr_write_string(dev, attr, "0");
+	ret = iio_device_buffer_attr_write_string(dev, buf_id, attr, value);
 
 	return (int) (ret < 0 ? ret : 0);
 }

--- a/device.c
+++ b/device.c
@@ -305,7 +305,7 @@ ssize_t iio_device_write_raw(const struct iio_device *dev,
 		return -ENOSYS;
 }
 
-ssize_t iio_device_attr_read(const struct iio_device *dev,
+ssize_t iio_device_attr_read_raw(const struct iio_device *dev,
 		const char *attr, char *dst, size_t len)
 {
 	if (!attr)
@@ -331,13 +331,13 @@ ssize_t iio_device_attr_write_raw(const struct iio_device *dev,
 		return -ENOSYS;
 }
 
-ssize_t iio_device_attr_write(const struct iio_device *dev,
-		const char *attr, const char *src)
+ssize_t iio_device_attr_write_string(const struct iio_device *dev,
+				     const char *attr, const char *src)
 {
 	return iio_device_attr_write_raw(dev, attr, src, strlen(src) + 1);
 }
 
-ssize_t iio_device_buffer_attr_read(const struct iio_device *dev,
+ssize_t iio_device_buffer_attr_read_raw(const struct iio_device *dev,
 		const char *attr, char *dst, size_t len)
 {
 	if (!attr)
@@ -363,8 +363,8 @@ ssize_t iio_device_buffer_attr_write_raw(const struct iio_device *dev,
 		return -ENOSYS;
 }
 
-ssize_t iio_device_buffer_attr_write(const struct iio_device *dev,
-		const char *attr, const char *src)
+ssize_t iio_device_buffer_attr_write_string(const struct iio_device *dev,
+					    const char *attr, const char *src)
 {
 	return iio_device_buffer_attr_write_raw(dev, attr, src, strlen(src) + 1);
 }
@@ -500,7 +500,9 @@ int iio_device_attr_read_longlong(const struct iio_device *dev,
 {
 	char *end, buf[1024];
 	long long value;
-	ssize_t ret = iio_device_attr_read(dev, attr, buf, sizeof(buf));
+	ssize_t ret;
+
+	ret = iio_device_attr_read_raw(dev, attr, buf, sizeof(buf));
 	if (ret < 0)
 		return (int) ret;
 
@@ -516,7 +518,9 @@ int iio_device_attr_read_bool(const struct iio_device *dev,
 		const char *attr, bool *val)
 {
 	long long value;
-	int ret = iio_device_attr_read_longlong(dev, attr, &value);
+	int ret;
+
+	ret = iio_device_attr_read_longlong(dev, attr, &value);
 	if (ret < 0)
 		return ret;
 
@@ -528,7 +532,9 @@ int iio_device_attr_read_double(const struct iio_device *dev,
 		const char *attr, double *val)
 {
 	char buf[1024];
-	ssize_t ret = iio_device_attr_read(dev, attr, buf, sizeof(buf));
+	ssize_t ret;
+
+	ret = iio_device_attr_read_raw(dev, attr, buf, sizeof(buf));
 	if (ret < 0)
 		return (int) ret;
 	else
@@ -542,7 +548,7 @@ int iio_device_attr_write_longlong(const struct iio_device *dev,
 	char buf[1024];
 
 	iio_snprintf(buf, sizeof(buf), "%lld", val);
-	ret = iio_device_attr_write(dev, attr, buf);
+	ret = iio_device_attr_write_string(dev, attr, buf);
 
 	return (int) (ret < 0 ? ret : 0);
 }
@@ -555,7 +561,7 @@ int iio_device_attr_write_double(const struct iio_device *dev,
 
 	ret = (ssize_t) write_double(buf, sizeof(buf), val);
 	if (!ret)
-		ret = iio_device_attr_write(dev, attr, buf);
+		ret = iio_device_attr_write_string(dev, attr, buf);
 	return (int) (ret < 0 ? ret : 0);
 }
 
@@ -565,9 +571,9 @@ int iio_device_attr_write_bool(const struct iio_device *dev,
 	ssize_t ret;
 
 	if (val)
-		ret = iio_device_attr_write(dev, attr, "1");
+		ret = iio_device_attr_write_string(dev, attr, "1");
 	else
-		ret = iio_device_attr_write(dev, attr, "0");
+		ret = iio_device_attr_write_string(dev, attr, "0");
 
 	return (int) (ret < 0 ? ret : 0);
 }
@@ -577,7 +583,9 @@ int iio_device_buffer_attr_read_longlong(const struct iio_device *dev,
 {
 	char *end, buf[1024];
 	long long value;
-	ssize_t ret = iio_device_buffer_attr_read(dev, attr, buf, sizeof(buf));
+	ssize_t ret;
+
+	ret = iio_device_buffer_attr_read_raw(dev, attr, buf, sizeof(buf));
 	if (ret < 0)
 		return (int) ret;
 
@@ -593,7 +601,9 @@ int iio_device_buffer_attr_read_bool(const struct iio_device *dev,
 		const char *attr, bool *val)
 {
 	long long value;
-	int ret = iio_device_buffer_attr_read_longlong(dev, attr, &value);
+	int ret;
+
+	ret = iio_device_buffer_attr_read_longlong(dev, attr, &value);
 	if (ret < 0)
 		return ret;
 
@@ -605,7 +615,9 @@ int iio_device_buffer_attr_read_double(const struct iio_device *dev,
 		const char *attr, double *val)
 {
 	char buf[1024];
-	ssize_t ret = iio_device_buffer_attr_read(dev, attr, buf, sizeof(buf));
+	ssize_t ret;
+
+	ret = iio_device_buffer_attr_read_raw(dev, attr, buf, sizeof(buf));
 	if (ret < 0)
 		return (int) ret;
 	else
@@ -619,7 +631,7 @@ int iio_device_buffer_attr_write_longlong(const struct iio_device *dev,
 	char buf[1024];
 
 	iio_snprintf(buf, sizeof(buf), "%lld", val);
-	ret = iio_device_buffer_attr_write(dev, attr, buf);
+	ret = iio_device_buffer_attr_write_string(dev, attr, buf);
 
 	return (int) (ret < 0 ? ret : 0);
 }
@@ -632,7 +644,7 @@ int iio_device_buffer_attr_write_double(const struct iio_device *dev,
 
 	ret = (ssize_t) write_double(buf, sizeof(buf), val);
 	if (!ret)
-		ret = iio_device_buffer_attr_write(dev, attr, buf);
+		ret = iio_device_buffer_attr_write_string(dev, attr, buf);
 	return (int) (ret < 0 ? ret : 0);
 }
 
@@ -642,14 +654,14 @@ int iio_device_buffer_attr_write_bool(const struct iio_device *dev,
 	ssize_t ret;
 
 	if (val)
-		ret = iio_device_buffer_attr_write(dev, attr, "1");
+		ret = iio_device_buffer_attr_write_string(dev, attr, "1");
 	else
-		ret = iio_device_buffer_attr_write(dev, attr, "0");
+		ret = iio_device_buffer_attr_write_string(dev, attr, "0");
 
 	return (int) (ret < 0 ? ret : 0);
 }
 
-ssize_t iio_device_debug_attr_read(const struct iio_device *dev,
+ssize_t iio_device_debug_attr_read_raw(const struct iio_device *dev,
 		const char *attr, char *dst, size_t len)
 {
 	if (!attr)
@@ -675,7 +687,7 @@ ssize_t iio_device_debug_attr_write_raw(const struct iio_device *dev,
 		return -ENOSYS;
 }
 
-ssize_t iio_device_debug_attr_write(const struct iio_device *dev,
+ssize_t iio_device_debug_attr_write_string(const struct iio_device *dev,
 		const char *attr, const char *src)
 {
 	return iio_device_debug_attr_write_raw(dev, attr, src, strlen(src) + 1);
@@ -697,7 +709,7 @@ int iio_device_debug_attr_read_longlong(const struct iio_device *dev,
 {
 	char *end, buf[1024];
 	long long value;
-	ssize_t ret = iio_device_debug_attr_read(dev, attr, buf, sizeof(buf));
+	ssize_t ret = iio_device_debug_attr_read_raw(dev, attr, buf, sizeof(buf));
 	if (ret < 0)
 		return (int) ret;
 
@@ -725,7 +737,7 @@ int iio_device_debug_attr_read_double(const struct iio_device *dev,
 		const char *attr, double *val)
 {
 	char buf[1024];
-	ssize_t ret = iio_device_debug_attr_read(dev, attr, buf, sizeof(buf));
+	ssize_t ret = iio_device_debug_attr_read_raw(dev, attr, buf, sizeof(buf));
 	if (ret < 0)
 		return (int) ret;
 	else
@@ -739,7 +751,7 @@ int iio_device_debug_attr_write_longlong(const struct iio_device *dev,
 	char buf[1024];
 
 	iio_snprintf(buf, sizeof(buf), "%lld", val);
-	ret = iio_device_debug_attr_write(dev, attr, buf);
+	ret = iio_device_debug_attr_write_string(dev, attr, buf);
 
 	return (int) (ret < 0 ? ret : 0);
 }
@@ -752,7 +764,7 @@ int iio_device_debug_attr_write_double(const struct iio_device *dev,
 
 	ret = (ssize_t) write_double(buf, sizeof(buf), val);
 	if (!ret)
-		ret = iio_device_debug_attr_write(dev, attr, buf);
+		ret = iio_device_debug_attr_write_string(dev, attr, buf);
 	return (int) (ret < 0 ? ret : 0);
 }
 
@@ -816,7 +828,7 @@ int iio_device_reg_write(struct iio_device *dev,
 
 	iio_snprintf(buf, sizeof(buf), "0x%" PRIx32 " 0x%" PRIx32,
 			address, value);
-	ret = iio_device_debug_attr_write(dev, "direct_reg_access", buf);
+	ret = iio_device_debug_attr_write_string(dev, "direct_reg_access", buf);
 
 	return (int) (ret < 0 ? ret : 0);
 }

--- a/examples/ad9361-iiostream.c
+++ b/examples/ad9361-iiostream.c
@@ -100,7 +100,7 @@ static void wr_ch_lli(struct iio_channel *chn, const char* what, long long val)
 /* write attribute: string */
 static void wr_ch_str(struct iio_channel *chn, const char* what, const char* str)
 {
-	errchk(iio_channel_attr_write(chn, what, str), what);
+	errchk(iio_channel_attr_write_string(chn, what, str), what);
 }
 
 /* helper function generating channel names */

--- a/examples/iio-monitor.c
+++ b/examples/iio-monitor.c
@@ -91,7 +91,7 @@ static double get_channel_value(struct iio_channel *chn)
 	setlocale(LC_NUMERIC, "C");
 
 	if (channel_has_attr(chn, "input")) {
-		ret = iio_channel_attr_read(chn, "input", buf, sizeof(buf));
+		ret = iio_channel_attr_read_raw(chn, "input", buf, sizeof(buf));
 		if (ret < 0) {
 			err_str(ret);
 			val = 0;
@@ -104,7 +104,7 @@ static double get_channel_value(struct iio_channel *chn)
 			}
 		}
 	} else {
-		ret = iio_channel_attr_read(chn, "raw", buf, sizeof(buf));
+		ret = iio_channel_attr_read_raw(chn, "raw", buf, sizeof(buf));
 		if (ret < 0) {
 			err_str(ret);
 			val = 0;
@@ -117,7 +117,7 @@ static double get_channel_value(struct iio_channel *chn)
 			}
 		}
 		if (channel_has_attr(chn, "offset")) {
-			ret = iio_channel_attr_read(chn, "offset", buf, sizeof(buf));
+			ret = iio_channel_attr_read_raw(chn, "offset", buf, sizeof(buf));
 			if (ret < 0)
 				err_str(ret);
 			else {
@@ -129,7 +129,7 @@ static double get_channel_value(struct iio_channel *chn)
 		}
 
 		if (channel_has_attr(chn, "scale")) {
-			ret = iio_channel_attr_read(chn, "scale", buf, sizeof(buf));
+			ret = iio_channel_attr_read_raw(chn, "scale", buf, sizeof(buf));
 			if (ret < 0)
 				err_str(ret);
 			else {

--- a/iio-backend.h
+++ b/iio-backend.h
@@ -86,10 +86,12 @@ struct iio_backend_ops {
 			struct iio_channels_mask *mask);
 
 	ssize_t (*read_device_attr)(const struct iio_device *dev,
-			const char *attr, char *dst, size_t len, enum iio_attr_type);
+				    unsigned int buf_id, const char *attr,
+				    char *dst, size_t len, enum iio_attr_type);
 	ssize_t (*write_device_attr)(const struct iio_device *dev,
-			const char *attr, const char *src,
-			size_t len, enum iio_attr_type);
+				     unsigned int buf_id, const char *attr,
+				     const char *src, size_t len,
+				     enum iio_attr_type);
 	ssize_t (*read_channel_attr)(const struct iio_channel *chn,
 			const char *attr, char *dst, size_t len);
 	ssize_t (*write_channel_attr)(const struct iio_channel *chn,

--- a/iio.h
+++ b/iio.h
@@ -750,22 +750,6 @@ __api __check_ret ssize_t iio_device_attr_read(const struct iio_device *dev,
 		const char *attr, char *dst, size_t len);
 
 
-/** @brief Read the content of all device-specific attributes
- * @param dev A pointer to an iio_device structure
- * @param cb A pointer to a callback function
- * @param data A pointer that will be passed to the callback function
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned
- *
- * <b>NOTE:</b> This function is especially useful when used with the network
- * backend, as all the device-specific attributes are read in one single
- * command. */
-__api __check_ret int iio_device_attr_read_all(struct iio_device *dev,
-		int (*cb)(struct iio_device *dev, const char *attr,
-			const char *value, size_t len, void *d),
-		void *data);
-
-
 /** @brief Read the content of the given device-specific attribute
  * @param dev A pointer to an iio_device structure
  * @param attr A NULL-terminated string corresponding to the name of the
@@ -1669,21 +1653,6 @@ __api __check_ret ssize_t iio_device_debug_attr_write(const struct iio_device *d
  * @return On error, a negative errno code is returned */
 __api __check_ret ssize_t iio_device_debug_attr_write_raw(const struct iio_device *dev,
 		const char *attr, const void *src, size_t len);
-
-
-/** @brief Set the values of all debug attributes
- * @param dev A pointer to an iio_device structure
- * @param cb A pointer to a callback function
- * @param data A pointer that will be passed to the callback function
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned
- *
- * <b>NOTE:</b> This function is especially useful when used with the network
- * backend, as all the debug attributes are written in one single command. */
-__api __check_ret int iio_device_debug_attr_write_all(struct iio_device *dev,
-		ssize_t (*cb)(struct iio_device *dev,
-			const char *attr, void *buf, size_t len, void *d),
-		void *data);
 
 
 /** @brief Read the content of the given debug attribute

--- a/iio.h
+++ b/iio.h
@@ -746,8 +746,9 @@ __api __check_ret __pure const char * iio_device_find_buffer_attr(
  * @param len The available length of the memory area, in bytes
  * @return On success, the number of bytes written to the buffer
  * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t iio_device_attr_read(const struct iio_device *dev,
-		const char *attr, char *dst, size_t len);
+__api __check_ret ssize_t
+iio_device_attr_read_raw(const struct iio_device *dev,
+			 const char *attr, char *dst, size_t len);
 
 
 /** @brief Read the content of the given device-specific attribute
@@ -790,8 +791,9 @@ __api __check_ret int iio_device_attr_read_double(const struct iio_device *dev,
  * @param src A NULL-terminated string to set the attribute to
  * @return On success, the number of bytes written
  * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t iio_device_attr_write(const struct iio_device *dev,
-		const char *attr, const char *src);
+__api __check_ret ssize_t
+iio_device_attr_write_string(const struct iio_device *dev,
+			      const char *attr, const char *src);
 
 
 /** @brief Set the value of the given device-specific attribute
@@ -847,8 +849,9 @@ __api __check_ret int iio_device_attr_write_double(const struct iio_device *dev,
  * @param len The available length of the memory area, in bytes
  * @return On success, the number of bytes written to the buffer
  * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t iio_device_buffer_attr_read(const struct iio_device *dev,
-		const char *attr, char *dst, size_t len);
+__api __check_ret ssize_t
+iio_device_buffer_attr_read_raw(const struct iio_device *dev,
+				const char *attr, char *dst, size_t len);
 
 /** @brief Read the content of the given buffer-specific attribute
  * @param dev A pointer to an iio_device structure
@@ -890,8 +893,9 @@ __api __check_ret int iio_device_buffer_attr_read_double(const struct iio_device
  * @param src A NULL-terminated string to set the attribute to
  * @return On success, the number of bytes written
  * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t iio_device_buffer_attr_write(const struct iio_device *dev,
-		const char *attr, const char *src);
+__api __check_ret ssize_t
+iio_device_buffer_attr_write_string(const struct iio_device *dev,
+				     const char *attr, const char *src);
 
 
 /** @brief Set the value of the given buffer-specific attribute
@@ -1082,8 +1086,9 @@ __api __check_ret __pure const char * iio_channel_attr_get_filename(
  * @param len The available length of the memory area, in bytes
  * @return On success, the number of bytes written to the buffer
  * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t iio_channel_attr_read(const struct iio_channel *chn,
-		const char *attr, char *dst, size_t len);
+__api __check_ret ssize_t
+iio_channel_attr_read_raw(const struct iio_channel *chn,
+			  const char *attr, char *dst, size_t len);
 
 
 /** @brief Read the content of the given channel-specific attribute
@@ -1126,8 +1131,9 @@ __api __check_ret int iio_channel_attr_read_double(const struct iio_channel *chn
  * @param src A NULL-terminated string to set the attribute to
  * @return On success, the number of bytes written
  * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t iio_channel_attr_write(const struct iio_channel *chn,
-		const char *attr, const char *src);
+__api __check_ret ssize_t
+iio_channel_attr_write_string(const struct iio_channel *chn,
+			       const char *attr, const char *src);
 
 
 /** @brief Set the value of the given channel-specific attribute
@@ -1628,8 +1634,9 @@ __api __check_ret __pure const char * iio_device_find_debug_attr(
  * @param len The available length of the memory area, in bytes
  * @return On success, the number of bytes written to the buffer
  * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t iio_device_debug_attr_read(const struct iio_device *dev,
-		const char *attr, char *dst, size_t len);
+__api __check_ret ssize_t
+iio_device_debug_attr_read_raw(const struct iio_device *dev,
+			       const char *attr, char *dst, size_t len);
 
 
 /** @brief Set the value of the given debug attribute
@@ -1639,8 +1646,9 @@ __api __check_ret ssize_t iio_device_debug_attr_read(const struct iio_device *de
  * @param src A NULL-terminated string to set the debug attribute to
  * @return On success, the number of bytes written
  * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t iio_device_debug_attr_write(const struct iio_device *dev,
-		const char *attr, const char *src);
+__api __check_ret ssize_t
+iio_device_debug_attr_write_string(const struct iio_device *dev,
+				   const char *attr, const char *src);
 
 
 /** @brief Set the value of the given debug attribute

--- a/iio.h
+++ b/iio.h
@@ -796,6 +796,7 @@ iio_device_attr_write_raw(const struct iio_device *dev,
 
 /** @brief Read the content of the given buffer-specific attribute
  * @param dev A pointer to an iio_device structure
+ * @param buf_id The index of the hardware buffer (generally 0)
  * @param attr A NULL-terminated string corresponding to the name of the
  * attribute
  * @param dst A pointer to the memory area where the NULL-terminated string
@@ -805,25 +806,28 @@ iio_device_attr_write_raw(const struct iio_device *dev,
  * @return On error, a negative errno code is returned */
 __api __check_ret ssize_t
 iio_device_buffer_attr_read_raw(const struct iio_device *dev,
+				unsigned int buf_id,
 				const char *attr, char *dst, size_t len);
 
 
 /** @brief Read the content of the given buffer-specific attribute
  * @param dev A pointer to an iio_device structure
+ * @param buf_id The index of the hardware buffer (generally 0)
  * @param attr A NULL-terminated string corresponding to the name of the
  * attribute
  * @param ptr A pointer to the variable where the value should be stored
  * @return On success, 0 is returned
  * @return On error, a negative errno code is returned */
-#define iio_device_buffer_attr_read(buf, attr, ptr)			\
+#define iio_device_buffer_attr_read(dev, buf_id, attr, ptr)		\
 	_Generic((ptr),							\
 		 bool *: iio_device_buffer_attr_read_bool,		\
 		 long long *: iio_device_buffer_attr_read_longlong,	\
-		 double *: iio_device_buffer_attr_read_double)(buf, attr, ptr)
+		 double *: iio_device_buffer_attr_read_double)(dev, buf_id, attr, ptr)
 
 
 /** @brief Set the value of the given buffer-specific attribute
  * @param dev A pointer to an iio_device structure
+ * @param buf_id The index of the hardware buffer (generally 0)
  * @param attr A NULL-terminated string corresponding to the name of the
  * attribute
  * @param src A pointer to the data to be written
@@ -832,23 +836,25 @@ iio_device_buffer_attr_read_raw(const struct iio_device *dev,
  * @return On error, a negative errno code is returned */
 __api __check_ret ssize_t
 iio_device_buffer_attr_write_raw(const struct iio_device *dev,
-				 const char *attr, const void *src, size_t len);
+				 unsigned int buf_id, const char *attr,
+				 const void *src, size_t len);
 
 
 /** @brief Set the value of the given buffer-specific attribute
  * @param dev A pointer to an iio_device structure
+ * @param buf_id The index of the hardware buffer (generally 0)
  * @param attr A NULL-terminated string corresponding to the name of the
  * attribute
  * @param val A long long value to set the attribute to
  * @return On success, 0 is returned
  * @return On error, a negative errno code is returned */
-#define iio_device_buffer_attr_write(buf, attr, val)			\
+#define iio_device_buffer_attr_write(dev, buf_id, attr, val)		\
 	_Generic((val),							\
 		 const char *: iio_device_buffer_attr_write_string,	\
 		 char *: iio_device_buffer_attr_write_string,		\
 		 bool: iio_device_buffer_attr_write_bool,		\
 		 long long: iio_device_buffer_attr_write_longlong,	\
-		 double: iio_device_buffer_attr_write_double)(buf, attr, val)
+		 double: iio_device_buffer_attr_write_double)(dev, buf_id, attr, val)
 
 
 /** @brief Associate a pointer to an iio_device structure
@@ -1608,24 +1614,31 @@ iio_device_attr_write_double(const struct iio_device *dev,
 			     const char *attr, double val);
 __api __check_ret int
 iio_device_buffer_attr_read_bool(const struct iio_device *dev,
+				 unsigned int buf_id,
 				 const char *attr, bool *val);
 __api __check_ret int
 iio_device_buffer_attr_read_longlong(const struct iio_device *dev,
+				     unsigned int buf_id,
 				     const char *attr, long long *val);
 __api __check_ret int
 iio_device_buffer_attr_read_double(const struct iio_device *dev,
+				   unsigned int buf_id,
 				   const char *attr, double *val);
 __api __check_ret ssize_t
 iio_device_buffer_attr_write_string(const struct iio_device *dev,
+				    unsigned int buf_id,
 				    const char *attr, const char *src);
 __api __check_ret int
 iio_device_buffer_attr_write_bool(const struct iio_device *dev,
+				  unsigned int buf_id,
 				  const char *attr, bool val);
 __api __check_ret int
 iio_device_buffer_attr_write_longlong(const struct iio_device *dev,
+				      unsigned int buf_id,
 				      const char *attr, long long val);
 __api __check_ret int
 iio_device_buffer_attr_write_double(const struct iio_device *dev,
+				    unsigned int buf_id,
 				    const char *attr, double val);
 __api __check_ret int
 iio_channel_attr_read_bool(const struct iio_channel *chn,

--- a/iio.h
+++ b/iio.h
@@ -755,45 +755,14 @@ iio_device_attr_read_raw(const struct iio_device *dev,
  * @param dev A pointer to an iio_device structure
  * @param attr A NULL-terminated string corresponding to the name of the
  * attribute
- * @param val A pointer to a bool variable where the value should be stored
+ * @param ptr A pointer to a variable where the value should be stored
  * @return On success, 0 is returned
  * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_attr_read_bool(const struct iio_device *dev,
-		const char *attr, bool *val);
-
-
-/** @brief Read the content of the given device-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param val A pointer to a long long variable where the value should be stored
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_attr_read_longlong(const struct iio_device *dev,
-		const char *attr, long long *val);
-
-
-/** @brief Read the content of the given device-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param val A pointer to a double variable where the value should be stored
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_attr_read_double(const struct iio_device *dev,
-		const char *attr, double *val);
-
-
-/** @brief Set the value of the given device-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param src A NULL-terminated string to set the attribute to
- * @return On success, the number of bytes written
- * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t
-iio_device_attr_write_string(const struct iio_device *dev,
-			      const char *attr, const char *src);
+#define iio_device_attr_read(dev, attr, ptr)			\
+	_Generic((ptr),						\
+		 bool *: iio_device_attr_read_bool,		\
+		 long long *: iio_device_attr_read_longlong,	\
+		 double *: iio_device_attr_read_double)(dev, attr, ptr)
 
 
 /** @brief Set the value of the given device-specific attribute
@@ -804,41 +773,26 @@ iio_device_attr_write_string(const struct iio_device *dev,
  * @param len The number of bytes that should be written
  * @return On success, the number of bytes written
  * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t iio_device_attr_write_raw(const struct iio_device *dev,
-		const char *attr, const void *src, size_t len);
+__api __check_ret ssize_t
+iio_device_attr_write_raw(const struct iio_device *dev,
+			  const char *attr, const void *src, size_t len);
 
 
 /** @brief Set the value of the given device-specific attribute
  * @param dev A pointer to an iio_device structure
  * @param attr A NULL-terminated string corresponding to the name of the
  * attribute
- * @param val A bool value to set the attribute to
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_attr_write_bool(const struct iio_device *dev,
-		const char *attr, bool val);
+ * @param val The value to set the attribute to
+ * @return On success, the number of bytes written
+ * @return On error, a negative errno code is returned. */
+#define iio_device_attr_write(dev, attr, val)			\
+	_Generic((val),						\
+		 const char *: iio_device_attr_write_string,	\
+		 char *: iio_device_attr_write_string,		\
+		 bool: iio_device_attr_write_bool,		\
+		 long long: iio_device_attr_write_longlong,	\
+		 double: iio_device_attr_write_double)(dev, attr, val)
 
-
-/** @brief Set the value of the given device-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param val A long long value to set the attribute to
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_attr_write_longlong(const struct iio_device *dev,
-		const char *attr, long long val);
-
-
-/** @brief Set the value of the given device-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param val A double value to set the attribute to
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_attr_write_double(const struct iio_device *dev,
-		const char *attr, double val);
 
 /** @brief Read the content of the given buffer-specific attribute
  * @param dev A pointer to an iio_device structure
@@ -853,49 +807,19 @@ __api __check_ret ssize_t
 iio_device_buffer_attr_read_raw(const struct iio_device *dev,
 				const char *attr, char *dst, size_t len);
 
-/** @brief Read the content of the given buffer-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param val A pointer to a bool variable where the value should be stored
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_buffer_attr_read_bool(const struct iio_device *dev,
-		const char *attr, bool *val);
-
 
 /** @brief Read the content of the given buffer-specific attribute
  * @param dev A pointer to an iio_device structure
  * @param attr A NULL-terminated string corresponding to the name of the
  * attribute
- * @param val A pointer to a long long variable where the value should be stored
+ * @param ptr A pointer to the variable where the value should be stored
  * @return On success, 0 is returned
  * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_buffer_attr_read_longlong(const struct iio_device *dev,
-		const char *attr, long long *val);
-
-
-/** @brief Read the content of the given buffer-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param val A pointer to a double variable where the value should be stored
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_buffer_attr_read_double(const struct iio_device *dev,
-		const char *attr, double *val);
-
-
-/** @brief Set the value of the given buffer-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param src A NULL-terminated string to set the attribute to
- * @return On success, the number of bytes written
- * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t
-iio_device_buffer_attr_write_string(const struct iio_device *dev,
-				     const char *attr, const char *src);
+#define iio_device_buffer_attr_read(buf, attr, ptr)			\
+	_Generic((ptr),							\
+		 bool *: iio_device_buffer_attr_read_bool,		\
+		 long long *: iio_device_buffer_attr_read_longlong,	\
+		 double *: iio_device_buffer_attr_read_double)(buf, attr, ptr)
 
 
 /** @brief Set the value of the given buffer-specific attribute
@@ -906,19 +830,9 @@ iio_device_buffer_attr_write_string(const struct iio_device *dev,
  * @param len The number of bytes that should be written
  * @return On success, the number of bytes written
  * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t iio_device_buffer_attr_write_raw(const struct iio_device *dev,
-		const char *attr, const void *src, size_t len);
-
-
-/** @brief Set the value of the given buffer-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param val A bool value to set the attribute to
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_buffer_attr_write_bool(const struct iio_device *dev,
-		const char *attr, bool val);
+__api __check_ret ssize_t
+iio_device_buffer_attr_write_raw(const struct iio_device *dev,
+				 const char *attr, const void *src, size_t len);
 
 
 /** @brief Set the value of the given buffer-specific attribute
@@ -928,19 +842,13 @@ __api __check_ret int iio_device_buffer_attr_write_bool(const struct iio_device 
  * @param val A long long value to set the attribute to
  * @return On success, 0 is returned
  * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_buffer_attr_write_longlong(const struct iio_device *dev,
-		const char *attr, long long val);
-
-
-/** @brief Set the value of the given buffer-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param val A double value to set the attribute to
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_buffer_attr_write_double(const struct iio_device *dev,
-		const char *attr, double val);
+#define iio_device_buffer_attr_write(buf, attr, val)			\
+	_Generic((val),							\
+		 const char *: iio_device_buffer_attr_write_string,	\
+		 char *: iio_device_buffer_attr_write_string,		\
+		 bool: iio_device_buffer_attr_write_bool,		\
+		 long long: iio_device_buffer_attr_write_longlong,	\
+		 double: iio_device_buffer_attr_write_double)(buf, attr, val)
 
 
 /** @brief Associate a pointer to an iio_device structure
@@ -1095,45 +1003,14 @@ iio_channel_attr_read_raw(const struct iio_channel *chn,
  * @param chn A pointer to an iio_channel structure
  * @param attr A NULL-terminated string corresponding to the name of the
  * attribute
- * @param val A pointer to a bool variable where the value should be stored
+ * @param ptr A pointer to the variable where the value should be stored
  * @return On success, 0 is returned
  * @return On error, a negative errno code is returned */
-__api __check_ret int iio_channel_attr_read_bool(const struct iio_channel *chn,
-		const char *attr, bool *val);
-
-
-/** @brief Read the content of the given channel-specific attribute
- * @param chn A pointer to an iio_channel structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param val A pointer to a long long variable where the value should be stored
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_channel_attr_read_longlong(const struct iio_channel *chn,
-		const char *attr, long long *val);
-
-
-/** @brief Read the content of the given channel-specific attribute
- * @param chn A pointer to an iio_channel structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param val A pointer to a double variable where the value should be stored
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_channel_attr_read_double(const struct iio_channel *chn,
-		const char *attr, double *val);
-
-
-/** @brief Set the value of the given channel-specific attribute
- * @param chn A pointer to an iio_channel structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param src A NULL-terminated string to set the attribute to
- * @return On success, the number of bytes written
- * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t
-iio_channel_attr_write_string(const struct iio_channel *chn,
-			       const char *attr, const char *src);
+#define iio_channel_attr_read(dev, attr, ptr)			\
+	_Generic((ptr),						\
+		 bool *: iio_channel_attr_read_bool,		\
+		 long long *: iio_channel_attr_read_longlong,	\
+		 double *: iio_channel_attr_read_double)(dev, attr, ptr)
 
 
 /** @brief Set the value of the given channel-specific attribute
@@ -1144,41 +1021,25 @@ iio_channel_attr_write_string(const struct iio_channel *chn,
  * @param len The number of bytes that should be written
  * @return On success, the number of bytes written
  * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t iio_channel_attr_write_raw(const struct iio_channel *chn,
-		const char *attr, const void *src, size_t len);
+__api __check_ret ssize_t
+iio_channel_attr_write_raw(const struct iio_channel *chn,
+			   const char *attr, const void *src, size_t len);
 
 
 /** @brief Set the value of the given channel-specific attribute
  * @param chn A pointer to an iio_channel structure
  * @param attr A NULL-terminated string corresponding to the name of the
  * attribute
- * @param val A bool value to set the attribute to
+ * @param val The value to set the attribute to
  * @return On success, 0 is returned
  * @return On error, a negative errno code is returned */
-__api __check_ret int iio_channel_attr_write_bool(const struct iio_channel *chn,
-		const char *attr, bool val);
-
-
-/** @brief Set the value of the given channel-specific attribute
- * @param chn A pointer to an iio_channel structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param val A long long value to set the attribute to
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_channel_attr_write_longlong(const struct iio_channel *chn,
-		const char *attr, long long val);
-
-
-/** @brief Set the value of the given channel-specific attribute
- * @param chn A pointer to an iio_channel structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param val A double value to set the attribute to
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_channel_attr_write_double(const struct iio_channel *chn,
-		const char *attr, double val);
+#define iio_channel_attr_write(dev, attr, val)			\
+	_Generic((val),						\
+		 const char *: iio_channel_attr_write_string,	\
+		 char *: iio_channel_attr_write_string,		\
+		 bool: iio_channel_attr_write_bool,		\
+		 long long: iio_channel_attr_write_longlong,	\
+		 double: iio_channel_attr_write_double)(dev, attr, val)
 
 
 /** @brief Enable the given channel
@@ -1639,16 +1500,18 @@ iio_device_debug_attr_read_raw(const struct iio_device *dev,
 			       const char *attr, char *dst, size_t len);
 
 
-/** @brief Set the value of the given debug attribute
+/** @brief Read the content of the given debug attribute
  * @param dev A pointer to an iio_device structure
  * @param attr A NULL-terminated string corresponding to the name of the
  * debug attribute
- * @param src A NULL-terminated string to set the debug attribute to
- * @return On success, the number of bytes written
+ * @param ptr A pointer to a variable where the value should be stored
+ * @return On success, 0 is returned
  * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t
-iio_device_debug_attr_write_string(const struct iio_device *dev,
-				   const char *attr, const char *src);
+#define iio_device_debug_attr_read(dev, attr, ptr)			\
+	_Generic((ptr),							\
+		 bool *: iio_device_debug_attr_read_bool,		\
+		 long long *: iio_device_debug_attr_read_longlong,	\
+		 double *: iio_device_debug_attr_read_double)(dev, attr, ptr)
 
 
 /** @brief Set the value of the given debug attribute
@@ -1659,63 +1522,9 @@ iio_device_debug_attr_write_string(const struct iio_device *dev,
  * @param len The number of bytes that should be written
  * @return On success, the number of bytes written
  * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t iio_device_debug_attr_write_raw(const struct iio_device *dev,
-		const char *attr, const void *src, size_t len);
-
-
-/** @brief Read the content of the given debug attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * debug attribute
- * @param val A pointer to a bool variable where the value should be stored
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_debug_attr_read_bool(const struct iio_device *dev,
-		const char *attr, bool *val);
-
-
-/** @brief Read the content of the given debug attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * debug attribute
- * @param val A pointer to a long long variable where the value should be stored
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_debug_attr_read_longlong(const struct iio_device *dev,
-		const char *attr, long long *val);
-
-
-/** @brief Read the content of the given debug attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * debug attribute
- * @param val A pointer to a double variable where the value should be stored
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_debug_attr_read_double(const struct iio_device *dev,
-		const char *attr, double *val);
-
-
-/** @brief Set the value of the given debug attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * debug attribute
- * @param val A bool value to set the debug attribute to
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_debug_attr_write_bool(const struct iio_device *dev,
-		const char *attr, bool val);
-
-
-/** @brief Set the value of the given debug attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * debug attribute
- * @param val A long long value to set the debug attribute to
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_debug_attr_write_longlong(const struct iio_device *dev,
-		const char *attr, long long val);
+__api __check_ret ssize_t
+iio_device_debug_attr_write_raw(const struct iio_device *dev,
+				const char *attr, const void *src, size_t len);
 
 
 /** @brief Set the value of the given debug attribute
@@ -1725,8 +1534,13 @@ __api __check_ret int iio_device_debug_attr_write_longlong(const struct iio_devi
  * @param val A double value to set the debug attribute to
  * @return On success, 0 is returned
  * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_debug_attr_write_double(const struct iio_device *dev,
-		const char *attr, double val);
+#define iio_device_debug_attr_write(dev, attr, val)			\
+	_Generic((val),							\
+		 const char *: iio_device_debug_attr_write_string,	\
+		 char *: iio_device_debug_attr_write_string,		\
+		 bool: iio_device_debug_attr_write_bool,		\
+		 long long: iio_device_debug_attr_write_longlong,	\
+		 double: iio_device_debug_attr_write_double)(dev, attr, val)
 
 
 /** @brief Identify the channel or debug attribute corresponding to a filename
@@ -1767,6 +1581,95 @@ __api __check_ret int iio_device_reg_read(struct iio_device *dev,
 
 
 /** @} */
+
+#ifndef DOXYGEN
+/* These functions can be used directly, but should be used through the generic
+ * macros iio_{device,channel,device_buffer,device_debug}_attr_{read,write}() */
+__api __check_ret int
+iio_device_attr_read_bool(const struct iio_device *dev,
+			  const char *attr, bool *val);
+__api __check_ret int
+iio_device_attr_read_longlong(const struct iio_device *dev,
+			      const char *attr, long long *val);
+__api __check_ret int
+iio_device_attr_read_double(const struct iio_device *dev,
+			    const char *attr, double *val);
+__api __check_ret ssize_t
+iio_device_attr_write_string(const struct iio_device *dev,
+			     const char *attr, const char *src);
+__api __check_ret int
+iio_device_attr_write_bool(const struct iio_device *dev,
+			   const char *attr, bool val);
+__api __check_ret int
+iio_device_attr_write_longlong(const struct iio_device *dev,
+			       const char *attr, long long val);
+__api __check_ret int
+iio_device_attr_write_double(const struct iio_device *dev,
+			     const char *attr, double val);
+__api __check_ret int
+iio_device_buffer_attr_read_bool(const struct iio_device *dev,
+				 const char *attr, bool *val);
+__api __check_ret int
+iio_device_buffer_attr_read_longlong(const struct iio_device *dev,
+				     const char *attr, long long *val);
+__api __check_ret int
+iio_device_buffer_attr_read_double(const struct iio_device *dev,
+				   const char *attr, double *val);
+__api __check_ret ssize_t
+iio_device_buffer_attr_write_string(const struct iio_device *dev,
+				    const char *attr, const char *src);
+__api __check_ret int
+iio_device_buffer_attr_write_bool(const struct iio_device *dev,
+				  const char *attr, bool val);
+__api __check_ret int
+iio_device_buffer_attr_write_longlong(const struct iio_device *dev,
+				      const char *attr, long long val);
+__api __check_ret int
+iio_device_buffer_attr_write_double(const struct iio_device *dev,
+				    const char *attr, double val);
+__api __check_ret int
+iio_channel_attr_read_bool(const struct iio_channel *chn,
+			   const char *attr, bool *val);
+__api __check_ret int
+iio_channel_attr_read_longlong(const struct iio_channel *chn,
+			       const char *attr, long long *val);
+__api __check_ret int
+iio_channel_attr_read_double(const struct iio_channel *chn,
+			     const char *attr, double *val);
+__api __check_ret ssize_t
+iio_channel_attr_write_string(const struct iio_channel *chn,
+			      const char *attr, const char *src);
+__api __check_ret
+int iio_channel_attr_write_bool(const struct iio_channel *chn,
+				const char *attr, bool val);
+__api __check_ret int
+iio_channel_attr_write_longlong(const struct iio_channel *chn,
+				const char *attr, long long val);
+__api __check_ret int
+iio_channel_attr_write_double(const struct iio_channel *chn,
+			      const char *attr, double val);
+__api __check_ret int
+iio_device_debug_attr_read_bool(const struct iio_device *dev,
+				const char *attr, bool *val);
+__api __check_ret int
+iio_device_debug_attr_read_longlong(const struct iio_device *dev,
+				    const char *attr, long long *val);
+__api __check_ret int
+iio_device_debug_attr_read_double(const struct iio_device *dev,
+				  const char *attr, double *val);
+__api __check_ret ssize_t
+iio_device_debug_attr_write_string(const struct iio_device *dev,
+				   const char *attr, const char *src);
+__api __check_ret int
+iio_device_debug_attr_write_bool(const struct iio_device *dev,
+				 const char *attr, bool val);
+__api __check_ret int
+iio_device_debug_attr_write_longlong(const struct iio_device *dev,
+				     const char *attr, long long val);
+__api __check_ret int
+iio_device_debug_attr_write_double(const struct iio_device *dev,
+				   const char *attr, double val);
+#endif /* DOXYGEN */
 
 #ifdef __cplusplus
 }

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -313,11 +313,15 @@ ssize_t iiod_client_read_attr(struct iiod_client *client,
 			      const struct iio_device *dev,
 			      const struct iio_channel *chn,
 			      const char *attr, char *dest,
-			      size_t len, enum iio_attr_type type)
+			      size_t len, enum iio_attr_type type,
+			      unsigned int buf_id)
 {
 	const char *id = iio_device_get_id(dev);
 	char buf[1024];
 	ssize_t ret;
+
+	if (buf_id > 0)
+		return -ENOSYS;
 
 	if (attr) {
 		if (chn) {
@@ -396,13 +400,17 @@ ssize_t iiod_client_write_attr(struct iiod_client *client,
 			       const struct iio_device *dev,
 			       const struct iio_channel *chn,
 			       const char *attr, const char *src,
-			       size_t len, enum iio_attr_type type)
+			       size_t len, enum iio_attr_type type,
+			       unsigned int buf_id)
 {
 	const struct iiod_client_ops *ops = client->ops;
 	const char *id = iio_device_get_id(dev);
 	char buf[1024];
 	ssize_t ret;
 	int resp;
+
+	if (buf_id > 0)
+		return -ENOSYS;
 
 	if (attr) {
 		if (chn) {

--- a/iiod-client.h
+++ b/iiod-client.h
@@ -55,13 +55,15 @@ __api ssize_t iiod_client_read_attr(struct iiod_client *client,
 				    const struct iio_device *dev,
 				    const struct iio_channel *chn,
 				    const char *attr, char *dest, size_t len,
-				    enum iio_attr_type type);
+				    enum iio_attr_type type,
+				    unsigned int buf_id);
 
 __api ssize_t iiod_client_write_attr(struct iiod_client *client,
 				     const struct iio_device *dev,
 				     const struct iio_channel *chn,
 				     const char *attr, const char *src,
-				     size_t len, enum iio_attr_type type);
+				     size_t len, enum iio_attr_type type,
+				     unsigned int buf_id);
 
 __api struct iiod_client_io *
 iiod_client_open_unlocked(struct iiod_client *client,

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -1205,7 +1205,7 @@ ssize_t read_dev_attr(struct parser_pdata *pdata, struct iio_device *dev,
 				attr, buf, sizeof(buf) - 1);
 			break;
 		case IIO_ATTR_TYPE_BUFFER:
-			ret = iio_device_buffer_attr_read_raw(dev,
+			ret = iio_device_buffer_attr_read_raw(dev, 0,
 							attr, buf, sizeof(buf) - 1);
 			break;
 		default:
@@ -1247,7 +1247,7 @@ ssize_t write_dev_attr(struct parser_pdata *pdata, struct iio_device *dev,
 			ret = iio_device_debug_attr_write_raw(dev, attr, buf, len);
 			break;
 		case IIO_ATTR_TYPE_BUFFER:
-			ret = iio_device_buffer_attr_write_raw(dev, attr, buf, len);
+			ret = iio_device_buffer_attr_write_raw(dev, 0, attr, buf, len);
 			break;
 		default:
 			ret = -EINVAL;

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -1198,14 +1198,14 @@ ssize_t read_dev_attr(struct parser_pdata *pdata, struct iio_device *dev,
 
 	switch (type) {
 		case IIO_ATTR_TYPE_DEVICE:
-			ret = iio_device_attr_read(dev, attr, buf, sizeof(buf) - 1);
+			ret = iio_device_attr_read_raw(dev, attr, buf, sizeof(buf) - 1);
 			break;
 		case IIO_ATTR_TYPE_DEBUG:
-			ret = iio_device_debug_attr_read(dev,
+			ret = iio_device_debug_attr_read_raw(dev,
 				attr, buf, sizeof(buf) - 1);
 			break;
 		case IIO_ATTR_TYPE_BUFFER:
-			ret = iio_device_buffer_attr_read(dev,
+			ret = iio_device_buffer_attr_read_raw(dev,
 							attr, buf, sizeof(buf) - 1);
 			break;
 		default:
@@ -1268,7 +1268,7 @@ ssize_t read_chn_attr(struct parser_pdata *pdata,
 	ssize_t ret = -ENODEV;
 
 	if (chn)
-		ret = iio_channel_attr_read(chn, attr, buf, sizeof(buf) - 1);
+		ret = iio_channel_attr_read_raw(chn, attr, buf, sizeof(buf) - 1);
 	else if (pdata->dev)
 		ret = -ENXIO;
 	print_value(pdata, ret);

--- a/local.c
+++ b/local.c
@@ -404,8 +404,8 @@ static int local_buffer_enabled_set(const struct iio_device *dev, bool en)
 {
 	int ret;
 
-	ret = (int) local_write_dev_attr(dev, "buffer/enable", en ? "1" : "0",
-					 2, false);
+	ret = (int) local_write_dev_attr(dev, "buffer/enable",
+					 en ? "1" : "0", 2, IIO_ATTR_TYPE_DEVICE);
 	if (ret < 0)
 		return ret;
 
@@ -598,14 +598,16 @@ static ssize_t local_read_chn_attr(const struct iio_channel *chn,
 		const char *attr, char *dst, size_t len)
 {
 	attr = get_filename(chn, attr);
-	return local_read_dev_attr(chn->dev, attr, dst, len, false);
+	return local_read_dev_attr(chn->dev, attr,
+				   dst, len, IIO_ATTR_TYPE_DEVICE);
 }
 
 static ssize_t local_write_chn_attr(const struct iio_channel *chn,
 		const char *attr, const char *src, size_t len)
 {
 	attr = get_filename(chn, attr);
-	return local_write_dev_attr(chn->dev, attr, src, len, false);
+	return local_write_dev_attr(chn->dev, attr,
+				    src, len, IIO_ATTR_TYPE_DEVICE);
 }
 
 static int channel_write_state(const struct iio_channel *chn, bool en)
@@ -735,7 +737,7 @@ static int local_open(const struct iio_device *dev,
 
 	iio_snprintf(buf, sizeof(buf), "%lu", (unsigned long) samples_count);
 	ret = local_write_dev_attr(dev, "buffer/length",
-			buf, strlen(buf) + 1, false);
+				   buf, strlen(buf) + 1, IIO_ATTR_TYPE_DEVICE);
 	if (ret < 0)
 		return ret;
 
@@ -744,7 +746,7 @@ static int local_open(const struct iio_device *dev,
 	 * maximum if it's too high without issueing an error.
 	 */
 	ret = local_write_dev_attr(dev, "buffer/watermark",
-				   buf, strlen(buf) + 1, false);
+				   buf, strlen(buf) + 1, IIO_ATTR_TYPE_DEVICE);
 	if (ret < 0 && ret != -ENOENT && ret != -EACCES)
 		return ret;
 
@@ -805,7 +807,8 @@ static int local_open(const struct iio_device *dev,
 		 * refilling the iio_buffer. */
 		iio_snprintf(buf, sizeof(buf), "%lu", size);
 		ret = local_write_dev_attr(dev, "buffer/length",
-				buf, strlen(buf) + 1, false);
+					   buf, strlen(buf) + 1,
+					   IIO_ATTR_TYPE_DEVICE);
 		if (ret < 0)
 			goto err_close;
 	}
@@ -922,8 +925,10 @@ static int local_get_trigger(const struct iio_device *dev,
 {
 	char buf[1024];
 	unsigned int i;
-	ssize_t nb = local_read_dev_attr(dev, "trigger/current_trigger",
-			buf, sizeof(buf), false);
+	ssize_t nb;
+
+	nb = local_read_dev_attr(dev, "trigger/current_trigger",
+				 buf, sizeof(buf), IIO_ATTR_TYPE_DEVICE);
 	if (nb < 0) {
 		*trigger = NULL;
 		return (int) nb;
@@ -950,8 +955,9 @@ static int local_set_trigger(const struct iio_device *dev,
 {
 	ssize_t nb;
 	const char *value = trigger ? trigger->name : "";
-	nb = local_write_dev_attr(dev, "trigger/current_trigger",
-			value, strlen(value) + 1, false);
+
+	nb = local_write_dev_attr(dev, "trigger/current_trigger", value,
+				  strlen(value) + 1, IIO_ATTR_TYPE_DEVICE);
 	if (nb < 0)
 		return (int) nb;
 	else
@@ -1092,7 +1098,8 @@ static int handle_protected_scan_element_attr(struct iio_channel *chn,
 	int ret;
 
 	if (!strcmp(name, "index")) {
-		ret = local_read_dev_attr(dev, path, buf, sizeof(buf), false);
+		ret = local_read_dev_attr(dev, path, buf, sizeof(buf),
+					  IIO_ATTR_TYPE_DEVICE);
 		if (ret > 0) {
 			char *end;
 			long long value;
@@ -1105,7 +1112,8 @@ static int handle_protected_scan_element_attr(struct iio_channel *chn,
 			chn->index = (long) value;
 		}
 	} else if (!strcmp(name, "type")) {
-		ret = local_read_dev_attr(dev, path, buf, sizeof(buf), false);
+		ret = local_read_dev_attr(dev, path, buf, sizeof(buf),
+					  IIO_ATTR_TYPE_DEVICE);
 		if (ret > 0) {
 			char endian, sign;
 

--- a/local.c
+++ b/local.c
@@ -1045,7 +1045,9 @@ static char * get_short_attr_name(struct iio_channel *chn, const char *attr)
 static int read_device_name(struct iio_device *dev)
 {
 	char buf[1024];
-	ssize_t ret = iio_device_attr_read(dev, "name", buf, sizeof(buf));
+	ssize_t ret;
+
+	ret = iio_device_attr_read_raw(dev, "name", buf, sizeof(buf));
 	if (ret < 0)
 		return ret;
 	else if (ret == 0)
@@ -1061,7 +1063,9 @@ static int read_device_name(struct iio_device *dev)
 static int read_device_label(struct iio_device *dev)
 {
 	char buf[1024];
-	ssize_t ret = iio_device_attr_read(dev, "label", buf, sizeof(buf));
+	ssize_t ret;
+
+	ret = iio_device_attr_read_raw(dev, "label", buf, sizeof(buf));
 	if (ret < 0)
 		return ret;
 	else if (ret == 0)
@@ -1803,7 +1807,7 @@ static void init_data_scale(struct iio_channel *chn)
 	float value;
 
 	chn->format.with_scale = false;
-	ret = iio_channel_attr_read(chn, "scale", buf, sizeof(buf));
+	ret = iio_channel_attr_read_raw(chn, "scale", buf, sizeof(buf));
 	if (ret < 0)
 		return;
 

--- a/network.c
+++ b/network.c
@@ -360,23 +360,27 @@ static ssize_t network_write(const struct iio_device *dev,
 }
 
 static ssize_t network_read_dev_attr(const struct iio_device *dev,
-		const char *attr, char *dst, size_t len, enum iio_attr_type type)
+				     unsigned int buf_id, const char *attr,
+				     char *dst, size_t len,
+				     enum iio_attr_type type)
 {
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
 	return iiod_client_read_attr(pdata->iiod_client, dev, NULL,
-				     attr, dst, len, type);
+				     attr, dst, len, type, buf_id);
 }
 
 static ssize_t network_write_dev_attr(const struct iio_device *dev,
-		const char *attr, const char *src, size_t len, enum iio_attr_type type)
+				      unsigned int buf_id, const char *attr,
+				      const char *src, size_t len,
+				      enum iio_attr_type type)
 {
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
 	return iiod_client_write_attr(pdata->iiod_client, dev, NULL,
-				      attr, src, len, type);
+				      attr, src, len, type, buf_id);
 }
 
 static ssize_t network_read_chn_attr(const struct iio_channel *chn,
@@ -387,7 +391,7 @@ static ssize_t network_read_chn_attr(const struct iio_channel *chn,
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
 	return iiod_client_read_attr(pdata->iiod_client, dev, chn,
-				     attr, dst, len, false);
+				     attr, dst, len, false, 0);
 }
 
 static ssize_t network_write_chn_attr(const struct iio_channel *chn,
@@ -398,7 +402,7 @@ static ssize_t network_write_chn_attr(const struct iio_channel *chn,
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
 	return iiod_client_write_attr(pdata->iiod_client, dev, chn,
-				      attr, src, len, false);
+				      attr, src, len, false, 0);
 }
 
 static int network_get_trigger(const struct iio_device *dev,

--- a/serial.c
+++ b/serial.c
@@ -179,23 +179,27 @@ static ssize_t serial_write(const struct iio_device *dev,
 }
 
 static ssize_t serial_read_dev_attr(const struct iio_device *dev,
-		const char *attr, char *dst, size_t len, enum iio_attr_type type)
+				    unsigned int buf_id, const char *attr,
+				    char *dst, size_t len,
+				    enum iio_attr_type type)
 {
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
 	return iiod_client_read_attr(pdata->iiod_client,
-				     dev, NULL, attr, dst, len, type);
+				     dev, NULL, attr, dst, len, type, buf_id);
 }
 
 static ssize_t serial_write_dev_attr(const struct iio_device *dev,
-		const char *attr, const char *src, size_t len, enum iio_attr_type type)
+				     unsigned int buf_id, const char *attr,
+				     const char *src, size_t len,
+				     enum iio_attr_type type)
 {
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
-	return iiod_client_write_attr(pdata->iiod_client,
-				      dev, NULL, attr, src, len, type);
+	return iiod_client_write_attr(pdata->iiod_client, dev, NULL, attr,
+				      src, len, type, buf_id);
 }
 
 static ssize_t serial_read_chn_attr(const struct iio_channel *chn,
@@ -206,7 +210,7 @@ static ssize_t serial_read_chn_attr(const struct iio_channel *chn,
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
 	return iiod_client_read_attr(pdata->iiod_client,
-				     dev, chn, attr, dst, len, false);
+				     dev, chn, attr, dst, len, false, 0);
 }
 
 static ssize_t serial_write_chn_attr(const struct iio_channel *chn,
@@ -217,7 +221,7 @@ static ssize_t serial_write_chn_attr(const struct iio_channel *chn,
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
 	return iiod_client_write_attr(pdata->iiod_client,
-				      dev, chn, attr, src, len, false);
+				      dev, chn, attr, src, len, false, 0);
 }
 
 static int serial_set_kernel_buffers_count(const struct iio_device *dev,

--- a/tests/iio_attr.c
+++ b/tests/iio_attr.c
@@ -164,7 +164,7 @@ static int dump_buffer_attributes(const struct iio_device *dev,
 
 	if (!wbuf || quiet == ATTR_VERBOSE ) {
 		gen_function("device_buffer", "dev", attr, NULL);
-		ret = iio_device_buffer_attr_read_raw(dev, attr, buf, BUF_SIZE);
+		ret = iio_device_buffer_attr_read_raw(dev, 0, attr, buf, BUF_SIZE);
 
 		if (quiet == ATTR_VERBOSE) {
 			printf("%s ", iio_device_is_trigger(dev) ? "trig" : "dev");
@@ -185,7 +185,7 @@ static int dump_buffer_attributes(const struct iio_device *dev,
 
 	if (wbuf) {
 		gen_function("device_buffer", "dev", attr, wbuf);
-		ret = iio_device_buffer_attr_write_string(dev, attr, wbuf);
+		ret = iio_device_buffer_attr_write_string(dev, 0, attr, wbuf);
 		if (ret > 0) {
 			if (quiet == ATTR_VERBOSE)
 				printf("wrote %li bytes to %s\n", (long)ret, attr);

--- a/tests/iio_attr.c
+++ b/tests/iio_attr.c
@@ -127,7 +127,7 @@ static int dump_device_attributes(const struct iio_device *dev,
 			printf(", attr '%s', value :", attr);
 		}
 		gen_function("device", "dev", attr, NULL);
-		ret = iio_device_attr_read(dev, attr, buf, BUF_SIZE);
+		ret = iio_device_attr_read_raw(dev, attr, buf, BUF_SIZE);
 		if (ret > 0) {
 			if (quiet == ATTR_NORMAL)
 				printf("%s\n", buf);
@@ -140,7 +140,7 @@ static int dump_device_attributes(const struct iio_device *dev,
 	}
 	if (wbuf) {
 		gen_function("device", "dev", attr, wbuf);
-		ret = iio_device_attr_write(dev, attr, wbuf);
+		ret = iio_device_attr_write_string(dev, attr, wbuf);
 		if (ret > 0) {
 			if (quiet == ATTR_VERBOSE)
 				printf("wrote %li bytes to %s\n", (long)ret, attr);
@@ -164,7 +164,7 @@ static int dump_buffer_attributes(const struct iio_device *dev,
 
 	if (!wbuf || quiet == ATTR_VERBOSE ) {
 		gen_function("device_buffer", "dev", attr, NULL);
-		ret = iio_device_buffer_attr_read(dev, attr, buf, BUF_SIZE);
+		ret = iio_device_buffer_attr_read_raw(dev, attr, buf, BUF_SIZE);
 
 		if (quiet == ATTR_VERBOSE) {
 			printf("%s ", iio_device_is_trigger(dev) ? "trig" : "dev");
@@ -185,7 +185,7 @@ static int dump_buffer_attributes(const struct iio_device *dev,
 
 	if (wbuf) {
 		gen_function("device_buffer", "dev", attr, wbuf);
-		ret = iio_device_buffer_attr_write(dev, attr, wbuf);
+		ret = iio_device_buffer_attr_write_string(dev, attr, wbuf);
 		if (ret > 0) {
 			if (quiet == ATTR_VERBOSE)
 				printf("wrote %li bytes to %s\n", (long)ret, attr);
@@ -209,7 +209,7 @@ static int dump_debug_attributes(const struct iio_device *dev,
 
 	if (!wbuf || quiet == ATTR_VERBOSE) {
 		gen_function("device_debug", "dev", attr, NULL);
-		ret = iio_device_debug_attr_read(dev, attr, buf, BUF_SIZE);
+		ret = iio_device_debug_attr_read_raw(dev, attr, buf, BUF_SIZE);
 
 		if (quiet == ATTR_VERBOSE) {
 			printf("%s ", iio_device_is_trigger(dev) ? "trig" : "dev");
@@ -231,7 +231,7 @@ static int dump_debug_attributes(const struct iio_device *dev,
 
 	if (wbuf) {
 		gen_function("device_debug", "dev", attr, wbuf);
-		ret = iio_device_debug_attr_write(dev, attr, wbuf);
+		ret = iio_device_debug_attr_write_string(dev, attr, wbuf);
 		if (ret > 0) {
 			if (quiet == ATTR_VERBOSE)
 				printf("wrote %li bytes to %s\n", (long)ret, attr);
@@ -261,7 +261,7 @@ static int dump_channel_attributes(const struct iio_device *dev,
 			type_name = "input";
 
 		gen_function("channel", "ch", attr, NULL);
-		ret = iio_channel_attr_read(ch, attr, buf, BUF_SIZE);
+		ret = iio_channel_attr_read_raw(ch, attr, buf, BUF_SIZE);
 		if (quiet == ATTR_VERBOSE) {
 			printf("%s ", iio_device_is_trigger(dev) ? "trig" : "dev");
 			printf("'%s'", get_label_or_name_or_id(dev));
@@ -287,7 +287,7 @@ static int dump_channel_attributes(const struct iio_device *dev,
 	}
 	if (wbuf) {
 		gen_function("channel", "ch", attr, wbuf);
-		ret = iio_channel_attr_write(ch, attr, wbuf);
+		ret = iio_channel_attr_write_string(ch, attr, wbuf);
 		if (ret > 0) {
 			if (quiet == ATTR_VERBOSE)
 				printf("wrote %li bytes to %s\n", (long)ret, attr);

--- a/tests/iio_info.c
+++ b/tests/iio_info.c
@@ -261,7 +261,7 @@ int main(int argc, char **argv)
 					nb_attrs);
 			for (j = 0; j < nb_attrs; j++) {
 				const char *attr = iio_device_get_buffer_attr(dev, j);
-				ret = (int) iio_device_buffer_attr_read_raw(dev,
+				ret = (int) iio_device_buffer_attr_read_raw(dev, 0,
 						attr, buf, BUF_SIZE);
 
 				printf("\t\t\t\tattr %2u: %s ",

--- a/tests/iio_info.c
+++ b/tests/iio_info.c
@@ -220,7 +220,7 @@ int main(int argc, char **argv)
 			unsigned int k;
 			for (k = 0; k < nb_attrs; k++) {
 				const char *attr = iio_channel_get_attr(ch, k);
-				ret = (int) iio_channel_attr_read(ch,
+				ret = (int) iio_channel_attr_read_raw(ch,
 						attr, buf, BUF_SIZE);
 
 				printf("\t\t\t\tattr %2u: %s ", k, attr);
@@ -240,7 +240,7 @@ int main(int argc, char **argv)
 					nb_attrs);
 			for (j = 0; j < nb_attrs; j++) {
 				const char *attr = iio_device_get_attr(dev, j);
-				ret = (int) iio_device_attr_read(dev,
+				ret = (int) iio_device_attr_read_raw(dev,
 						attr, buf, BUF_SIZE);
 
 				printf("\t\t\t\tattr %2u: %s ",
@@ -261,7 +261,7 @@ int main(int argc, char **argv)
 					nb_attrs);
 			for (j = 0; j < nb_attrs; j++) {
 				const char *attr = iio_device_get_buffer_attr(dev, j);
-				ret = (int) iio_device_buffer_attr_read(dev,
+				ret = (int) iio_device_buffer_attr_read_raw(dev,
 						attr, buf, BUF_SIZE);
 
 				printf("\t\t\t\tattr %2u: %s ",
@@ -283,7 +283,7 @@ int main(int argc, char **argv)
 				const char *attr =
 					iio_device_get_debug_attr(dev, j);
 
-				ret = (int) iio_device_debug_attr_read(dev,
+				ret = (int) iio_device_debug_attr_read_raw(dev,
 						attr, buf, BUF_SIZE);
 				printf("\t\t\t\tdebug attr %2u: %s ",
 						j, attr);

--- a/usb.c
+++ b/usb.c
@@ -367,23 +367,28 @@ static ssize_t usb_write(const struct iio_device *dev,
 }
 
 static ssize_t usb_read_dev_attr(const struct iio_device *dev,
-		const char *attr, char *dst, size_t len, enum iio_attr_type type)
+				 unsigned int buf_id, const char *attr,
+				 char *dst, size_t len, enum iio_attr_type type)
 {
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 	struct iiod_client *client = pdata->io_ctx.iiod_client;
 
-	return iiod_client_read_attr(client, dev, NULL, attr, dst, len, type);
+	return iiod_client_read_attr(client, dev, NULL, attr,
+				     dst, len, type, buf_id);
 }
 
 static ssize_t usb_write_dev_attr(const struct iio_device *dev,
-		const char *attr, const char *src, size_t len, enum iio_attr_type type)
+				  unsigned int buf_id, const char *attr,
+				  const char *src, size_t len,
+				  enum iio_attr_type type)
 {
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 	struct iiod_client *client = pdata->io_ctx.iiod_client;
 
-	return iiod_client_write_attr(client, dev, NULL, attr, src, len, type);
+	return iiod_client_write_attr(client, dev, NULL, attr, src,
+				      len, type, buf_id);
 }
 
 static ssize_t usb_read_chn_attr(const struct iio_channel *chn,
@@ -394,7 +399,8 @@ static ssize_t usb_read_chn_attr(const struct iio_channel *chn,
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 	struct iiod_client *client = pdata->io_ctx.iiod_client;
 
-	return iiod_client_read_attr(client, dev, chn, attr, dst, len, false);
+	return iiod_client_read_attr(client, dev, chn, attr,
+				     dst, len, false, 0);
 }
 
 static ssize_t usb_write_chn_attr(const struct iio_channel *chn,
@@ -405,7 +411,7 @@ static ssize_t usb_write_chn_attr(const struct iio_channel *chn,
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 	struct iiod_client *client = pdata->io_ctx.iiod_client;
 
-	return iiod_client_write_attr(client, dev, chn, attr, src, len, false);
+	return iiod_client_write_attr(client, dev, chn, attr, src, len, false, 0);
 }
 
 static int usb_set_kernel_buffers_count(const struct iio_device *dev,


### PR DESCRIPTION
This PR reworks the attribute read/write functions.

It switches libiio to C11, and rename some functions so that `iio_device_attr_read()` and `iio_device_attr_write()` can be redefined as generic macros, which will accept multiple types.

It also adds a buffer ID argument to the buffer attribute read/write functions, in preparation of the multi-buffer support.