### PR TITLE
Update ARM builds to use --platform flag

### DIFF
--- a/CI/azure/ci-ubuntu.sh
+++ b/CI/azure/ci-ubuntu.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -x
 uname -a
-DEBIAN_FRONTEND=noninteractive apt update
-DEBIAN_FRONTEND=noninteractive apt -y upgrade
-DEBIAN_FRONTEND=noninteractive apt install -y bison flex cmake git build-essential libxml2-dev doxygen
-DEBIAN_FRONTEND=noninteractive apt install -y python3 python3-sphinx python3-setuptools
 echo "$PWD"
 mkdir build && cd build
 cmake .. -DWITH_HWMON=ON -DWITH_SERIAL_BACKEND=ON -DWITH_EXAMPLES=ON -DPYTHON_BINDINGS=ON -DENABLE_PACKAGING=ON -DCPACK_SYSTEM_NAME="${ARTIFACTNAME}"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -273,7 +273,7 @@ stages:
       displayName: 'Setup'
     - script: |
         set -e
-        sudo docker run --rm -t --privileged -e ARTIFACTNAME=$(artifactName) -v "$(Agent.BuildDirectory)/s":"/ci" -v "/usr/bin/qemu-$(arch)-static":"/usr/bin/qemu-$(arch)-static" "$(image)" /bin/bash -c "cd /ci/ && chmod +x ./CI/azure/$(build_script) && ./CI/azure/$(build_script)"
+        sudo docker run --platform "linux/$(arch)" --rm -t --privileged -e ARTIFACTNAME=$(artifactName) -v "$(Agent.BuildDirectory)/s":"/ci" -v "/usr/bin/qemu-$(arch)-static":"/usr/bin/qemu-$(arch)-static" "$(image)" /bin/bash -c "cd /ci/ && chmod +x ./CI/azure/$(build_script) && ./CI/azure/$(build_script)"
       displayName: 'Build'
     - task: CopyFiles@2
       inputs:


### PR DESCRIPTION
This coincides with an upstream fix from https://github.com/sdgtt/Dockerfiles/pull/13 which uses the updated buildx API. My guess is that when the default image from Azure switched from 18.04 to 20.04, and as a result the version of docker changed, this broke the ARM builds.

This change updates the Azure pipeline to include the new required --platform argument

Signed-off-by: Travis F. Collins <travis.collins@analog.com>