### PR TITLE
Fix IIOD's USB interface

### DIFF
--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -93,9 +93,9 @@ struct parser_pdata {
 	bool fd_in_is_socket, fd_out_is_socket;
 	bool is_usb;
 #if WITH_AIO
-	io_context_t aio_ctx;
-	int aio_eventfd;
-	pthread_mutex_t aio_mutex;
+	io_context_t aio_ctx[2];
+	int aio_eventfd[2];
+	pthread_mutex_t aio_mutex[2];
 #endif
 	struct thread_pool *pool;
 	struct iiod_io *io;

--- a/local-mmap.c
+++ b/local-mmap.c
@@ -233,11 +233,11 @@ int local_dequeue_mmap_block(struct iio_block_pdata *pdata, bool nonblock)
 		time_ptr = &start;
 	}
 
-	ret = buffer_check_ready(buf, fd, POLLIN | POLLOUT, time_ptr);
-	if (ret < 0)
-		return ret;
-
 	for (;;) {
+		ret = buffer_check_ready(buf, fd, POLLIN | POLLOUT, time_ptr);
+		if (ret < 0)
+			return ret;
+
 		ret = ioctl_nointr(fd, BLOCK_DEQUEUE_IOCTL, &block);
 		if (ret < 0)
 			return ret;


### PR DESCRIPTION
When using the new async. protocol, IIOD must be able to receive and
send at the same time. This was previously not possible when using AIO.
It didn't seem to matter with the network code, but it did matter with
the USB code.

To address this issue, use two AIO contexts, one for each transfer
direction.