### PR TITLE
local: Ignore ill-formed INI files

### DIFF
--- a/local.c
+++ b/local.c
@@ -2116,7 +2116,7 @@ struct iio_context * local_create_context(void)
 	if (WITH_LOCAL_CONFIG) {
 		ret = populate_context_attrs(ctx, "/etc/libiio.ini");
 		if (ret < 0)
-			goto err_context_destroy;
+			IIO_WARNING("Unable to read INI file: %d\n", ret);
 	}
 
 	uname(&uts);


### PR DESCRIPTION
If the INI file is present but cannot be read, print a warning about it,
but keep on creating the IIO context.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>