### PR TITLE
usb: Destroy USB I/O context after IIOD client

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -323,13 +323,12 @@ static void usb_shutdown(struct iio_context *ctx)
 {
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
-	usb_io_context_exit(&pdata->io_ctx);
+	iiod_client_destroy(pdata->io_ctx.iiod_client);
 
 	/* TODO: free buffers? */
 
+	usb_io_context_exit(&pdata->io_ctx);
 	iio_mutex_destroy(pdata->ep_lock);
-
-	iiod_client_destroy(pdata->io_ctx.iiod_client);
 
 	free(pdata->io_endpoints);
 


### PR DESCRIPTION
In usb_shutdown(), destroy the USB I/O context structure after destroying the IIOD client, to address a use-after-free issue.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>