### PR TITLE
Rework XML context creation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -271,6 +271,7 @@ stages:
     steps:
     - script: |
         set -e
+        sudo apt-get update
         sudo apt-get install -y gcc-arm-linux-gnueabihf libc6-dev-armhf-cross
         sudo apt-get install -y g++-arm-linux-gnueabihf
         sudo apt-get install -y g++-aarch64-linux-gnu

--- a/context.c
+++ b/context.c
@@ -483,14 +483,6 @@ struct iio_context * iio_create_context(const struct iio_context_params *params,
 	return ctx;
 }
 
-struct iio_context * iio_create_xml_context_mem(const char *xml, size_t len)
-{
-	if (WITH_XML_BACKEND)
-		return xml_create_context_mem(&default_params, xml, len);
-
-	return iio_ptr(-ENOSYS);
-}
-
 unsigned int iio_context_get_attrs_count(const struct iio_context *ctx)
 {
 	return ctx->nb_attrs;

--- a/context.c
+++ b/context.c
@@ -421,11 +421,6 @@ struct iio_context * iio_context_clone(const struct iio_context *ctx)
 	return iio_ptr(-ENOSYS);
 }
 
-struct iio_context * iio_create_context_from_uri(const char *uri)
-{
-	return iio_create_context(NULL, uri);
-}
-
 const struct iio_backend *iio_backends[] = {
 	IF_ENABLED(WITH_LOCAL_BACKEND, &iio_local_backend),
 	IF_ENABLED(WITH_NETWORK_BACKEND && !WITH_NETWORK_BACKEND_DYNAMIC,

--- a/context.c
+++ b/context.c
@@ -589,8 +589,7 @@ int iio_context_add_attr(struct iio_context *ctx,
 
 struct iio_context *
 iio_create_context_from_xml(const struct iio_context_params *params,
-			    const char *xml, size_t xml_len,
-			    const struct iio_backend *backend,
+			    const char *uri, const struct iio_backend *backend,
 			    const char *description, const char **ctx_attrs,
 			    const char **ctx_values, unsigned int nb_ctx_attrs)
 {
@@ -603,7 +602,7 @@ iio_create_context_from_xml(const struct iio_context_params *params,
 	if (!WITH_XML_BACKEND)
 		return iio_ptr(-ENOSYS);
 
-	ctx = xml_create_context_mem(params, xml, xml_len);
+	ctx = iio_create_context(params, uri);
 	if (iio_err(ctx))
 		return ctx;
 

--- a/iio-private.h
+++ b/iio-private.h
@@ -217,8 +217,6 @@ int write_double(char *buf, size_t len, double val);
 
 bool iio_list_has_elem(const char *list, const char *elem);
 
-struct iio_context * xml_create_context_mem(const struct iio_context_params *params,
-					    const char *xml, size_t len);
 struct iio_context *
 iio_create_dynamic_context(const struct iio_context_params *params,
 			   const char *uri);

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -165,8 +165,7 @@ __api size_t iio_strlcpy(char * __restrict dst, const char * __restrict src, siz
 
 __api struct iio_context *
 iio_create_context_from_xml(const struct iio_context_params *params,
-			    const char *xml, size_t len,
-			    const struct iio_backend *backend,
+			    const char *uri, const struct iio_backend *backend,
 			    const char *description, const char **ctx_attr,
 			    const char **ctx_values, unsigned int nb_ctx_attrs);
 

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -415,18 +415,6 @@ __api __check_ret __cnst const char * iio_get_backend(unsigned int index);
  * @brief Contains the representation of an IIO context */
 
 
-/** @brief Create a context from XML data in memory
- * @param xml Pointer to the XML data in memory
- * @param len Length of the XML string in memory (excluding the final \0)
- * @return On success, A pointer to an iio_context structure
- * @return On failure, a pointer-encoded error is returned
- *
- * <b>NOTE:</b> The format of the XML must comply to the one returned by
- * iio_context_get_xml */
-__api __check_ret struct iio_context * iio_create_xml_context_mem(
-		const char *xml, size_t len);
-
-
 /** @brief Create a context from a URI description
  * @param params A pointer to a iio_context_params structure that contains
  *   context creation information; can be NULL

--- a/xml.c
+++ b/xml.c
@@ -18,6 +18,9 @@
 static struct iio_context *
 xml_create_context(const struct iio_context_params *params,
 		   const char *xml_file);
+static struct iio_context *
+xml_create_context_mem(const struct iio_context_params *params,
+		       const char *xml, size_t len);
 
 static int add_attr_to_channel(struct iio_channel *chn, xmlNode *n)
 {
@@ -496,13 +499,12 @@ xml_create_context(const struct iio_context_params *params, const char *arg)
 	return ctx;
 }
 
-struct iio_context * xml_create_context_mem(const struct iio_context_params *params,
-					    const char *xml, size_t len)
+static struct iio_context *
+xml_create_context_mem(const struct iio_context_params *params,
+		       const char *xml, size_t len)
 {
 	struct iio_context *ctx;
 	xmlDoc *doc;
-
-	LIBXML_TEST_VERSION;
 
 	doc = xmlReadMemory(xml, (int) len, NULL, NULL, XML_PARSE_DTDVALID);
 	if (!doc) {

--- a/xml.c
+++ b/xml.c
@@ -13,6 +13,8 @@
 #include <libxml/tree.h>
 #include <string.h>
 
+#define XML_HEADER "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+
 static struct iio_context *
 xml_create_context(const struct iio_context_params *params,
 		   const char *xml_file);
@@ -470,15 +472,20 @@ iio_create_xml_context_helper(const struct iio_context_params *params,
 }
 
 static struct iio_context *
-xml_create_context(const struct iio_context_params *params,
-		   const char *xml_file)
+xml_create_context(const struct iio_context_params *params, const char *arg)
 {
 	struct iio_context *ctx;
 	xmlDoc *doc;
 
 	LIBXML_TEST_VERSION;
 
-	doc = xmlReadFile(xml_file, NULL, XML_PARSE_DTDVALID);
+	if (!strncmp(arg, XML_HEADER, sizeof(XML_HEADER) - 1)) {
+		doc = xmlReadMemory(arg, (int) strlen(arg),
+				    NULL, NULL, XML_PARSE_DTDVALID);
+	} else {
+		doc = xmlReadFile(arg, NULL, XML_PARSE_DTDVALID);
+	}
+
 	if (!doc) {
 		prm_err(params, "Unable to parse XML file\n");
 		return iio_ptr(-EINVAL);


### PR DESCRIPTION
- Add support for creating a XML from a XML string embedded into a URI
- This means that every possible IIO context can now be created with the single function `iio_create_context`.
- The public function `iio_create_xml_context_mem` is now removed.
- The IIOD client code will now build a URI using the received XML string, and create a IIO context the standard way.