### PR TITLE
iio-debug.h: Don't set errno variable

### DIFF
--- a/include/iio/iio-debug.h
+++ b/include/iio/iio-debug.h
@@ -66,7 +66,6 @@ iio_prm_printf(const struct iio_context_params *params,
 	iio_strerror(_err, _buf, sizeof(_buf));				\
 	prm_err(params, __FIRST(__VA_ARGS__, 0)				\
 		__OTHERS(": %s\n",__VA_ARGS__, _buf));			\
-	errno = _err;							\
 } while (0)
 #define ctx_perror(ctx, err, ...)	prm_perror(__ctx_params_or_null(ctx), err, __VA_ARGS__)
 #define dev_perror(dev, err, ...)	ctx_perror(__dev_ctx_or_null(dev), err, __VA_ARGS__)


### PR DESCRIPTION
We don't need/want to set the errno variable anymore. Besides, the
header does not include <errno.h>.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>