### PR TITLE
Fix Task code

### DIFF
--- a/task.c
+++ b/task.c
@@ -45,6 +45,7 @@ static int iio_task_run(void *d)
 {
 	struct iio_task *task = d;
 	struct iio_task_token *entry;
+	bool autoclear;
 
 	iio_mutex_lock(task->lock);
 
@@ -69,10 +70,11 @@ static int iio_task_run(void *d)
 
 		iio_mutex_lock(entry->done_lock);
 		entry->done = true;
+		autoclear = entry->autoclear;
 		iio_cond_signal(entry->done_cond);
 		iio_mutex_unlock(entry->done_lock);
 
-		if (entry->autoclear)
+		if (autoclear)
 			iio_task_token_destroy(entry);
 
 		/* Signal that we're done with the previous entry */

--- a/task.c
+++ b/task.c
@@ -251,6 +251,7 @@ int iio_task_destroy(struct iio_task *task)
 
 	iio_cond_destroy(task->cond);
 	iio_mutex_destroy(task->lock);
+	free(task);
 
 	return ret;
 }


### PR DESCRIPTION
Two fixes to the `task.c` code, which allows one function to be called asynchronously.

Fix one nasty race between the task thread and iio_task_sync(), which is called elsewhere in Libiio and IIOD, and caused IIOD to segfault.

Also add a missing free() on the task structures in iio_task_destroy(), as they were never freed before.