### PR TITLE
CMake: When using pkg-config, link libusb using its full path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,8 @@ if (WITH_USB_BACKEND)
 		if (NOT LIBUSB_FOUND)
 			#Handle FreeBSD libusb and Linux libusb-1.0 libraries
 			find_library(LIBUSB_LIBRARIES NAMES usb-1.0 usb)
+		else()
+			set(LIBUSB_LIBRARIES ${LIBUSB_LINK_LIBRARIES})
 		endif()
 	endif()
 	find_path(LIBUSB_INCLUDE_DIR libusb.h PATH_SUFFIXES libusb-1.0)


### PR DESCRIPTION
When libusb-1.0 is detected using pkg-config, we should include the
library's directory to the link path.

Since target_link_directories() is not available in the minimum version
of CMake that we support, override LIBUSB_LIBRARIES with the full path
to the library, to ensure that it will build fine even if the library is
installed at a non-standard path.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>