### PR TITLE
network: Avoid SIGPIPE on send()

### DIFF
--- a/network-unix.c
+++ b/network-unix.c
@@ -132,6 +132,12 @@ int wait_cancellable(struct iiod_client_pdata *io_ctx,
 			return -EBADF;
 	} while (!(pfd[0].revents & (pfd[0].events | POLLERR | POLLHUP)));
 
+	/* If we get POLLHUP when writing, return -EPIPE, otherwise send() will
+	 * get a SIGPIPE. When reading, recv() will return 0 once all bytes have
+	 * been read from the input stream and won't send a SIGPIPE. */
+	if (!read && (pfd[0].revents & POLLHUP))
+		return -EPIPE;
+
 	return 0;
 }
 


### PR DESCRIPTION
Update wait_cancellable() to return -EPIPE if the remote closed the connection or the network link was lost, only when writing; otherwise, a follow-up send() would get a SIGPIPE.

When reading, recv() will return zero as soon as all bytes have been read from the input stream, and won't trigger a SIGPIPE.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>