### PR TITLE
iiod-client: Dequeueing an already dequeued block is not an error

### DIFF
--- a/block.c
+++ b/block.c
@@ -153,7 +153,7 @@ int iio_block_enqueue(struct iio_block *block, size_t bytes_used, bool cyclic)
 
 	if (block->token) {
 		/* Already enqueued */
-		return -EBUSY;
+		return -EPERM;
 	}
 
 	block->bytes_used = bytes_used;
@@ -185,7 +185,7 @@ int iio_block_dequeue(struct iio_block *block, bool nonblock)
 
 	if (!token) {
 		/* Already dequeued */
-		return 0;
+		return -EPERM;
 	}
 
 	return iio_task_sync(token, 0);

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -1659,7 +1659,7 @@ int iiod_client_enqueue_block(struct iio_block_pdata *block,
 	iio_mutex_lock(block->lock);
 
 	if (block->enqueued) {
-		ret = -EBUSY;
+		ret = -EPERM;
 		goto out_unlock;
 	}
 
@@ -1686,7 +1686,7 @@ int iiod_client_dequeue_block(struct iio_block_pdata *block, bool nonblock)
 	iio_mutex_lock(block->lock);
 
 	if (!block->enqueued) {
-		ret = -EBADF;
+		ret = -EPERM;
 		goto out_unlock;
 	}
 

--- a/local-mmap.c
+++ b/local-mmap.c
@@ -198,7 +198,7 @@ int local_enqueue_mmap_block(struct iio_block_pdata *pdata,
 	mask = atomic_fetch_or(&buf->pdata->mmap_enqueued_blocks_mask, BIT(priv->idx));
 	if (mask & BIT(priv->idx)) {
 		/* Already enqueued */
-		return -EBUSY;
+		return -EPERM;
 	}
 
 	priv->block.bytes_used = (uint32_t) bytes_used;
@@ -225,7 +225,7 @@ int local_dequeue_mmap_block(struct iio_block_pdata *pdata, bool nonblock)
 
 	if (!(atomic_load(&buf->pdata->mmap_enqueued_blocks_mask) & BIT(priv->idx))) {
 		/* Already dequeued */
-		return 0;
+		return -EPERM;
 	}
 
 	if (!nonblock) {

--- a/local.h
+++ b/local.h
@@ -33,6 +33,7 @@ struct iio_block_pdata {
 	struct iio_block_impl_pdata *pdata;
 	size_t size;
 	void *data;
+	bool dequeued;
 };
 
 int ioctl_nointr(int fd, unsigned long request, void *data);

--- a/stream.c
+++ b/stream.c
@@ -105,16 +105,6 @@ iio_stream_get_next_block(struct iio_stream *stream)
 			return stream->blocks[0];
 	}
 
-	if (!stream->buf_enabled && is_tx) {
-		err = iio_buffer_enable(stream->buffer);
-		if (err) {
-			dev_perror(dev, err, "Unable to enable buffer");
-			return iio_ptr(err);
-		}
-
-		stream->buf_enabled = true;
-	}
-
 	buf_size = is_tx ? stream->buf_size : 0;
 
 	err = iio_block_enqueue(stream->blocks[stream->curr], buf_size, false);
@@ -123,7 +113,7 @@ iio_stream_get_next_block(struct iio_stream *stream)
 		return iio_ptr(err);
 	}
 
-	if (!stream->buf_enabled && !is_tx) {
+	if (!stream->buf_enabled) {
 		err = iio_buffer_enable(stream->buffer);
 		if (err) {
 			dev_perror(dev, err, "Unable to enable buffer");


### PR DESCRIPTION
Dequeueing an already dequeued block is not an error, but a no-op.
Return 0 instead of -EBADF.

Fixes: #901.