### PR TITLE
CMake: Fix detection of libxml2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,7 +402,7 @@ if (WITH_XML_BACKEND)
 	# So, try first to find the CMake module provided by libxml2 package, then fallback
 	# on the CMake's FindLibXml2.cmake module (which can lack some definition, especially
 	# in static build case).
-	find_package(LibXml2 QUIET NO_MODULE)
+	find_package(LibXml2 QUIET NO_MODULE NO_SYSTEM_ENVIRONMENT_PATH)
 	if(DEFINED LIBXML2_VERSION_STRING)
 		set(LIBXML2_FOUND ON)
 		set(LIBXML2_INCLUDE_DIR ${LIBXML2_INCLUDE_DIRS})


### PR DESCRIPTION
Without the NO_SYSTEM_ENVIRONMENT_PATH option, find_package() would result on my system in a random toolchain's libxml2 library/include paths to be picked, just because it happens to be in $PATH (with a low priority).

Signed-off-by: Paul Cercueil <paul@crapouillou.net>