### PR TITLE
ci: Build man pages as part of documentation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ stages:
     - script: |
         set -e
         mkdir build && cd build
-        cmake .. -DENABLE_PACKAGING=ON -DPYTHON_BINDINGS=ON -DWITH_DOC=ON -DCPACK_SYSTEM_NAME=${ARTIFACTNAME}
+        cmake .. -DENABLE_PACKAGING=ON -DPYTHON_BINDINGS=ON -DWITH_DOC=ON -DWITH_MAN=ON -DCPACK_SYSTEM_NAME=${ARTIFACTNAME}
         make
         make package
       displayName: 'Build'


### PR DESCRIPTION
The main page of the documentation points to the man pages, so these
must be generated too.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>