### PR TITLE
Rgetz update man pages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND OSX_FRAMEWORK)
 	set(SKIP_INSTALL_ALL ${OSX_PACKAGE})
 endif()
 
+option(WITH_MAN "Generate on-line reference manuals (man pages)" OFF)
+include(cmake/CheckManPages.cmake)
 option(WITH_NETWORK_BACKEND "Enable the network backend" ON)
 option(WITH_TESTS "Build the test programs" ON)
 option(WITH_EXAMPLES "Build examples" OFF)
@@ -551,8 +553,9 @@ option(CSHARP_BINDINGS "Install C# bindings" OFF)
 option(PYTHON_BINDINGS "Install Python bindings" OFF)
 add_subdirectory(bindings)
 
-option(WITH_MAN "Generate on-line reference manuals (man pages)" OFF)
-add_subdirectory(man)
+if(WITH_MAN)
+	add_subdirectory(man)
+endif()
 
 # Create an installer if compiling for OSX
 if(OSX_PACKAGE AND OSX_FRAMEWORK)

--- a/cmake/CheckManPages.cmake
+++ b/cmake/CheckManPages.cmake
@@ -1,0 +1,31 @@
+# check to make sure man pages are there, otherwise build them
+
+macro( CheckManPages FILE_LIST )
+	if(WITH_MAN AND NOT CMAKE_CROSSCOMPILING)
+		foreach(UTIL IN ITEMS ${FILE_LIST})
+			if(NOT EXISTS "${CMAKE_SOURCE_DIR}/man/${UTIL}.1.in")
+				if(NOT DEFINED HELP2MAN OR HELP2MAN STREQUAL "")
+					find_program(HELP2MAN "help2man")
+				endif()
+				if(HELP2MAN)
+					if(NOT TARGET ${UTIL}.1)
+						add_custom_target("${UTIL}.1" ALL
+							COMMAND ${HELP2MAN}
+								-n 'Part of the libiio utils'
+								--no-info --no-discard-stderr
+								-o ${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_MANDIR}/${UTIL}.1
+								${CMAKE_CURRENT_BINARY_DIR}/${UTIL}
+								COMMENT "Generating man page for ${UTIL}"
+							DEPENDS "${UTIL}"
+							WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+						)
+					endif()
+				else()
+					message(STATUS "can not generate ${UTIL} man page, missing help2man")
+				endif()
+			endif()
+		endforeach()
+	endif()
+endmacro()
+
+

--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -89,6 +89,9 @@ if(NOT SKIP_INSTALL_ALL)
 	install(TARGETS iiod RUNTIME DESTINATION ${CMAKE_INSTALL_SBINDIR})
 endif()
 
+CheckManPages(iiod)
+
+
 if (WITH_SYSTEMD)
 	configure_file(${CMAKE_CURRENT_SOURCE_DIR}/init/iiod.service.cmakein ${PROJECT_BINARY_DIR}/init/iiod.service)
 	install(FILES ${PROJECT_BINARY_DIR}/init/iiod.service DESTINATION ${SYSTEMD_UNIT_INSTALL_DIR})

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -1,3 +1,6 @@
+# it doesn't make sense to create man pages on windows, so we don't really
+# worry about that.
+
 if (WITH_MAN)
 	find_program(BASH_EXECUTABLE bash)
 	find_program(DATE_EXECUTABLE date)
@@ -36,7 +39,11 @@ if (WITH_MAN)
 	if (WITH_TESTS)
 		list(APPEND MAN1 iio_attr.1 iio_info.1 iio_readdev.1 iio_reg.1 iio_writedev.1)
 		foreach(_page ${MAN1})
-			configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/${_page}.in
+			execute_process(
+				COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/make_util_pages.sh ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${_page}.in
+				OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/${_page}.in
+			)
+			configure_file( ${CMAKE_CURRENT_BINARY_DIR}/${_page}.in
 				${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_MANDIR}/${_page} @ONLY)
 		endforeach()
 		if (WITH_DOC)

--- a/man/iio_attr.1.in
+++ b/man/iio_attr.1.in
@@ -82,45 +82,11 @@ Read and Write IIO Context attributes
 .TP
 .B \-D \-\-debug-attr
 Read and Write IIO Debug attributes
-.TP
-.B \-S, \-\-scan
-Scan for available IIO contexts, optional arg of specific backend(s) 'ip', 'usb' or 'ip,usb'.
-Specific options for USB include Vendor ID, Product ID to limit scanning to specific devices 'usb=0456:b673'.
-vid,pid are hexadecimal numbers (no prefix needed), "*" (match any for pid only)
-If no argument is given, it checks all that are availble.
-.TP
-.B \-h, \-\-help
-Tells
-.I iio_attr
-to display some help, and then quit.
-
+##COMMON_COMMANDS_START##
+##COMMON_COMMANDS_STOP##
 .SH OPTIONS
-.TP
-.B \-a, \-\-auto
-Look around for devices (locally, ip, and usb), and if there is only one device
-found, connect to it.
-.TP
-.B \-u, \-\-uri
-The Uniform Resource Identifier
-.I (uri)
-for connecting to devices, can be one of:
-.RS
-.IP ip:[address]
-network address, either numeric (192.168.0.1) or network hostname (pluto.local)
-.IP ip:
-blank, if compiled with zeroconf support, will find an IIO device on network
-.IP usb:[device:port:instance]
-normally returned from
-.B iio_info -s
-or
-.B iio_attr -S
-.IP usb:
-blank, if there is only one IIO device plugged into USB, find it, and attach to it.
-.IP serial:[port],[baud],[config]
-serial configuration, serial:/dev/ttyUSB0,115200,8n1 115200 baud, 8 data bits, no partity, one stop bit
-.IP local:
-with no address part
-.RE
+##COMMON_OPTION_START##
+##COMMON_OPTION_STOP##
 .TP
 .B \-i, \-\-input-channel
 Filters channels by input channels only
@@ -140,23 +106,3 @@ Generate small C or python snippets that emulate what you are doing on the comma
 .SH RETURN VALUE
 If the specified device is not found, a non-zero exit code is returned.
 
-.SH "SEE ALSO"
-.ad l
-.BR iio_attr (1),
-.BR iio_info (1),
-.BR iio_readdev (1),
-.BR iio_reg (1),
-.BR iio_writedev (1),
-.BR libiio (3)
-.PP
-libiio home page:
-.BR \%https://wiki.analog.com/resources/tools-software/linux-software/libiio
-.PP
-libiio code:
-.BR \%https://github.com/analogdevicesinc/libiio
-.PP
-Doxygen for libiio
-.BR \%https://analogdevicesinc.github.io/libiio/
-.SH BUGS
-All bugs are tracked at:
-.BR \%https://github.com/analogdevicesinc/libiio/issues

--- a/man/iio_common_cmds.1
+++ b/man/iio_common_cmds.1
@@ -1,0 +1,11 @@
+.TP
+.B \-h, \-\-help
+Tells
+.I ##APP_NAME##
+to display some help, and then quit.
+.TP
+.B \-S, \-\-Scan
+Scan for available IIO contexts, optional arg of specific backend(s) 'ip', 'usb' or 'ip:usb'.
+Specific options for USB include Vendor ID, Product ID to limit scanning to specific devices 'usb=0456,b673'.
+vid,pid are hexadecimal numbers (no prefix needed), "*" (match any for pid only)
+If no argument is given, it checks all that are availble.

--- a/man/iio_common_footer.1
+++ b/man/iio_common_footer.1
@@ -1,0 +1,20 @@
+.SH "SEE ALSO"
+.ad l
+.BR iio_attr (1),
+.BR iio_info (1),
+.BR iio_readdev (1),
+.BR iio_reg (1),
+.BR iio_writedev (1),
+.BR libiio (3)
+.PP
+libiio home page:
+.BR \%https://wiki.analog.com/resources/tools-software/linux-software/libiio
+.PP
+libiio code:
+.BR \%https://github.com/analogdevicesinc/libiio
+.PP
+Doxygen for libiio
+.BR \%https://analogdevicesinc.github.io/libiio/
+.SH BUGS
+All bugs are tracked at:
+.BR \%https://github.com/analogdevicesinc/libiio/issues

--- a/man/iio_common_opts.1
+++ b/man/iio_common_opts.1
@@ -1,0 +1,36 @@
+.TP
+.B \-u, \-\-uri
+The Uniform Resource Identifier
+.I (uri)
+for connecting to devices, can be one of:
+.RS
+.IP ip:[address]
+network address, either numeric (192.168.0.1) or network hostname
+.IP ip:
+blank, if compiled with zeroconf support, will find an IIO device on network
+.IP usb:[device:port:instance]
+normally returned from
+.B ##APP_NAME## -S
+.IP serial:[port],[baud],[settings]
+which are controlled, and need to match the iiod (or tinyiiod) on the other end of the serial port.
+.RS
+.IP [port]
+is something like '/dev/ttyUSB0' on Linux, and 'COM4' on Windows.
+.IP [baud]
+is is normally one of 110, 300, 600, 1200, 2400, 4800, 9600, 14400, 19200, 38400, 57600, 115200 [default], 128000 or 256000, but can vary system to system.
+.IP [settings]
+would normally be configured as '8n1' this is controlled by:
+.RS
+.IP data_bits:
+(5, 6, 7, 8 [default], or 9)
+.IP parity_bits:
+('n' none [default], 'o' odd, 'e' even, 'm' mark, or 's' space)
+.IP stop_bits:
+(1 [default, or 2)
+.IP flow_control:
+('0' none [default], 'x' Xon Xoff, 'r' RTSCTS, or 'd' DTRDSR)
+.RE
+.RE 
+.IP local
+with no address part
+.RE

--- a/man/iio_info.1.in
+++ b/man/iio_info.1.in
@@ -31,58 +31,16 @@ iio_info \- list IIO devices and device attributes
 [
 .I options
 ]
--x <xml_file>
-.br
-.B iio_info
-[
-.I options
-]
--n <hostname>
-.br
-.B iio_info
-[
-.I options
-]
 -u <uri>
 .SH DESCRIPTION
 .B iio_info
 is a utility for displaying information about local or remote IIO devices
 
 .SH OPTIONS
-.TP
-.B \-h, \-\-help
-Tells
-.I iio_info
-to display some help, and then quit.
-.TP
-.B \-x, \-\-xml
-Use the XML backend with the provided XML file
-.TP
-.B \-n, \-\-network
-Use the network backend with the provided hostname
-.TP
-.B \-u, \-\-uri
-The Uniform Resource Identifier
-.I (uri)
-for connecting to devices, can be one of:
-.RS
-.IP ip:[address]
-network address, either numeric (192.168.0.1) or network hostname
-.IP ip:
-blank, if compiled with zeroconf support, will find an IIO device on network
-.IP usb:[device:port:instance]
-normally returned from
-.B iio_info -s
-.IP serial:[port]
-.IP local
-with no address part
-.RE
-.TP
-.B \-S, \-\-scan
-Scan for available IIO contexts, optional arg of specific backend(s) 'ip', 'usb' or 'ip,usb'.
-Specific options for USB include Vendor ID, Product ID to limit scanning to specific devices 'usb=0456:b673'.
-vid,pid are hexadecimal numbers (no prefix needed), "*" (match any for pid only)
-If no argument is given, it checks all that are availble.
+##COMMON_COMMANDS_START##
+##COMMON_COMMANDS_STOP##
+##COMMON_OPTION_START##
+##COMMON_OPTION_STOP##
 .TP
 .B \-a, \-\-auto
 Scan for available contexts and if only one is available use it.
@@ -90,23 +48,3 @@ Scan for available contexts and if only one is available use it.
 .SH RETURN VALUE
 If the specified device is not found, a non-zero exit code is returned.
 
-.SH "SEE ALSO"
-.ad l
-.BR iio_attr (1),
-.BR iio_info (1),
-.BR iio_readdev (1),
-.BR iio_reg (1),
-.BR iio_writedev (1),
-.BR libiio (3)
-.PP
-libiio home page:
-.BR \%https://wiki.analog.com/resources/tools-software/linux-software/libiio
-.PP
-libiio code:
-.BR \%https://github.com/analogdevicesinc/libiio
-.PP
-Doxygen for libiio
-.BR \%https://analogdevicesinc.github.io/libiio/
-.SH BUGS
-All bugs are tracked at:
-.BR \%https://github.com/analogdevicesinc/libiio/issues

--- a/man/iio_readdev.1.in
+++ b/man/iio_readdev.1.in
@@ -37,30 +37,8 @@ iio_readdev \- read buffers from an IIO device
 is a utility for reading buffers from connected IIO devices, and sending resutls to standard out.
 
 .SH OPTIONS
-.TP
-.B \-h, \-\-help
-Tells
-.I iio_readdev
-to display some help, and then quit.
-.B \-n, \-\-network
-Use the network backend with the provided hostname
-.TP
-.B \-u, \-\-uri
-The Uniform Resource Identifier
-.I (uri)
-for connecting to devices, can be one of:
-.RS
-.IP ip:[address]
-network address, either numeric (192.168.0.1) or network hostname
-.IP ip:
-blank, if compiled with zeroconf support, will find an IIO device on network
-.IP usb:[device:port:instance]
-normally returned from
-.B iio_info -s
-.IP serial:[port]
-.IP local
-with no address part
-.RE
+##COMMON_COMMANDS_START##
+##COMMON_COMMANDS_STOP##
 .TP
 .B \-t \-\-trigger
 Use the specified trigger, if needed on the specified channel
@@ -73,15 +51,8 @@ Number of samples (not bytes) to capture, 0 = infinite. Default is 0.
 .TP
 .B \-T \-\-timeout
 Buffer timeout in milliseconds. 0 = no timeout. Default is 0.
-.TP
-.B \-a, \-\-auto
-Scan for available contexts and if only one is available use it.
-.TP
-.B \-S, \-\-scan
-Scan for available IIO contexts, optional arg of specific backend(s) 'ip', 'usb' or 'ip,usb'.
-Specific options for USB include Vendor ID, Product ID to limit scanning to specific devices 'usb=0456:b673'.
-vid,pid are hexadecimal numbers (no prefix needed), "*" (match any for pid only)
-If no argument is given, it checks all that are availble.
+##COMMON_OPTION_START##
+##COMMON_OPTION_STOP##
 .SH RETURN VALUE
 If the specified device is not found, a non-zero exit code is returned.
 
@@ -115,23 +86,3 @@ And plots the data with gnuplot.
 .B \f(WCgnuplot \-e \(dq\&set term png; set output 'sample.png'; plot 'sample.dat' binary format='%short%short' using 1 with lines, 'sample.dat' binary format='%short%short' using 2 with lines;\(dq\&\fP
 .RE
 
-.SH "SEE ALSO"
-.ad l
-.BR iio_attr (1),
-.BR iio_info (1),
-.BR iio_readdev (1),
-.BR iio_reg (1),
-.BR iio_writedev (1),
-.BR libiio (3)
-.PP
-libiio home page:
-.BR \%https://wiki.analog.com/resources/tools-software/linux-software/libiio
-.PP
-libiio code:
-.BR \%https://github.com/analogdevicesinc/libiio
-.PP
-Doxygen for libiio
-.BR \%https://analogdevicesinc.github.io/libiio/
-.SH BUGS
-All bugs are tracked at:
-.BR \%https://github.com/analogdevicesinc/libiio/issues

--- a/man/iio_reg.1.in
+++ b/man/iio_reg.1.in
@@ -42,33 +42,11 @@ It provides a mechanism to read or write SPI or I2C registers for IIO devices.
 This can be useful when troubleshooting IIO devices, and understanding how
 the Linux IIO subsystem is managing the device.
 
-This IIO utility does not work across a network or USB context.
 .SH OPTIONS
-.TP
-.B \-h, \-\-help
-Tells
-.I iio_reg
-to display some help, and then quit.
+##COMMON_COMMANDS_START##
+##COMMON_COMMANDS_STOP##
+##COMMON_OPTION_START##
+##COMMON_OPTION_STOP##
 .SH RETURN VALUE
 If the specified device is not found, a non-zero exit code is returned.
 
-.SH "SEE ALSO"
-.ad l
-.BR iio_attr (1),
-.BR iio_info (1),
-.BR iio_readdev (1),
-.BR iio_reg (1),
-.BR iio_writedev (1),
-.BR libiio (3)
-.PP
-libiio home page:
-.BR \%https://wiki.analog.com/resources/tools-software/linux-software/libiio
-.PP
-libiio code:
-.BR \%https://github.com/analogdevicesinc/libiio
-.PP
-Doxygen for libiio
-.BR \%https://analogdevicesinc.github.io/libiio/
-.SH BUGS
-All bugs are tracked at:
-.BR \%https://github.com/analogdevicesinc/libiio/issues

--- a/man/iio_writedev.1.in
+++ b/man/iio_writedev.1.in
@@ -31,42 +31,14 @@ iio_writedev \- write buffers on an IIO device
 [
 .I options
 ]
-[-n <hostname>] [-t <trigger>] [-T <timeout-ms>] [-b <buffer-size>] [-s <samples>] <iio_device> [<channel> ...]
+[-t <trigger>] [-T <timeout-ms>] [-b <buffer-size>] [-s <samples>] <iio_device> [<channel> ...]
 .SH DESCRIPTION
 .B iio_reg
 is a utility for writing buffers from connected IIO devices.
 
 .SH OPTIONS
-.TP
-.B \-h, \-\-help
-Tells
-.I iio_readdev
-to display some help, and then quit.
-.B \-n, \-\-network
-Use the network backend with the provided hostname
-.TP
-.B \-u, \-\-uri
-The Uniform Resource Identifier
-.I (uri)
-for connecting to devices, can be one of:
-.RS
-.IP ip:[address]
-network address, either numeric (192.168.0.1) or network hostname
-.IP ip:
-blank, if compiled with zeroconf support, will find an IIO device on network
-.IP usb:[device:port:instance]
-normally returned from
-.B iio_info -s
-.IP serial:[port]
-.IP local
-with no address part
-.TP
-.B \-S, \-\-scan
-Scan for available IIO contexts, optional arg of specific backend(s) 'ip', 'usb' or 'ip,usb'.
-Specific options for USB include Vendor ID, Product ID to limit scanning to specific devices 'usb=0456:b673'.
-vid,pid are hexadecimal numbers (no prefix needed), "*" (match any for pid only)
-If no argument is given, it checks all that are availble.
-.RE
+##COMMON_COMMANDS_START##
+##COMMON_COMMANDS_STOP##
 .TP
 .B \-t \-\-trigger
 Use the specified trigger, if needed on the specified channel
@@ -80,11 +52,10 @@ Number of samples (not bytes) to capture, 0 = infinite. Default is 0.
 .B \-T \-\-timeout
 Buffer timeout in milliseconds. 0 = no timeout. Default is 0.
 .TP
-.B \-a, \-\-auto
-Scan for available contexts and if only one is available use it.
-.TP
 .B \-c \-\-cyclic
 Use cyclic buffer mode.
+##COMMON_OPTION_START##
+##COMMON_OPTION_STOP##
 
 .SH RETURN VALUE
 If the specified device is not found, a non-zero exit code is returned.
@@ -113,23 +84,4 @@ This sends 1024 samples of I and Q data to the USB attached AD9361. data is taki
 .B \f(CWiio_writedev \-a \-s 1024 cf-ad9361-dds-core-lpc voltage0 voltage1 < ./samples.dat\fP
 .RE
 
-.SH "SEE ALSO"
-.ad l
-.BR iio_attr (1),
-.BR iio_info (1),
-.BR iio_readdev (1),
-.BR iio_reg (1),
-.BR iio_writedev (1),
-.BR libiio (3)
-.PP
-libiio home page:
-.BR \%https://wiki.analog.com/resources/tools-software/linux-software/libiio
-.PP
-libiio code:
-.BR \%https://github.com/analogdevicesinc/libiio
-.PP
-Doxygen for libiio
-.BR \%https://analogdevicesinc.github.io/libiio/
-.SH BUGS
-All bugs are tracked at:
-.BR \%https://github.com/analogdevicesinc/libiio/issues
+

--- a/man/make_util_pages.sh
+++ b/man/make_util_pages.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+dir=$1
+if [ -z "${dir}" -o ! -f "${dir}/iio_common_cmds.1" -o ! -f "${dir}/iio_common_opts.1" -o ! -f "${dir}/iio_common_footer.1" ] ; then
+	echo "not pointing to src directory ${dir}" 1>&2
+	exit
+fi
+file=$2
+if [ -z "${file}" -o ! -f "${file}" ] ; then
+	echo "missing 2nd argument file to manipulate ${file}" 1>&2
+	exit
+fi
+
+app=$(grep "^.TH" "${file}" | head -1 | awk '{print $2}')
+
+sed '/##COMMON_COMMANDS_START##/Q' "${file}"
+sed "s/##APP_NAME##/${app}/g" "${dir}/iio_common_cmds.1"
+sed -n '/^##COMMON_COMMANDS_STOP##/,${p;/^##COMMON_OPTION_START##/q}' "${file}" |  grep -v "##COMMON_"
+sed "s/##APP_NAME##/${app}/g" "${dir}/iio_common_opts.1"
+sed -ne '/^##COMMON_OPTION_STOP#/,$ p' "${file}" | grep -v "##COMMON_OPTION_STOP##"
+sed "s/##APP_NAME##/${app}/g" "${dir}/iio_common_footer.1"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,5 +83,7 @@ if(NOT SKIP_INSTALL_ALL)
 	endif()
 endif()
 
+CheckManPages("${IIO_TESTS_TARGETS}")
+
 # Make the test targets available to the main CMakeLists.txt
 set(IIO_TESTS_TARGETS ${IIO_TESTS_TARGETS} PARENT_SCOPE)


### PR DESCRIPTION
This uses a slightly different solution than #886, (which checks in auto generated files), but adds some cmake to actually just generate the files on the build machine, and the time of building.

assumption is that all utils generate help (with #942 ; they do), and that the host has access to 'help2man'.

-Robin