### PR TITLE
Cmake: shift some iiod specific things into iiod Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -592,15 +592,6 @@ if(OSX_PACKAGE)
 endif()
 
 if(WITH_IIOD)
-	option(WITH_SYSTEMD "Enable installation of systemd service file for iiod" OFF)
-	set(SYSTEMD_UNIT_INSTALL_DIR /lib/systemd/system CACHE PATH "default install path for systemd unit files")
-
-	option(WITH_SYSVINIT "Enable installation of SysVinit script for iiod" OFF)
-	set(SYSVINIT_INSTALL_DIR /etc/init.d CACHE PATH "default install path for SysVinit scripts")
-
-	option(WITH_UPSTART "Enable installation of upstart config file for iiod" OFF)
-	set(UPSTART_CONF_INSTALL_DIR /etc/init CACHE PATH "default install path for upstart conf files")
-
 	if (NOT PTHREAD_LIBRARIES)
 		message(SEND_ERROR "IIOD requires pthread support\n."
 			"If you want to disable IIOD, set WITH_IIOD=OFF.")

--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required(VERSION 2.8.7)
 project(iiod C)
 
+option(WITH_SYSTEMD "Enable installation of systemd service file for iiod" OFF)
+option(WITH_SYSVINIT "Enable installation of SysVinit script for iiod" OFF)
+option(WITH_UPSTART "Enable installation of upstart config file for iiod" OFF)
+
+if ((WITH_SYSTEMD AND WITH_SYSVINIT) OR (WITH_SYSTEMD AND WITH_UPSTART) OR
+		(WITH_SYSVINIT AND WITH_UPSTART))
+	message(FATAL_ERROR "Multiple init systems enabled: only enable one")
+endif()
+
 include(FindBISON)
 include(FindFLEX)
 
@@ -90,11 +99,26 @@ if(NOT SKIP_INSTALL_ALL)
 endif()
 
 if (WITH_SYSTEMD)
+	# Borrowed a portion of this from https://github.com/intel/hdcp/blob/master/config/systemdservice.cmake
+	# Copyright (c) 2018, Intel Corporation
+	pkg_check_modules(SYSTEMD "systemd")
+	if (SYSTEMD_FOUND AND "${SYSTEMD_SERVICES_INSTALL_DIR}" STREQUAL "")
+		execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE}
+			--variable=systemdsystemunitdir systemd
+			OUTPUT_VARIABLE SYSTEMD_SERVICES_INSTALL_DIR)
+		string(REGEX REPLACE "[ \t\n]+" "" SYSTEMD_SERVICES_INSTALL_DIR
+			"${SYSTEMD_SERVICES_INSTALL_DIR}")
+	else()
+		set(SYSTEMD_SERVICES_INSTALL_DIR /lib/systemd/system CACHE PATH "default install path for systemd unit files")
+	endif()
+	message(STATUS "Configured for the systemd init system, installing into " ${SYSTEMD_SERVICES_INSTALL_DIR})
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/init/iiod.service.cmakein ${PROJECT_BINARY_DIR}/init/iiod.service)
-	install(FILES ${PROJECT_BINARY_DIR}/init/iiod.service DESTINATION ${SYSTEMD_UNIT_INSTALL_DIR})
+	install(FILES ${PROJECT_BINARY_DIR}/init/iiod.service DESTINATION ${SYSTEMD_SERVICES_INSTALL_DIR})
 endif()
 
 if (WITH_SYSVINIT)
+	set(SYSVINIT_INSTALL_DIR /etc/init.d CACHE PATH "default install path for SysVinit scripts")
+	message(STATUS "Configured for the SysVinit system, installing into " ${SYSVINIT_INSTALL_DIR})
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/init/iiod.init.cmakein ${PROJECT_BINARY_DIR}/init/iiod)
 	install(FILES ${PROJECT_BINARY_DIR}/init/iiod
 	        PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
@@ -102,6 +126,8 @@ if (WITH_SYSVINIT)
 endif()
 
 if (WITH_UPSTART)
+	set(UPSTART_CONF_INSTALL_DIR /etc/init CACHE PATH "default install path for upstart conf files")
+	message(STATUS "Configured for the Upstart init system, installing into "  ${UPSTART_CONF_INSTALL_DIR})
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/init/iiod.conf.cmakein ${PROJECT_BINARY_DIR}/init/iiod.conf)
 	install(FILES ${PROJECT_BINARY_DIR}/init/iiod.conf DESTINATION ${UPSTART_CONF_INSTALL_DIR})
 endif()


### PR DESCRIPTION
This moves all the iiod specific things out of the main Cmake file
and into the iiod specific cmake file, as well as prints out where
the startup scripts are being installed.

Signed-off-by: Robin Getz <robin.getz@analog.com>