### PR TITLE
network: Set non-blocking mode on Windows too

### DIFF
--- a/network-unix.c
+++ b/network-unix.c
@@ -84,12 +84,6 @@ void cleanup_cancel(struct iiod_client_pdata *io_ctx)
 
 int setup_cancel(struct iiod_client_pdata *io_ctx)
 {
-	int ret;
-
-	ret = set_blocking_mode(io_ctx->fd, false);
-	if (ret)
-		return ret;
-
 	return create_cancel_fd(io_ctx);
 }
 

--- a/network.c
+++ b/network.c
@@ -363,6 +363,10 @@ static int network_open(const struct iio_device *dev,
 	if (ret < 0)
 		goto err_close_socket;
 
+	ret = set_blocking_mode(ppdata->io_ctx.fd, false);
+	if (ret)
+		goto err_cleanup_cancel;
+
 	set_socket_timeout(ppdata->io_ctx.fd, pdata->io_ctx.timeout_ms);
 
 	ppdata->io_ctx.timeout_ms = pdata->io_ctx.timeout_ms;
@@ -378,6 +382,8 @@ static int network_open(const struct iio_device *dev,
 
 	return 0;
 
+err_cleanup_cancel:
+	cleanup_cancel(&ppdata->io_ctx);
 err_close_socket:
 	close(ppdata->io_ctx.fd);
 	ppdata->io_ctx.fd = -1;


### PR DESCRIPTION
The Windows specific code has the cancellation functionality and the
ability to poll for data implemented, so it can use the non-blocking
mode as well.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>