### PR TITLE
cmake/LinuxPackaging.cmake: Fix apt dependencies list otherwise .deb is not installable.

### DIFF
--- a/cmake/LinuxPackaging.cmake
+++ b/cmake/LinuxPackaging.cmake
@@ -115,7 +115,7 @@ if(DEB_DETECT_DEPENDENCIES AND DPKG_CMD AND DPKGQ_CMD)
 		${CPACK_DEBIAN_PACKAGE_DEPENDS})
 else()
 	# assume everything is turned on, and running on a modern OS
-	set(CPACK_DEBIAN_PACKAGE_DEPENDS "libaio (>= 0.3.109), libavahi-client (>= 0.6.31), libavahi-common (>= 0.6.31), libc6 (>= 2.19), libusb-1.0-0 (>= 2:1.0.17), libxml2 (>= 2.9.1), libserialport0 (>=0.1.1)")
+	set(CPACK_DEBIAN_PACKAGE_DEPENDS "libaio1 (>= 0.3.109), libavahi-client3 (>= 0.6.31), libavahi-common3 (>= 0.6.31), libavahi-common-data (>= 0.6.31), libc6 (>= 2.19), libusb-1.0-0 (>= 2:1.0.17), libxml2 (>= 2.9.1), libserialport0 (>=0.1.1)")
 	message(STATUS "Using default dependencies for packaging")
 endif()
 


### PR DESCRIPTION
The created .deb will search for the packages in this list when installed. The old packages don't exist and the install process ends up with an error:

`The following packages have unmet dependencies:`
` libiio : Depends: libaio (>= 0.3.109) but it is not installable`
          `Depends: libavahi-client (>= 0.6.31) but it is not installable`
        `  Depends: libavahi-common (>= 0.6.31) but it is not installable`

Signed-off-by: AlexandraTrifan <Alexandra.Trifan@analog.com>