### PR TITLE
set errno to 0, and check after calling library functions

### DIFF
--- a/network.c
+++ b/network.c
@@ -1126,8 +1126,10 @@ struct iio_context * network_create_context(const char *host)
 	}
 	if (port) {
 		unsigned long int tmp;
+
+		errno = 0;
 		tmp = strtoul(port, &end, 0);
-		if (port == end || tmp > 0xFFFF) {
+		if (port == end || tmp > 0xFFFF || errno == ERANGE) {
 			errno = ENOENT;
 			return NULL;
 		}

--- a/usb.c
+++ b/usb.c
@@ -1222,8 +1222,9 @@ static int parse_vid_pid(const char *vid_pid, uint16_t *vid, uint16_t *pid)
 	if (!vid_pid)
 		return 0;
 
+	errno = 0;
 	val = strtoul(vid_pid, &ptr, 16);
-	if (ptr == vid_pid || val > 0xFFFF || *ptr != ':')
+	if (ptr == vid_pid || val > 0xFFFF || *ptr != ':' || errno == ERANGE)
 		return -EINVAL;
 
 	*vid = (uint16_t) val;
@@ -1233,8 +1234,9 @@ static int parse_vid_pid(const char *vid_pid, uint16_t *vid, uint16_t *pid)
 	if (*vid_pid == '*')
 		return vid_pid[1] == '\0' ? 0 : -EINVAL;
 
+	errno = 0;
 	val = strtoul(vid_pid, &ptr, 16);
-	if (ptr == vid_pid || val > 0xFFFF || *ptr != '\0')
+	if (ptr == vid_pid || val > 0xFFFF || *ptr != '\0' || errno == ERANGE)
 		return -EINVAL;
 
 	*pid = (uint16_t) val;

--- a/xml.c
+++ b/xml.c
@@ -428,12 +428,14 @@ static struct iio_context * iio_create_xml_context_helper(xmlDoc *doc)
 		if (!strcmp((char *) attr->name, "description")) {
 			description = content;
 		} else if (!strcmp((char *) attr->name, "version-major")) {
+			errno = 0;
 			major = strtol(content, &end, 10);
-			if (*end != '\0')
+			if (*end != '\0' ||  errno == ERANGE)
 				IIO_WARNING("invalid format for major version\n");
 		} else if (!strcmp((char *) attr->name, "version-minor")) {
+			errno = 0;
 			minor = strtol(content, &end, 10);
-			if (*end != '\0')
+			if (*end != '\0' || errno == ERANGE)
 				IIO_WARNING("invalid format for minor version\n");
 		} else if (!strcmp((char *) attr->name, "version-git")) {
 			git_tag = content;


### PR DESCRIPTION
A few times we are using strtol and strtoul, where we were not setting errno to zero, and then checking it afterwards - this could lead to undefined behaviour based on end user inputs, so do like the man page suggests.