### PR TITLE
scan: ignore localhosts in scans

### DIFF
--- a/dns_sd.c
+++ b/dns_sd.c
@@ -251,6 +251,26 @@ void remove_dup_discovery_data(struct dns_sd_discovery_data **ddata)
 		}
 		i++;
 	}
+
+	prev = NULL;
+	ndata = d;
+	i = 0;
+	while (ndata->next) {
+		if (!strcmp(ndata->addr_str, "127.0.0.1") ||
+				!strcmp(ndata->addr_str, "::1")) {
+			IIO_DEBUG("Removing localhost in list: %i '%s' '%s' port:%hu\n",
+				i, ndata->hostname, ndata->addr_str, ndata->port);
+			dnssd_remove_node(&d, i);
+			if (!prev)
+				ndata = d;
+			else
+				ndata = prev->next;
+			continue;
+		}
+		i++;
+		prev = ndata;
+		ndata = ndata->next;
+	}
 	iio_mutex_unlock(d->lock);
 
 	*ddata = d;

--- a/dns_sd.c
+++ b/dns_sd.c
@@ -215,7 +215,7 @@ void port_knock_discovery_data(struct dns_sd_discovery_data **ddata)
 
 void remove_dup_discovery_data(struct dns_sd_discovery_data **ddata)
 {
-	struct dns_sd_discovery_data *d, *ndata, *mdata;
+	struct dns_sd_discovery_data *d, *ndata, *mdata, *prev;
 	int i, j;
 
 	d = *ddata;
@@ -227,15 +227,26 @@ void remove_dup_discovery_data(struct dns_sd_discovery_data **ddata)
 		return;
 
 	iio_mutex_lock(d->lock);
+	/* since we are removing nodes in the linked list, we keep track of the
+	 * previous "good" node, so we always can link from the last to the next
+	 */
 	for (i = 0, ndata = d; ndata->next != NULL; ndata = ndata->next) {
+		prev = ndata;
 		for (j = i + 1, mdata = ndata->next; mdata->next != NULL; mdata = mdata->next) {
 			if (!strcmp(mdata->hostname, ndata->hostname) &&
 					!strcmp(mdata->addr_str, ndata->addr_str) &&
 					mdata->port == ndata->port){
-				IIO_DEBUG("Removing duplicate in list: '%s'\n",
-						ndata->hostname);
+				IIO_DEBUG("Removing duplicate in list: %i '%s' '%s' port:%hu\n",
+						j, ndata->hostname, ndata->addr_str,
+						ndata->port);
 				dnssd_remove_node(&d, j);
+				/* back up one, so the mdata->next will point to the
+				 * next one to be tested.
+				 */
+				mdata = prev;
+				continue;
 			}
+			prev = mdata;
 			j++;
 		}
 		i++;


### PR DESCRIPTION
sometimes we get:

	2: 127.0.0.1 on Raspberry Pi 4 Model B Rev 1.5 [ip:phaser.local]
	3: 192.168.1.105 on Raspberry Pi 4 Model B Rev 1.5 [ip:phaser.local]
	4: 192.168.2.10 on Raspberry Pi 4 Model B Rev 1.5 [ip:phaser.local]
	5: 2601:190:400:da:a448:8c38:150a:7d4e on Raspberry Pi 4 Model B Rev 1.5 [ip:phaser.local]

obviously, 127.0.0.1 is not useful at all, so throw it away when we are looking for duplicates.

Signed-off-by: Robin Getz <robin.getz@analog.com>