### PR TITLE
CI:fix ARM error

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -271,6 +271,7 @@ stages:
     steps:
     - script: |
         set -e
+        sudo apt-get update
         sudo apt-get install -y gcc-arm-linux-gnueabihf libc6-dev-armhf-cross
         sudo apt-get install -y g++-arm-linux-gnueabihf
         sudo apt-get install -y g++-aarch64-linux-gnu


### PR DESCRIPTION
Add `sudo apt-get update` command for ARM builds to eliminate "Fail to fetch" error.