### PR TITLE
tests: Fix build under MinGW

### DIFF
--- a/tests/iio_common.c
+++ b/tests/iio_common.c
@@ -451,7 +451,7 @@ uint64_t get_time_us(void)
 {
 	struct timespec tp;
 
-#ifdef _WIN32
+#ifdef _MSC_BUILD
 	timespec_get(&tp, TIME_UTC);
 #else
 	clock_gettime(CLOCK_REALTIME, &tp);


### PR DESCRIPTION
MinGW 32-bit does not have timespec_get(). Strangely, the 64-bit version
does have it. But both have clock_gettime(), so only use timespec_get()
when building under Visual Studio.

Fixes #830.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>