### PR TITLE
CMake: Fix cyclic dependency under MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -548,6 +548,10 @@ if (IIOD_CLIENT OR WITH_IIOD)
 	add_library(iiod-responder STATIC iiod-responder.c)
 	target_include_directories(iiod-responder PRIVATE include)
 	set_target_properties(iiod-responder PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+	# Link against exported symbols of Libiio and not the
+	# DLL-exported symbols
+	target_compile_definitions(iiod-responder PRIVATE LIBIIO_STATIC)
 endif()
 
 if (IIOD_CLIENT)


### PR DESCRIPTION
iiod-responder is compiled as a static library, because it is used both inside Libiio, and by IIOD as well.

On Windows, it will only be compiled against Libiio, as IIOD cannot be enabled. However, unlike a program linked against Libiio that will import the symbols from the DLL, it is an integral part of Libiio, and therefore should not try to import the symbol names as DLL symbols.