### PR TITLE
iio_strndup : fix off by one error

### DIFF
--- a/utilities.c
+++ b/utilities.c
@@ -247,7 +247,7 @@ char *iio_strndup(const char *str, size_t n)
 #ifdef HAS_STRNDUP
 	return strndup(str, n);
 #else
-	size_t len = strnlen(str, n + 1);
+	size_t len = strnlen(str, n);
 	char *buf = malloc(len + 1);
 	if (buf) {
 		/* len = size of buf, so memcpy is OK */


### PR DESCRIPTION
When debugging some weirdness between the windows code and linux code
running mds, I noticed that iio_strndup() was behaving differently. :(

That is because the local implmentation for Windows was wrong.
Checking against:
https://github.com/gcc-mirror/gcc/blob/master/libiberty/strndup.c
(Which we can't use directly since it is GPL3, and not compatible with
LGPL), and checking against (which is BSD):
https://opensource.apple.com/source/Libc/Libc-1158.30.7/string/FreeBSD/strndup.c.auto.html

we can see the strlen we should be using is n, not n+1, which is what it
was before. :(

So, fix it.

Signed-off-by: Robin Getz <robin.getz@analog.com>