### PR TITLE
Remove iio_context_clone()

### DIFF
--- a/context.c
+++ b/context.c
@@ -406,14 +406,6 @@ int iio_context_set_timeout(struct iio_context *ctx, unsigned int timeout)
 	return 0;
 }
 
-struct iio_context * iio_context_clone(const struct iio_context *ctx)
-{
-	if (ctx->ops->clone)
-		return ctx->ops->clone(ctx);
-
-	return iio_ptr(-ENOSYS);
-}
-
 const struct iio_backend *iio_backends[] = {
 	IF_ENABLED(WITH_LOCAL_BACKEND, &iio_local_backend),
 	IF_ENABLED(WITH_NETWORK_BACKEND && !WITH_NETWORK_BACKEND_DYNAMIC,

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -68,7 +68,6 @@ struct iio_backend_ops {
 		    struct iio_scan *ctx, const char *args);
 	struct iio_context * (*create)(const struct iio_context_params *params,
 				       const char *uri);
-	struct iio_context * (*clone)(const struct iio_context *ctx);
 
 	ssize_t (*read_device_attr)(const struct iio_device *dev,
 				    unsigned int buf_id, const char *attr,

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -467,17 +467,6 @@ __api __check_ret struct iio_context *
 iio_create_context(const struct iio_context_params *params, const char *uri);
 
 
-/** @brief Duplicate a pre-existing IIO context
- * @param ctx A pointer to an iio_context structure
- * @return On success, A pointer to an iio_context structure
- * @return On failure, a pointer-encoded error is returned
- *
- * <b>NOTE:</b> This function is not supported on 'usb:' contexts, since libusb
- * can only claim the interface once. "Function not implemented" is the expected errno.
- * Any context which is cloned, must be destroyed via calling iio_context_destroy() */
-__api __check_ret struct iio_context * iio_context_clone(const struct iio_context *ctx);
-
-
 /** @brief Destroy the given context
  * @param ctx A pointer to an iio_context structure
  *

--- a/local.c
+++ b/local.c
@@ -1393,11 +1393,6 @@ static void local_cancel_buffer(struct iio_buffer_pdata *pdata)
 	}
 }
 
-static struct iio_context * local_clone(const struct iio_context *ctx)
-{
-	return local_create_context(&ctx->params, "");
-}
-
 static char * local_get_description(const struct iio_context *ctx)
 {
 	char *description;
@@ -1588,7 +1583,6 @@ int local_dequeue_block(struct iio_block_pdata *pdata, bool nonblock)
 static const struct iio_backend_ops local_ops = {
 	.scan = local_context_scan,
 	.create = local_create_context,
-	.clone = local_clone,
 	.read_device_attr = local_read_dev_attr,
 	.write_device_attr = local_write_dev_attr,
 	.read_channel_attr = local_read_chn_attr,

--- a/network.c
+++ b/network.c
@@ -456,14 +456,6 @@ static int network_set_timeout(struct iio_context *ctx, unsigned int timeout)
 	return 0;
 }
 
-static struct iio_context * network_clone(const struct iio_context *ctx)
-{
-	const struct iio_context_params *params = iio_context_get_params(ctx);
-	const char *addr = iio_context_get_attr_value(ctx, "ip,ip-addr");
-
-	return network_create_context(params, addr);
-}
-
 static struct iio_buffer_pdata *
 network_create_buffer(const struct iio_device *dev, unsigned int idx,
 		      struct iio_channels_mask *mask)
@@ -530,7 +522,6 @@ struct iio_block_pdata * network_create_block(struct iio_buffer_pdata *pdata,
 static const struct iio_backend_ops network_ops = {
 	.scan = IF_ENABLED(HAVE_DNS_SD, dnssd_context_scan),
 	.create = network_create_context,
-	.clone = network_clone,
 	.read_device_attr = network_read_dev_attr,
 	.write_device_attr = network_write_dev_attr,
 	.read_channel_attr = network_read_chn_attr,

--- a/xml.c
+++ b/xml.c
@@ -18,9 +18,6 @@
 static struct iio_context *
 xml_create_context(const struct iio_context_params *params,
 		   const char *xml_file);
-static struct iio_context *
-xml_create_context_mem(const struct iio_context_params *params,
-		       const char *xml, size_t len);
 
 static int add_attr_to_channel(struct iio_channel *chn, xmlNode *n)
 {
@@ -332,14 +329,8 @@ err_free_device:
 	return iio_ptr(err);
 }
 
-static struct iio_context * xml_clone(const struct iio_context *ctx)
-{
-	return xml_create_context_mem(&ctx->params, ctx->xml, strlen(ctx->xml));
-}
-
 static const struct iio_backend_ops xml_ops = {
 	.create = xml_create_context,
-	.clone = xml_clone,
 };
 
 const struct iio_backend iio_xml_backend = {
@@ -498,25 +489,6 @@ xml_create_context(const struct iio_context_params *params, const char *arg)
 	xmlFreeDoc(doc);
 	return ctx;
 }
-
-static struct iio_context *
-xml_create_context_mem(const struct iio_context_params *params,
-		       const char *xml, size_t len)
-{
-	struct iio_context *ctx;
-	xmlDoc *doc;
-
-	doc = xmlReadMemory(xml, (int) len, NULL, NULL, XML_PARSE_DTDVALID);
-	if (!doc) {
-		prm_err(params, "Unable to parse XML file\n");
-		return iio_ptr(-EINVAL);
-	}
-
-	ctx = iio_create_xml_context_helper(params, doc);
-	xmlFreeDoc(doc);
-	return ctx;
-}
-
 
 static void cleanup_libxml2_stuff(void)
 {


### PR DESCRIPTION
Cloning a context is a trivial operation with the new API. It is enough
to retrieve the context's params with `iio_context_get_params` and the
context's URI with `iio_context_find_attr(ctx, "uri")`, and call
`iio_context_create` with these.