### PR TITLE
DMABUF API v2

### DIFF
--- a/block.c
+++ b/block.c
@@ -148,6 +148,9 @@ int iio_block_enqueue(struct iio_block *block, size_t bytes_used, bool cyclic)
 	const struct iio_device *dev = buffer->dev;
 	const struct iio_backend_ops *ops = dev->ctx->ops;
 
+	if (bytes_used > block->size)
+		return -EINVAL;
+
 	if (ops->enqueue_block && block->pdata)
 		return ops->enqueue_block(block->pdata, bytes_used, cyclic);
 

--- a/block.c
+++ b/block.c
@@ -307,3 +307,13 @@ struct iio_buffer * iio_block_get_buffer(const struct iio_block *block)
 {
 	return block->buffer;
 }
+
+int iio_block_disable_cpu_access(struct iio_block *block, bool disable)
+{
+	const struct iio_backend_ops *ops = block->buffer->dev->ctx->ops;
+
+	if (ops->disable_cpu_access)
+		return ops->disable_cpu_access(block->pdata, disable);
+
+	return -ENOSYS;
+}

--- a/block.c
+++ b/block.c
@@ -152,6 +152,9 @@ int iio_block_enqueue(struct iio_block *block, size_t bytes_used, bool cyclic)
 	if (bytes_used > block->size)
 		return -EINVAL;
 
+	if (!bytes_used)
+		bytes_used = block->size;
+
 	if (ops->enqueue_block && block->pdata)
 		return ops->enqueue_block(block->pdata, bytes_used, cyclic);
 

--- a/iio-config.h.cmakein
+++ b/iio-config.h.cmakein
@@ -29,6 +29,7 @@
 #cmakedefine01 WITH_NETWORK_EVENTFD
 #cmakedefine01 WITH_IIOD_USBD
 #cmakedefine01 WITH_IIOD_SERIAL
+#cmakedefine01 WITH_IIOD_USB_DMABUF
 #cmakedefine01 WITH_LOCAL_CONFIG
 #cmakedefine01 WITH_LOCAL_DMABUF_API
 #cmakedefine01 WITH_LOCAL_MMAP_API

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -1641,7 +1641,7 @@ int iiod_client_enqueue_block(struct iio_block_pdata *block,
 	struct iiod_command cmd;
 	struct iiod_buf buf[2];
 	bool is_rx = !iio_device_is_tx(pdata->dev);
-	unsigned int nb_buf = 1;
+	unsigned int nb_buf = 1 + !is_rx;
 	int ret = 0;
 
 	cmd.op = cyclic ? IIOD_OP_ENQUEUE_BLOCK_CYCLIC : IIOD_OP_TRANSFER_BLOCK;
@@ -1652,13 +1652,7 @@ int iiod_client_enqueue_block(struct iio_block_pdata *block,
 	buf[0].ptr = &block->bytes_used;
 	buf[0].size = 8;
 	buf[1].ptr = block->data;
-
-	if (is_rx) {
-		buf[1].size = block->size;
-	} else if (bytes_used) {
-		buf[1].size = bytes_used;
-		nb_buf++;
-	}
+	buf[1].size = bytes_used;
 
 	iio_mutex_lock(block->lock);
 

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -1644,9 +1644,6 @@ int iiod_client_enqueue_block(struct iio_block_pdata *block,
 	unsigned int nb_buf = 1;
 	int ret = 0;
 
-	if (bytes_used > block->size)
-		return -EINVAL;
-
 	cmd.op = cyclic ? IIOD_OP_ENQUEUE_BLOCK_CYCLIC : IIOD_OP_TRANSFER_BLOCK;
 	cmd.dev = (uint8_t) iio_device_get_index(pdata->dev);
 	cmd.code = pdata->idx | (block->idx << 16);

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -97,13 +97,13 @@ static ssize_t iiod_client_read_integer(struct iiod_client *client, int *val)
 
 		nb = (unsigned int) ret;
 	} else {
-		start_time = iiod_responder_read_counter_us();
+		start_time = iio_read_counter_us();
 		nb = sizeof(buf);
 	}
 
 	for (i = 0; i < nb; i++) {
 		if (!has_read_line) {
-			diff_ms = (iiod_responder_read_counter_us() - start_time) / 1000;
+			diff_ms = (iio_read_counter_us() - start_time) / 1000;
 
 			if (timeout_ms) {
 				if (diff_ms >= timeout_ms)
@@ -149,13 +149,13 @@ static ssize_t iiod_client_write_all(struct iiod_client *client,
 	uint64_t start_time, diff_ms;
 	ssize_t ret;
 
-	start_time = iiod_responder_read_counter_us();
+	start_time = iio_read_counter_us();
 
 	if (iiod_client_uses_binary_interface(client))
 		timeout_ms = 0;
 
 	while (len) {
-		diff_ms = (iiod_responder_read_counter_us() - start_time) / 1000;
+		diff_ms = (iio_read_counter_us() - start_time) / 1000;
 
 		if (timeout_ms) {
 			if (diff_ms >= timeout_ms)
@@ -204,13 +204,13 @@ static ssize_t iiod_client_read_all(struct iiod_client *client,
 	uint64_t start_time, diff_ms;
 	ssize_t ret;
 
-	start_time = iiod_responder_read_counter_us();
+	start_time = iio_read_counter_us();
 
 	if (iiod_client_uses_binary_interface(client))
 		timeout_ms = 0;
 
 	while (len) {
-		diff_ms = (iiod_responder_read_counter_us() - start_time) / 1000;
+		diff_ms = (iio_read_counter_us() - start_time) / 1000;
 
 		if (timeout_ms) {
 			if (diff_ms >= timeout_ms)

--- a/iiod-responder.h
+++ b/iiod-responder.h
@@ -82,9 +82,6 @@ void iiod_responder_destroy(struct iiod_responder *responder);
 void iiod_responder_set_timeout(struct iiod_responder *priv,
 				unsigned int timeout_ms);
 
-/* Read the current value of the micro-second counter */
-uint64_t iiod_responder_read_counter_us(void);
-
 /* Wait until the iiod_responder stops. */
 void iiod_responder_wait_done(struct iiod_responder *responder);
 

--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -64,6 +64,12 @@ if (WITH_AIO)
 		endif()
 
 		target_sources(iiod PRIVATE usbd.c)
+
+
+		option(WITH_IIOD_USB_DMABUF "Enable DMABUF support on the USB stack" OFF)
+		if (WITH_IIOD_USB_DMABUF)
+			target_sources(iiod PRIVATE usb-dmabuf.c)
+		endif()
 	endif()
 
 	target_include_directories(iiod PRIVATE ${LIBAIO_INCLUDE_DIR})

--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -47,6 +47,7 @@
 
 struct iio_task;
 struct iiod_io;
+struct parser_pdata;
 struct thread_pool;
 extern struct thread_pool *main_thread_pool;
 struct DevEntry;
@@ -64,6 +65,7 @@ struct block_entry {
 	uint64_t bytes_used;
 	uint16_t client_id;
 	bool cyclic;
+	int dmabuf_fd;
 };
 
 struct buffer_entry {
@@ -71,8 +73,10 @@ struct buffer_entry {
 	struct iio_device *dev;
 	struct iio_buffer *buf;
 	struct iio_task *enqueue_task, *dequeue_task;
+	struct parser_pdata *pdata;
 	uint32_t *words;
 	uint16_t idx;
+	bool is_tx;
 };
 
 struct parser_pdata {
@@ -130,6 +134,10 @@ int start_usb_daemon(struct iio_context *ctx, const char *ffs,
 int start_serial_daemon(struct iio_context *ctx, const char *uart_params,
 			bool debug, struct thread_pool *pool,
 			const void *xml_zstd, size_t xml_zstd_len);
+
+int usb_attach_dmabuf(int ep_fd, int fd);
+int usb_detach_dmabuf(int ep_fd, int fd);
+int usb_transfer_dmabuf(int ep_fd, int fd, uint64_t size);
 
 int binary_parse(struct parser_pdata *pdata);
 

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -751,7 +751,7 @@ static void handle_transfer_block(struct parser_pdata *pdata,
 	int ret;
 
 	buf = get_iio_buffer(pdata, cmd, &entry);
-	ret = iio_err(block);
+	ret = iio_err(buf);
 	if (ret)
 		goto out_send_response;
 

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -768,6 +768,12 @@ static void handle_transfer_block(struct parser_pdata *pdata,
 	if (ret < 0)
 		goto out_send_response;
 
+	if (bytes_used == 0) {
+		IIO_ERROR("Cannot enqueue a block with size 0\n");
+		ret =  -EINVAL;
+		goto out_send_response;
+	}
+
 	/* Read the data into the block if we are dealing with a TX buffer */
 	if (iio_buffer_is_tx(buf)) {
 		readbuf.ptr = iio_block_start(block);

--- a/iiod/usb-dmabuf.c
+++ b/iiod/usb-dmabuf.c
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * libiio - Library for interfacing industrial I/O (IIO) devices
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ * Author: Paul Cercueil <paul.cercueil@analog.com>
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/ioctl.h>
+
+#define IIO_FFS_DMABUF_ATTACH	_IOW('g', 131, int)
+#define IIO_FFS_DMABUF_DETACH	_IOW('g', 132, int)
+#define IIO_FFS_DMABUF_TRANSFER	_IOW('g', 133, struct iio_ffs_dmabuf_transfer)
+
+struct iio_ffs_dmabuf_transfer {
+	int fd;
+	uint32_t flags;
+	uint64_t length;
+};
+
+int usb_attach_dmabuf(int ep_fd, int fd)
+{
+	int ret;
+
+	ret = ioctl(ep_fd, IIO_FFS_DMABUF_ATTACH, &fd);
+	if (ret == -1)
+		return -errno;
+
+	return 0;
+}
+
+int usb_detach_dmabuf(int ep_fd, int fd)
+{
+	int ret;
+
+	ret = ioctl(ep_fd, IIO_FFS_DMABUF_DETACH, &fd);
+	if (ret == -1)
+		return -errno;
+
+	return 0;
+}
+
+int usb_transfer_dmabuf(int ep_fd, int fd, uint64_t size)
+{
+	struct iio_ffs_dmabuf_transfer req;
+	int ret;
+
+	req.fd = fd;
+	req.length = size;
+	req.flags = 0;
+
+	ret = ioctl(ep_fd, IIO_FFS_DMABUF_TRANSFER, &req);
+	if (ret == -1)
+		return -errno;
+
+	return 0;
+}

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -116,6 +116,7 @@ struct iio_backend_ops {
 	int (*dequeue_block)(struct iio_block_pdata *pdata, bool nonblock);
 
 	int (*get_dmabuf_fd)(struct iio_block_pdata *pdata);
+	int (*disable_cpu_access)(struct iio_block_pdata *pdata, bool disable);
 };
 
 /**

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -11,6 +11,7 @@
 #include <iio/iio.h>
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #define __api __iio_api
 
@@ -169,6 +170,7 @@ __api __iio_printf ssize_t
 iio_snprintf(char *buf, size_t len, const char *fmt, ...);
 __api char *iio_strdup(const char *str);
 __api size_t iio_strlcpy(char * __restrict dst, const char * __restrict src, size_t dsize);
+__api uint64_t iio_read_counter_us(void);
 
 __api struct iio_context *
 iio_create_context_from_xml(const struct iio_context_params *params,

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1253,6 +1253,14 @@ iio_buffer_create_block(struct iio_buffer *buffer, size_t size);
 __api void iio_block_destroy(struct iio_block *block);
 
 
+/** @brief Get the file descriptor of the underlying DMABUF object
+ * @param block A pointer to an iio_block structure
+ * @return The file descriptor of the underlying DMABUF object.
+ * If the iio_block is not backed by a DMABUF object, -EINVAL is returned.
+ * Otherwise, the file descriptor will be valid until the block is destroyed. */
+__api __check_ret int iio_block_get_dmabuf_fd(const struct iio_block *block);
+
+
 /** @brief Disable CPU access of a given block
  * @param block A pointer to an iio_block structure
  * @param disable Whether or not to disable CPU access

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1313,7 +1313,7 @@ iio_block_foreach_sample(const struct iio_block *block,
 /** @brief Enqueue the given iio_block to the buffer's queue
  * @param block A pointer to an iio_block structure
  * @param bytes_used The amount of data in bytes to be transferred (either
- * transmitted or received).
+ * transmitted or received). If zero, the size of the block is used.
  * @param cyclic If True, enable cyclic mode. The block's content will be
  * repeated on the hardware's output until the buffer is cancelled or destroyed.
  * @return On success, 0 is returned

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1312,8 +1312,8 @@ iio_block_foreach_sample(const struct iio_block *block,
 
 /** @brief Enqueue the given iio_block to the buffer's queue
  * @param block A pointer to an iio_block structure
- * @param bytes_used The size of the data from the iio_block to be written,
- *   in bytes
+ * @param bytes_used The amount of data in bytes to be transferred (either
+ * transmitted or received).
  * @param cyclic If True, enable cyclic mode. The block's content will be
  * repeated on the hardware's output until the buffer is cancelled or destroyed.
  * @return On success, 0 is returned

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1253,6 +1253,17 @@ iio_buffer_create_block(struct iio_buffer *buffer, size_t size);
 __api void iio_block_destroy(struct iio_block *block);
 
 
+/** @brief Disable CPU access of a given block
+ * @param block A pointer to an iio_block structure
+ * @param disable Whether or not to disable CPU access
+ *
+ * <b>NOTE:</b>Disabling CPU access is useful when manipulating DMABUF objects.
+ * If CPU access is disabled, the block's internal buffer of samples should not
+ * be accessed. Therefore, the following functions should not be called:
+ * iio_block_start, iio_block_first, iio_block_end, iio_block_foreach_sample. */
+__api int iio_block_disable_cpu_access(struct iio_block *block, bool disable);
+
+
 /** @brief Get the start address of the block
  * @param buf A pointer to an iio_block structure
  * @return A pointer corresponding to the start address of the block */

--- a/local-dmabuf.c
+++ b/local-dmabuf.c
@@ -187,6 +187,11 @@ void local_free_dmabuf(struct iio_block_pdata *pdata)
 	free(pdata);
 }
 
+int local_dmabuf_get_fd(struct iio_block_pdata *pdata)
+{
+	return (int)(intptr_t) pdata->pdata;
+}
+
 int local_enqueue_dmabuf(struct iio_block_pdata *pdata,
 			 size_t bytes_used, bool cyclic)
 {

--- a/local-dmabuf.c
+++ b/local-dmabuf.c
@@ -253,3 +253,18 @@ int local_dequeue_dmabuf(struct iio_block_pdata *pdata, bool nonblock)
 
 	return 0;
 }
+
+int local_dmabuf_disable_cpu_access(struct iio_block_pdata *pdata, bool disable)
+{
+	int ret;
+
+	if (pdata->dequeued) {
+		ret = enable_cpu_access(pdata, !disable);
+		if (ret)
+			return ret;
+	}
+
+	pdata->cpu_access_disabled = disable;
+
+	return 0;
+}

--- a/local-dmabuf.c
+++ b/local-dmabuf.c
@@ -6,20 +6,35 @@
  * Author: Paul Cercueil <paul.cercueil@analog.com>
  */
 
+#define _GNU_SOURCE
 #include "local.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #include <iio/iio.h>
 #include <iio/iio-backend.h>
+#include <iio/iio-debug.h>
 #include <poll.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <sys/syscall.h>
 #include <time.h>
 #include <unistd.h>
 
-#define IIO_DMABUF_ALLOC_IOCTL		_IOW('i', 0x92, struct iio_dmabuf_req)
-#define IIO_DMABUF_ENQUEUE_IOCTL	_IOW('i', 0x93, struct iio_dmabuf)
+struct iio_udmabuf_create {
+	uint32_t memfd;
+	uint32_t flags;
+	uint64_t _;
+	uint64_t size;
+};
+
+#define IIO_UDMABUF_CREATE		_IOW('u', 0x42, struct iio_udmabuf_create)
+
+#define IIO_DMABUF_ATTACH_IOCTL		_IOW('i', 0x92, int)
+#define IIO_DMABUF_DETACH_IOCTL		_IOW('i', 0x93, int)
+#define IIO_DMABUF_ENQUEUE_IOCTL	_IOW('i', 0x94, struct iio_dmabuf)
 #define IIO_DMABUF_SYNC_IOCTL		_IOW('b', 0, struct dma_buf_sync)
 
 #define IIO_DMABUF_FLAG_CYCLIC		(1 << 0)
@@ -29,11 +44,6 @@
 #define DMA_BUF_SYNC_RW        (DMA_BUF_SYNC_READ | DMA_BUF_SYNC_WRITE)
 #define DMA_BUF_SYNC_START     (0 << 2)
 #define DMA_BUF_SYNC_END       (1 << 2)
-
-struct iio_dmabuf_req {
-	uint64_t size;
-	uint64_t resv;
-};
 
 struct iio_dmabuf {
 	int32_t fd;
@@ -45,30 +55,74 @@ struct dma_buf_sync {
 	uint64_t flags;
 };
 
+static int enable_cpu_access(struct iio_block_pdata *pdata, bool enable)
+{
+	struct dma_buf_sync dbuf_sync = { 0 };
+	int fd = (int)(intptr_t) pdata->pdata;
+
+	dbuf_sync.flags = DMA_BUF_SYNC_RW;
+
+	if (enable)
+		dbuf_sync.flags |= DMA_BUF_SYNC_START;
+	else
+		dbuf_sync.flags |= DMA_BUF_SYNC_END;
+
+	return ioctl_nointr(fd, IIO_DMABUF_SYNC_IOCTL, &dbuf_sync);
+}
+
 struct iio_block_pdata *
 local_create_dmabuf(struct iio_buffer_pdata *pdata, size_t size, void **data)
 {
+	struct iio_udmabuf_create req;
 	struct iio_block_pdata *priv;
-	struct iio_dmabuf_req req;
-	int ret, fd;
+	size_t page_size, mem_size;
+	int ret, fd, devfd, memfd;
 
 	priv = zalloc(sizeof(*priv));
 	if (!priv)
 		return iio_ptr(-ENOMEM);
 
-	req.size = size;
-	req.resv = 0;
+	page_size = sysconf(_SC_PAGESIZE);
+	mem_size = (size + page_size - 1) / page_size * page_size;
 
-	ret = ioctl_nointr(pdata->fd, IIO_DMABUF_ALLOC_IOCTL, &req);
+	devfd = open("/dev/udmabuf", O_RDWR | O_NOFOLLOW);
+	if (devfd < 0) {
+		ret = -errno;
 
-	/* If we get -ENODEV or -EINVAL errors here, the ioctl is wrong and the
-	 * high-speed DMABUF interface is not supported. */
-	if (ret == -ENODEV || ret == -EINVAL || ret == -ENOTTY)
-		ret = -ENOSYS;
-	if (ret < 0)
+		/* If we're running on an old kernel, return -ENOSYS to mark
+		 * the DMABUF interface as unavailable */
+		if (ret == -ENOENT)
+			ret = -ENOSYS;
+
 		goto err_free_priv;
+	}
 
-	fd = ret;
+	memfd = syscall(__NR_memfd_create, "/libiio-udmabuf", MFD_ALLOW_SEALING);
+	if (memfd < 0) {
+		ret = -errno;
+		goto err_close_devfd;
+	}
+
+	if (fcntl(memfd, F_ADD_SEALS, F_SEAL_SHRINK) < 0) {
+		ret = -errno;
+		goto err_close_devfd;
+	}
+
+	if (ftruncate(memfd, mem_size) < 0) {
+		ret = -errno;
+		goto err_close_memfd;
+	}
+
+	memset(&req, 0, sizeof(req));
+
+	req.memfd = memfd;
+	req.size = mem_size;
+
+	fd = ioctl(devfd, IIO_UDMABUF_CREATE, &req);
+	if (fd < 0) {
+		ret = -errno;
+		goto err_close_memfd;
+	}
 
 	*data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 	if (*data == MAP_FAILED) {
@@ -83,10 +137,38 @@ local_create_dmabuf(struct iio_buffer_pdata *pdata, size_t size, void **data)
 	priv->dequeued = true;
 	pdata->dmabuf_supported = true;
 
+	/* The new block is dequeued by default, so enable CPU access */
+	ret = enable_cpu_access(priv, true);
+	if (ret)
+		goto err_data_unmap;
+
+	/* Attach DMABUF to the buffer */
+	ret = ioctl(pdata->fd, IIO_DMABUF_ATTACH_IOCTL, &fd);
+	if (ret) {
+		ret = -errno;
+
+		if (ret == -ENOTTY) {
+			/* If the ioctl is not available, return -ENOSYS to mark
+			 * the DMABUF interface as unavailable */
+			ret = -ENOSYS;
+		}
+
+		goto err_data_unmap;
+	}
+
+	close(memfd);
+	close(devfd);
+
 	return priv;
 
+err_data_unmap:
+	munmap(priv->data, priv->size);
 err_close_fd:
 	close(fd);
+err_close_memfd:
+	close(memfd);
+err_close_devfd:
+	close(devfd);
 err_free_priv:
 	free(priv);
 	return iio_ptr(ret);
@@ -94,7 +176,11 @@ err_free_priv:
 
 void local_free_dmabuf(struct iio_block_pdata *pdata)
 {
-	int fd = (int)(intptr_t) pdata->pdata;
+	int ret, fd = (int)(intptr_t) pdata->pdata;
+
+	ret = ioctl(pdata->buf->fd, IIO_DMABUF_DETACH_IOCTL, &fd);
+	if (ret)
+		dev_perror(pdata->buf->dev, ret, "Unable to detach DMABUF");
 
 	munmap(pdata->data, pdata->size);
 	close(fd);
@@ -104,30 +190,34 @@ void local_free_dmabuf(struct iio_block_pdata *pdata)
 int local_enqueue_dmabuf(struct iio_block_pdata *pdata,
 			 size_t bytes_used, bool cyclic)
 {
-	struct dma_buf_sync dbuf_sync;
 	struct iio_dmabuf dmabuf;
 	int ret, fd = (int)(intptr_t) pdata->pdata;
 
 	if (!pdata->dequeued)
 		return -EPERM;
 
+	if (bytes_used > pdata->size || bytes_used == 0)
+		return -EINVAL;
+
 	dmabuf.fd = fd;
 	dmabuf.flags = 0;
 	dmabuf.bytes_used = bytes_used;
 
 	if (cyclic)
-	      dmabuf.flags |= IIO_DMABUF_FLAG_CYCLIC;
+		dmabuf.flags |= IIO_DMABUF_FLAG_CYCLIC;
 
-	dbuf_sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_RW;
-
-	/* Disable CPU access to last block */
-	ret = ioctl_nointr(fd, IIO_DMABUF_SYNC_IOCTL, &dbuf_sync);
-	if (ret)
-		return ret;
+	if (!pdata->cpu_access_disabled) {
+		/* Disable CPU access to last block */
+		ret = enable_cpu_access(pdata, false);
+		if (ret)
+			return ret;
+	}
 
 	ret = ioctl_nointr(pdata->buf->fd, IIO_DMABUF_ENQUEUE_IOCTL, &dmabuf);
-	if (ret)
+	if (ret) {
+		dev_perror(pdata->buf->dev, ret, "Unable to enqueue DMABUF");
 		return ret;
+	}
 
 	pdata->dequeued = false;
 
@@ -137,7 +227,6 @@ int local_enqueue_dmabuf(struct iio_block_pdata *pdata,
 int local_dequeue_dmabuf(struct iio_block_pdata *pdata, bool nonblock)
 {
 	struct iio_buffer_pdata *buf_pdata = pdata->buf;
-	struct dma_buf_sync dbuf_sync;
 	struct timespec start, *time_ptr = NULL;
 	int ret, fd = (int)(intptr_t) pdata->pdata;
 
@@ -153,12 +242,12 @@ int local_dequeue_dmabuf(struct iio_block_pdata *pdata, bool nonblock)
 	if (ret < 0)
 		return ret;
 
-	dbuf_sync.flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_RW;
-
-	/* Enable CPU access to new block */
-	ret = ioctl_nointr(fd, IIO_DMABUF_SYNC_IOCTL, &dbuf_sync);
-	if (ret < 0)
-		return ret;
+	if (!pdata->cpu_access_disabled) {
+		/* Enable CPU access to new block */
+		ret = enable_cpu_access(pdata, true);
+		if (ret < 0)
+			return ret;
+	}
 
 	pdata->dequeued = true;
 

--- a/local-mmap.c
+++ b/local-mmap.c
@@ -6,6 +6,7 @@
  * Author: Paul Cercueil <paul.cercueil@analog.com>
  */
 
+#include "iio-private.h"
 #include "local.h"
 
 #include <errno.h>
@@ -24,8 +25,6 @@
 
 #define container_of(ptr, type, member)	\
 	((type *)(void *)((uintptr_t)(ptr) - offsetof(type, member)))
-
-#define BIT(x) (1ull << (x))
 
 #define BLOCK_ALLOC_IOCTL	_IOWR('i', 0xa0, struct block_alloc_req)
 #define BLOCK_FREE_IOCTL	_IO('i', 0xa1)
@@ -193,6 +192,11 @@ int local_enqueue_mmap_block(struct iio_block_pdata *pdata,
 			return -EBUSY;
 
 		priv->block.flags |= BLOCK_FLAG_CYCLIC;
+	}
+
+	if (bytes_used != priv->block.size && !iio_device_is_tx(buf->dev)) {
+		/* MMAP interface only supports bytes_used on TX */
+		return -EINVAL;
 	}
 
 	mask = atomic_fetch_or(&buf->pdata->mmap_enqueued_blocks_mask, BIT(priv->idx));

--- a/local.c
+++ b/local.c
@@ -1580,6 +1580,14 @@ int local_dequeue_block(struct iio_block_pdata *pdata, bool nonblock)
 	return -ENOSYS;
 }
 
+static int local_get_dmabuf_fd(struct iio_block_pdata *pdata)
+{
+	if (WITH_LOCAL_DMABUF_API && pdata->buf->dmabuf_supported)
+		return local_dmabuf_get_fd(pdata);
+
+	return -EINVAL;
+}
+
 static int local_disable_cpu_access(struct iio_block_pdata *pdata, bool disable)
 {
 	if (WITH_LOCAL_DMABUF_API && pdata->buf->dmabuf_supported) {
@@ -1616,6 +1624,7 @@ static const struct iio_backend_ops local_ops = {
 	.readbuf = local_readbuf,
 	.writebuf = local_writebuf,
 
+	.get_dmabuf_fd = local_get_dmabuf_fd,
 	.disable_cpu_access = local_disable_cpu_access,
 };
 

--- a/local.c
+++ b/local.c
@@ -1580,6 +1580,18 @@ int local_dequeue_block(struct iio_block_pdata *pdata, bool nonblock)
 	return -ENOSYS;
 }
 
+static int local_disable_cpu_access(struct iio_block_pdata *pdata, bool disable)
+{
+	if (WITH_LOCAL_DMABUF_API && pdata->buf->dmabuf_supported) {
+		if (pdata->cpu_access_disabled == disable)
+			return 0;
+
+		return local_dmabuf_disable_cpu_access(pdata, disable);
+	}
+
+	return -EINVAL;
+}
+
 static const struct iio_backend_ops local_ops = {
 	.scan = local_context_scan,
 	.create = local_create_context,
@@ -1603,6 +1615,8 @@ static const struct iio_backend_ops local_ops = {
 
 	.readbuf = local_readbuf,
 	.writebuf = local_writebuf,
+
+	.disable_cpu_access = local_disable_cpu_access,
 };
 
 const struct iio_backend iio_local_backend = {

--- a/local.h
+++ b/local.h
@@ -50,6 +50,7 @@ int local_enqueue_dmabuf(struct iio_block_pdata *pdata,
 			 size_t bytes_used, bool cyclic);
 int local_dequeue_dmabuf(struct iio_block_pdata *pdata, bool nonblock);
 
+int local_dmabuf_get_fd(struct iio_block_pdata *pdata);
 int local_dmabuf_disable_cpu_access(struct iio_block_pdata *pdata, bool disable);
 
 struct iio_block_pdata *

--- a/local.h
+++ b/local.h
@@ -34,6 +34,7 @@ struct iio_block_pdata {
 	size_t size;
 	void *data;
 	bool dequeued;
+	bool cpu_access_disabled;
 };
 
 int ioctl_nointr(int fd, unsigned long request, void *data);
@@ -48,6 +49,8 @@ void local_free_dmabuf(struct iio_block_pdata *pdata);
 int local_enqueue_dmabuf(struct iio_block_pdata *pdata,
 			 size_t bytes_used, bool cyclic);
 int local_dequeue_dmabuf(struct iio_block_pdata *pdata, bool nonblock);
+
+int local_dmabuf_disable_cpu_access(struct iio_block_pdata *pdata, bool disable);
 
 struct iio_block_pdata *
 local_create_mmap_block(struct iio_buffer_pdata *pdata,

--- a/stream.c
+++ b/stream.c
@@ -16,7 +16,7 @@
 struct iio_stream {
 	struct iio_buffer *buffer;
 	struct iio_block **blocks;
-	size_t buf_size, nb_blocks;
+	size_t nb_blocks;
 	bool started, buf_enabled, all_enqueued;
 	unsigned int curr;
 };
@@ -56,7 +56,6 @@ iio_buffer_create_stream(struct iio_buffer *buffer, size_t nb_blocks,
 
 	stream->buffer = buffer;
 	stream->nb_blocks = nb_blocks;
-	stream->buf_size = buf_size;
 
 	return stream;
 
@@ -86,7 +85,6 @@ iio_stream_get_next_block(struct iio_stream *stream)
 {
 	const struct iio_device *dev = stream->buffer->dev;
 	bool is_tx = iio_device_is_tx(dev);
-	size_t buf_size;
 	unsigned int i;
 	int err;
 
@@ -107,9 +105,7 @@ iio_stream_get_next_block(struct iio_stream *stream)
 		stream->all_enqueued = true;
 	}
 
-	buf_size = is_tx ? stream->buf_size : 0;
-
-	err = iio_block_enqueue(stream->blocks[stream->curr], buf_size, false);
+	err = iio_block_enqueue(stream->blocks[stream->curr], 0, false);
 	if (err < 0) {
 		dev_perror(dev, err, "Unable to enqueue block");
 		return iio_ptr(err);

--- a/utilities.c
+++ b/utilities.c
@@ -21,6 +21,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <sys/time.h>
+#endif
+
 #if defined(_WIN32) || \
 		(defined(__APPLE__) && defined(__MACH__)) || \
 		(defined(__USE_XOPEN2K8) && \
@@ -392,4 +398,26 @@ void iio_prm_printf(const struct iio_context_params *params,
 		vfprintf(out, fmt, ap);
 
 	va_end(ap);
+}
+
+uint64_t iio_read_counter_us(void)
+{
+	uint64_t value;
+
+#ifdef _WIN32
+	LARGE_INTEGER freq, cnt;
+
+	QueryPerformanceFrequency(&freq);
+	QueryPerformanceCounter(&cnt);
+
+	value = (1000000 * cnt.QuadPart) / freq.QuadPart;
+#else
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+
+	value = tv.tv_sec * 1000000ull + tv.tv_usec;
+#endif
+
+	return value;
 }


### PR DESCRIPTION
These commits will modify how the local-DMABUF interface works, because the interface itself in the kernel changed (as it is not yet upstream).

The local backend will now make use of the "udmabuf" kernel driver, which was added in 5.19, to create DMABUF objects from memfd buffers. These DMABUFs can then be attached to the IIO device and/or other devices from other subsystems, and memory-mapped to access the data.

IIOD has also been modified to support enqueueing DMABUFs to the USB (functionfs) interface, and will support passing the buffers between IIO and USB in a zero-copy fashion.

From a Libiio API standpoint, some changes were introduced:
- `iio_block_enqueue` will support partial transfers on RX buffers as well;
- Setting bytes_used=0 in `iio_block_enqueue` will default to transferring the full buffer;
- New API function `iio_block_disable_cpu_access`, to disable CPU synchronization with the buffers when doing zero-copy;
- New API function `iio_block_get_dmabuf_fd` which can be used when doing zero-copy as well.