### PR TITLE
tests/iio{read,write}dev: Fix unkillable process

### DIFF
--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -209,6 +209,8 @@ int main(int argc, char **argv)
 
 	argw = dup_argv(MY_NAME, argc, argv);
 
+	setup_sig_handler();
+
 	ctx = handle_common_opts(MY_NAME, argc, argw, MY_OPTS, options, options_descriptions);
 	opts = add_common_options(options);
 	if (!opts) {
@@ -313,8 +315,6 @@ int main(int argc, char **argv)
 		usage(MY_NAME, options, options_descriptions);
 		return EXIT_FAILURE;
 	}
-
-	setup_sig_handler();
 
 	dev = iio_context_find_device(ctx, argw[optind]);
 	if (!dev) {

--- a/tests/iio_writedev.c
+++ b/tests/iio_writedev.c
@@ -220,6 +220,8 @@ int main(int argc, char **argv)
 
 	argw = dup_argv(MY_NAME, argc, argv);
 
+	setup_sig_handler();
+
 	ctx = handle_common_opts(MY_NAME, argc, argw, MY_OPTS, options, options_descriptions);
 	opts = add_common_options(options);
 	if (!opts) {
@@ -332,8 +334,6 @@ int main(int argc, char **argv)
 		iio_context_destroy(ctx);
 		return EXIT_FAILURE;
 	}
-
-	setup_sig_handler();
 
 	dev = iio_context_find_device(ctx, argw[optind]);
 	if (!dev) {


### PR DESCRIPTION
Register the signal handlers before everything else. Otherwise, the
signals might be sent to any thread that might be created by libiio, or
its dependencies, making these programs only killable by a signal 9.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>