### PR TITLE
iiod-client: Restore support for tinyiiod based programs

### DIFF
--- a/iiod-client.c
+++ b/iiod-client.c
@@ -482,6 +482,13 @@ int iiod_client_set_timeout(struct iiod_client *client, unsigned int timeout)
 		iio_snprintf(buf, sizeof(buf), "TIMEOUT %u\r\n", remote_timeout);
 		ret = iiod_client_exec_command(client, buf);
 		iio_mutex_unlock(client->lock);
+
+		if (ret == -EINVAL) {
+			/* The TIMEOUT command is not implemented in tinyiiod
+			 * based programs; so ignore if we get -EINVAL here. */
+			prm_dbg(client->params, "Unable to set remote timeout\n");
+			ret = 0;
+		}
 	}
 
 	return ret;


### PR DESCRIPTION
Tinyiiod may not handle the TIMEOUT command. This shouldn't prevent us from creating a IIO context, so in the case where we get a -22 error (aka. command does not exist), continue the context creation as usual.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>