### PR TITLE
libiio / iiod async interface fixes

### DIFF
--- a/block.c
+++ b/block.c
@@ -86,8 +86,10 @@ void iio_block_destroy(struct iio_block *block)
 	/* Stop the cyclic task */
 	block->cyclic = false;
 
-	if (block->token)
+	if (block->token) {
+		iio_task_cancel(block->token);
 		iio_task_sync(block->token, 0);
+	}
 	if (ops->free_block && block->pdata)
 		ops->free_block(block->pdata);
 	else

--- a/buffer.c
+++ b/buffer.c
@@ -174,7 +174,7 @@ void iio_buffer_destroy(struct iio_buffer *buf)
 }
 
 const struct iio_channels_mask *
-iio_buffer_get_channels_mask(struct iio_buffer *buf)
+iio_buffer_get_channels_mask(const struct iio_buffer *buf)
 {
 	return buf->mask;
 }

--- a/context.c
+++ b/context.c
@@ -591,7 +591,7 @@ iio_create_context_from_xml(const struct iio_context_params *params,
 	for (i = 0; i < nb_ctx_attrs; i++) {
 		ret = iio_context_add_attr(ctx, ctx_attrs[i], ctx_values[i]);
 		if (ret < 0) {
-			prm_perror(params, ret, "Unable to add context attribute\n");
+			prm_perror(params, ret, "Unable to add context attribute");
 			goto err_context_destroy;
 		}
 	}
@@ -601,7 +601,7 @@ iio_create_context_from_xml(const struct iio_context_params *params,
 				   ctx->description, description);
 		if (len < 0) {
 			ret = (int) len;
-			prm_perror(params, ret, "Unable to set context description\n");
+			prm_perror(params, ret, "Unable to set context description");
 			goto err_context_destroy;
 		}
 

--- a/dynamic-unix.c
+++ b/dynamic-unix.c
@@ -20,7 +20,7 @@ void iio_dlclose(void *lib)
 	dlclose(lib);
 }
 
-const void * iio_dlsym(void *lib, const char *symbol)
+void * iio_dlsym(void *lib, const char *symbol)
 {
 	return dlsym(lib, symbol);
 }

--- a/dynamic-windows.c
+++ b/dynamic-windows.c
@@ -17,10 +17,10 @@ void * iio_dlopen(const char *path)
 
 void iio_dlclose(void *lib)
 {
-	FreeLibrary((void *) module);
+	FreeLibrary((void *) lib);
 }
 
-const void * iio_dlsym(void *lib, const char *symbol)
+void * iio_dlsym(void *lib, const char *symbol)
 {
-	return (const void *) GetProcAddress(lib, symbol);
+	return (void *) GetProcAddress(lib, symbol);
 }

--- a/dynamic.c
+++ b/dynamic.c
@@ -7,10 +7,11 @@
  */
 
 #include "dynamic.h"
-#include "iio-backend.h"
 #include "iio-config.h"
-#include "iio-debug.h"
 #include "iio-private.h"
+
+#include <iio/iio-backend.h>
+#include <iio/iio-debug.h>
 
 #include <errno.h>
 #include <stdio.h>

--- a/dynamic.h
+++ b/dynamic.h
@@ -11,6 +11,6 @@
 
 void * iio_dlopen(const char *path);
 void iio_dlclose(void *lib);
-const void * iio_dlsym(void *lib, const char *symbol);
+void * iio_dlsym(void *lib, const char *symbol);
 
 #endif /* __IIO_DYNAMIC_H */

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -535,6 +535,9 @@ static ssize_t iiod_client_read_attr_new(struct iiod_client *client,
 			if (!strcmp(iio_channel_get_attr(chn, i), attr))
 				break;
 
+		if (i == iio_channel_get_attrs_count(chn))
+			return -ENOENT;
+
 		arg1 = (uint16_t) i;
 	} else {
 		switch (type) {
@@ -545,6 +548,9 @@ static ssize_t iiod_client_read_attr_new(struct iiod_client *client,
 				if (!strcmp(iio_device_get_attr(dev, i), attr))
 					break;
 
+			if (i == iio_device_get_attrs_count(dev))
+				return -ENOENT;
+
 			arg1 = (uint16_t) i;
 			break;
 		case IIO_ATTR_TYPE_DEBUG:
@@ -554,6 +560,9 @@ static ssize_t iiod_client_read_attr_new(struct iiod_client *client,
 				if (!strcmp(iio_device_get_debug_attr(dev, i), attr))
 					break;
 
+			if (i == iio_device_get_debug_attrs_count(dev))
+				return -ENOENT;
+
 			arg1 = (uint16_t) i;
 			break;
 		case IIO_ATTR_TYPE_BUFFER:
@@ -562,6 +571,9 @@ static ssize_t iiod_client_read_attr_new(struct iiod_client *client,
 			for (i = 0; i < iio_device_get_buffer_attrs_count(dev); i++)
 				if (!strcmp(iio_device_get_buffer_attr(dev, i), attr))
 					break;
+
+			if (i == iio_device_get_buffer_attrs_count(dev))
+				return -ENOENT;
 
 			arg1 = (uint16_t) i;
 			arg2 = (uint16_t) buf_id;
@@ -698,6 +710,9 @@ static ssize_t iiod_client_write_attr_new(struct iiod_client *client,
 			if (!strcmp(iio_channel_get_attr(chn, i), attr))
 				break;
 
+		if (i == iio_channel_get_attrs_count(chn))
+			return -ENOENT;
+
 		arg1 = (uint16_t) i;
 	} else {
 		switch (type) {
@@ -708,6 +723,9 @@ static ssize_t iiod_client_write_attr_new(struct iiod_client *client,
 				if (!strcmp(iio_device_get_attr(dev, i), attr))
 					break;
 
+			if (i == iio_device_get_attrs_count(dev))
+				return -ENOENT;
+
 			arg1 = (uint16_t) i;
 			break;
 		case IIO_ATTR_TYPE_DEBUG:
@@ -717,6 +735,9 @@ static ssize_t iiod_client_write_attr_new(struct iiod_client *client,
 				if (!strcmp(iio_device_get_debug_attr(dev, i), attr))
 					break;
 
+			if (i == iio_device_get_debug_attrs_count(dev))
+				return -ENOENT;
+
 			arg1 = (uint16_t) i;
 			break;
 		case IIO_ATTR_TYPE_BUFFER:
@@ -725,6 +746,9 @@ static ssize_t iiod_client_write_attr_new(struct iiod_client *client,
 			for (i = 0; i < iio_device_get_buffer_attrs_count(dev); i++)
 				if (!strcmp(iio_device_get_buffer_attr(dev, i), attr))
 					break;
+
+			if (i == iio_device_get_buffer_attrs_count(dev))
+				return -ENOENT;
 
 			arg1 = (uint16_t) i;
 			arg2 = (uint16_t) buf_id;

--- a/iiod-responder.c
+++ b/iiod-responder.c
@@ -376,13 +376,18 @@ static int iiod_enqueue_command(struct iiod_io *writer, uint8_t op,
 
 bool iiod_io_command_is_done(struct iiod_io *io)
 {
-	uint64_t timeout_us = io->timeout_ms * 1000;
+	uint64_t timeout_us;
 	bool done;
 
 	iio_mutex_lock(io->lock);
 
-	done = (io->write_token && iio_task_is_done(io->write_token)) ||
-		(read_counter_us() - io->w_io.start_time > timeout_us);
+	done = io->write_token && iio_task_is_done(io->write_token);
+
+	if (!done && io->timeout_ms) {
+		timeout_us = io->timeout_ms * 1000;
+
+		done = read_counter_us() - io->w_io.start_time > timeout_us;
+	}
 
 	iio_mutex_unlock(io->lock);
 
@@ -391,7 +396,7 @@ bool iiod_io_command_is_done(struct iiod_io *io)
 
 int iiod_io_wait_for_command_done(struct iiod_io *io)
 {
-	uint64_t diff_ms, timeout_ms = io->timeout_ms;
+	uint64_t diff_ms = 0, timeout_ms = io->timeout_ms;
 	struct iio_task_token *token;
 
 	iio_mutex_lock(io->lock);
@@ -402,10 +407,12 @@ int iiod_io_wait_for_command_done(struct iiod_io *io)
 	if (!token)
 		return 0;
 
-	diff_ms = (read_counter_us() - io->w_io.start_time) / 1000;
+	if (timeout_ms) {
+		diff_ms = (read_counter_us() - io->w_io.start_time) / 1000;
 
-	if (diff_ms >= timeout_ms)
-		iio_task_cancel(token);
+		if (diff_ms >= timeout_ms)
+			iio_task_cancel(token);
+	}
 
 	return iio_task_sync(token, (unsigned int)(timeout_ms - diff_ms));
 }
@@ -414,13 +421,23 @@ bool iiod_io_has_response(struct iiod_io *io)
 {
 	uint64_t timeout_us = io->timeout_ms * 1000;
 
-	return io->r_done ||
-		(read_counter_us() - io->w_io.start_time > timeout_us);
+	if (io->r_done)
+		return true;
+
+	if (!io->timeout_ms)
+		return false;
+
+	timeout_us = io->timeout_ms * 1000;
+
+	return read_counter_us() - io->w_io.start_time > timeout_us;
 }
 
 static int iiod_io_cond_wait(const struct iiod_io *io)
 {
 	uint64_t diff_ms, timeout_ms = io->timeout_ms;
+
+	if (!timeout_ms)
+		return iio_cond_wait(io->cond, io->lock, 0);
 
 	diff_ms = (read_counter_us() - io->r_io.start_time) / 1000;
 

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1206,7 +1206,7 @@ __api int iio_buffer_disable(struct iio_buffer *buf);
  * <b>NOTE:</b> The mask returned may contain more enabled channels than
  * the mask used for creating the buffer. */
 __api const struct iio_channels_mask *
-iio_buffer_get_channels_mask(struct iio_buffer *buf);
+iio_buffer_get_channels_mask(const struct iio_buffer *buf);
 
 
 /** @} *//* ------------------------------------------------------------------*/

--- a/include/iio/iiod-client.h
+++ b/include/iio/iiod-client.h
@@ -24,6 +24,7 @@ struct iiod_client_ops {
 			char *dst, size_t len, unsigned int timeout_ms);
 	ssize_t (*read_line)(struct iiod_client_pdata *desc,
 			     char *dst, size_t len, unsigned int timeout_ms);
+	void (*cancel)(struct iiod_client_pdata *desc);
 };
 
 __api void iiod_client_mutex_lock(struct iiod_client *client);

--- a/network.c
+++ b/network.c
@@ -77,10 +77,12 @@ network_write_data(struct iiod_client_pdata *io_ctx, const char *src, size_t len
 static ssize_t
 network_read_data(struct iiod_client_pdata *io_ctx, char *dst, size_t len,
 		  unsigned int timeout_ms);
+static void network_cancel(struct iiod_client_pdata *io_ctx);
 
 static const struct iiod_client_ops network_iiod_client_ops = {
 	.write = network_write_data,
 	.read = network_read_data,
+	.cancel = network_cancel,
 };
 
 static ssize_t network_recv(struct iiod_client_pdata *io_ctx, void *data,

--- a/network.c
+++ b/network.c
@@ -504,8 +504,7 @@ err_free_buf:
 void network_free_buffer(struct iio_buffer_pdata *pdata)
 {
 	iiod_client_free_buffer(pdata->pdata);
-	iiod_client_destroy(pdata->iiod_client);
-	cleanup_cancel(&pdata->io_ctx);
+	network_free_iiod_client(pdata->iiod_client, &pdata->io_ctx);
 	free(pdata);
 }
 


### PR DESCRIPTION
Some fixes for the new libiio / IIOD async. interface.

- Fix IIOD sometimes answering a -ETIMEDOUT (-110) error, as the iiod_responder code did not handle infinite timeouts properly;
- Fix deadlock on client side occurring when the context creation failed (e.g. when IIOD returns a timeout...);
- Fix IIOD not understanding "write attribute" commands;
- Fix iiod-client sending invalid commands when trying to access an attribute that does not exist;
- Fix the network backend not destroying the iiod-client properly.
- Fix the dynamic loading code which was completely broken (wrong include paths on Linux, undefined variable on Windows)
- Fix prototype of iio_buffer_get_channels_mask()
- Remove carriage returns at the end of strings used in prm_perror
- Fix iio_block_destroy() blocking until timeout happens