### PR TITLE
CMakeLists.txt: fix static build with libusb and -latomic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,8 +149,14 @@ endif()
 
 option(WITH_USB_BACKEND "Enable the libusb backend" ON)
 if (WITH_USB_BACKEND)
-	#Handle FreeBSD libusb and Linux libusb-1.0 libraries
-	find_library(LIBUSB_LIBRARIES NAMES usb-1.0 usb)
+	find_package(PkgConfig)
+	if (PkgConfig_FOUND)
+		pkg_check_modules(LIBUSB libusb-1.0)
+		if (NOT LIBUSB_FOUND)
+			#Handle FreeBSD libusb and Linux libusb-1.0 libraries
+			find_library(LIBUSB_LIBRARIES NAMES usb-1.0 usb)
+		endif()
+	endif()
 	find_path(LIBUSB_INCLUDE_DIR libusb.h PATH_SUFFIXES libusb-1.0)
 	if (NOT LIBUSB_LIBRARIES OR NOT LIBUSB_INCLUDE_DIR)
 		message(SEND_ERROR "Unable to find libusb-1.0 dependency.\n"


### PR DESCRIPTION
Use pkg-config to retrieve libusb dependencies such as `-latomic` and avoid the following static build failure:

```
/home/autobuild/autobuild/instance-4/output-1/host/lib/gcc/arc-buildroot-linux-uclibc/10.2.0/../../../../arc-buildroot-linux-uclibc/bin/ld: /home/autobuild/autobuild/instance-4/output-1/host/arc-buildroot-linux-uclibc/sysroot/lib/libusb-1.0.a(core.o): in function `libusb_ref_device':
core.c:(.text+0x107e): undefined reference to `__atomic_fetch_add_4'
```

Fixes:
 - http://autobuild.buildroot.org/results/3f421d6dfb48371f3fbc33fb25d23ad8f12a01d9

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>