### PR TITLE
ad9361-iiostream: Fix rf_port_select for PlutoSDR devices

### DIFF
--- a/examples/ad9361-iiostream.c
+++ b/examples/ad9361-iiostream.c
@@ -15,6 +15,7 @@
 #include <string.h>
 #include <signal.h>
 #include <stdio.h>
+#include <errno.h>
 
 /* helper macros */
 #define MHZ(x) ((long long)(x*1000000.0 + .5))
@@ -162,7 +163,12 @@ bool cfg_ad9361_streaming_ch(struct stream_cfg *cfg, enum iodev type, int chid)
 	// Configure phy and lo channels
 	printf("* Acquiring AD9361 phy channel %d\n", chid);
 	if (!get_phy_chan(type, chid, &chn)) {	return false; }
-	wr_ch_str(chn, "rf_port_select",     cfg->rfport);
+	int ret = iio_channel_attr_write_string(chn, "rf_port_select", cfg->rfport);
+	if (ret == -EINVAL)
+		printf("Error writing %s to channel \"rf_port_select\"\nThis error can be ignored for PlutoSDR and derivatives.\n",
+                        cfg->rfport);
+	else
+		errchk(ret, "rf_port_select");
 	wr_ch_lli(chn, "rf_bandwidth",       cfg->bw_hz);
 	wr_ch_lli(chn, "sampling_frequency", cfg->fs_hz);
 


### PR DESCRIPTION
PlutoSDR devices don't support changing the rf_port_select attribute,
because its fixed in the device tree. Therefore this error should not lead
to a shutdown for these type of devices.

Fixes: https://github.com/analogdevicesinc/libiio/issues/894

Signed-off-by: Benjamin Menküc <benjamin@menkuec.de>