### PR TITLE
utils: catch calloc memory failures in iio_stresstest

### DIFF
--- a/tests/iio_stresstest.c
+++ b/tests/iio_stresstest.c
@@ -519,6 +519,12 @@ int main(int argc, char **argv)
 
 	ret = (void *)calloc(info.num_threads, sizeof(void *));
 
+	if (!ret || !info.start || !info.refills || !info.buffers || !info.starts ||
+			!info.tid || !info.threads) {
+		fprintf(stderr, "Memory allocation failure\n");
+		return 0;
+	}
+
 	for (i = 0; i < info.num_threads; i++) {
 		info.start[i] = malloc(NUM_TIMESTAMPS * sizeof(struct timeval));
 	}
@@ -658,6 +664,11 @@ int main(int argc, char **argv)
 		/* gather and sort things, so we can print out a histogram */
 		struct timeval *sort;
 		sort = calloc(info.num_threads * NUM_TIMESTAMPS, sizeof(struct timeval));
+		if (!sort) {
+			app_running = 0;
+			fprintf(stderr, "Memory allocation failure\n");
+			break;
+		}
 		b = 0;
 		/* gather */
 		for (i = 0; i < info.num_threads; i++) {


### PR DESCRIPTION
On error, calloc() returns NULL. Or a successful call to calloc() with nmemb or size equal to zero.

In the past, we would not catch that, and just start operating on the null pointer (crashing). So catch that, and gracefully error out.