### PR TITLE
Remove python bindings to convert method

### DIFF
--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -593,10 +593,6 @@ _channel_get_type = _lib.iio_channel_get_type
 _channel_get_type.restype = c_int
 _channel_get_type.argtypes = (_ChannelPtr,)
 
-_channel_convert_inverse = _lib.iio_channel_convert_inverse
-_channel_convert_inverse.restype = None
-_channel_convert_inverse.argtypes = (_ChannelPtr, c_void_p, c_void_p)
-
 _create_buffer = _lib.iio_device_create_buffer
 _create_buffer.restype = _BufferPtr
 _create_buffer.argtypes = (
@@ -961,19 +957,6 @@ class Channel(object):
         type: iio.ChannelType(Enum)
         """
         return ChannelType(_channel_get_type(self._channel))
-
-    def convert_inverse(self, dst, src):
-        """
-        Convert the sample from host format to hardware format.
-
-        :param dst: type=list
-            The variable where the result is stored.
-        :param src: type=list
-            Data to be converted.
-        """
-        src_ptr = cast((c_char * (len(src) * self.data_format.length))(*src), c_void_p)
-        dst_ptr = cast((c_char * (len(dst) * self.data_format.length))(*dst), c_void_p)
-        _channel_convert_inverse(self._channel, src_ptr, dst_ptr)
 
 
 class Buffer(object):

--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -593,10 +593,6 @@ _channel_get_type = _lib.iio_channel_get_type
 _channel_get_type.restype = c_int
 _channel_get_type.argtypes = (_ChannelPtr,)
 
-_channel_convert = _lib.iio_channel_convert
-_channel_convert.restype = None
-_channel_convert.argtypes = (_ChannelPtr, c_void_p, c_void_p)
-
 _channel_convert_inverse = _lib.iio_channel_convert_inverse
 _channel_convert_inverse.restype = None
 _channel_convert_inverse.argtypes = (_ChannelPtr, c_void_p, c_void_p)
@@ -965,19 +961,6 @@ class Channel(object):
         type: iio.ChannelType(Enum)
         """
         return ChannelType(_channel_get_type(self._channel))
-
-    def convert(self, dst, src):
-        """
-        Convert src and saves the result in dst, using current channel's data format.
-
-        :param dst: type=list
-            The variable where the result is stored.
-        :param src: type=list
-            Data to be converted.
-        """
-        src_ptr = cast((c_char * (len(src) * self.data_format.length))(*src), c_void_p)
-        dst_ptr = cast((c_char * (len(dst) * self.data_format.length))(*dst), c_void_p)
-        _channel_convert(self._channel, src_ptr, dst_ptr)
 
     def convert_inverse(self, dst, src):
         """


### PR DESCRIPTION
The convert method from the Channel class had no functionality and the
read method performs the desired operation without requiring external
loops. Removing the method and dependent ctype definitions.

Signed-off-by: Travis F. Collins <travis.collins@analog.com>