### PR TITLE
Use FQDN_LEN instead of MAXHOSTNAMELEN for DNS names

### DIFF
--- a/dns_sd.c
+++ b/dns_sd.c
@@ -81,7 +81,7 @@ static int dnssd_fill_context_info(struct iio_context_info *info,
 		char *hostname, char *addr_str, uint16_t port)
 {
 	struct iio_context *ctx;
-	char uri[sizeof("ip:") + MAXHOSTNAMELEN + sizeof (":65535") + 1];
+	char uri[sizeof("ip:") + FQDN_LEN + sizeof (":65535") + 1];
 	char description[255], *p;
 	const char *hw_model, *serial;
 	unsigned int i;

--- a/dns_sd.h
+++ b/dns_sd.h
@@ -15,14 +15,12 @@
 
 #ifdef _WIN32
 #include <winsock2.h>
-#ifndef MAXHOSTNAMELEN
-#define MAXHOSTNAMELEN (MAX_COMPUTERNAME_LENGTH+1)
-#endif /* MAXHOSTNAMELEN */
 #else
 #include <sys/param.h>
 #endif
 
 #define DNS_SD_ADDRESS_STR_MAX (40) /* IPv6 Max = 4*8 + 7 + 1 for NUL */
+#define FQDN_LEN (255)              /* RFC 1035 */
 
 /* MacOS doesn't include ENOMEDIUM (No medium found) like Linux does */
 #ifndef ENOMEDIUM

--- a/dns_sd_bonjour.c
+++ b/dns_sd_bonjour.c
@@ -30,8 +30,8 @@ static void __cfnet_browser_cb(CFNetServiceBrowserRef browser,
 	struct dns_sd_discovery_data *dd = info;
 	char address_v4[DNS_SD_ADDRESS_STR_MAX+1] = "";
 	char address_v6[DNS_SD_ADDRESS_STR_MAX+1] = "";
-	char hostname[MAXHOSTNAMELEN];
-	char name[MAXHOSTNAMELEN];
+	char hostname[FQDN_LEN];
+	char name[FQDN_LEN];
 	bool have_v4 = false;
 	bool have_v6 = false;
 	struct sockaddr_in *sa;

--- a/network-windows.c
+++ b/network-windows.c
@@ -11,9 +11,6 @@
 #include <errno.h>
 #include <ws2tcpip.h>
 #define close(s) closesocket(s)
-#ifndef MAXHOSTNAMELEN
-#define MAXHOSTNAMELEN (MAX_COMPUTERNAME_LENGTH+1)
-#endif /* MAXHOSTNAMELEN */
 
 int set_blocking_mode(int s, bool blocking)
 {

--- a/network.c
+++ b/network.c
@@ -1218,7 +1218,7 @@ struct iio_context * network_create_context(const char *host)
 
 	uri_len = strlen(description);
 	if (host && host[0])
-		uri_len = strnlen(host, MAXHOSTNAMELEN);
+		uri_len = strnlen(host, FQDN_LEN);
 	uri_len += sizeof ("ip:");
 
 	uri = malloc(uri_len);

--- a/utilities.c
+++ b/utilities.c
@@ -321,7 +321,7 @@ char * iio_getenv (char * envvar)
 	if (!hostname)
 		return NULL;
 
-	tmp = MAXHOSTNAMELEN + sizeof("serial:") + sizeof(":65535") - 2;
+	tmp = FQDN_LEN + sizeof("serial:") + sizeof(":65535") - 2;
 	len = strnlen(hostname, tmp);
 
 	/* Should be smaller than max length */


### PR DESCRIPTION
As defined in nbase.h (or in some system header file on Linux),
MAXHOSTNAMELEN is 64. This is the maximum length of a hostname,
but not of a DNS name, which may be longer. RFC 1035 spells out
that DNS names are formed of labels, each of which must be 63
bytes or less, and that labels are combined to form a DNS name
(a.k.a. FQDN) which may not exceed 255 bytes.

So add and use that, which fixed a long name issue for me.

Signed-off-by: Robin Getz <robin.getz@analog.com>