### PR TITLE
cmake: tell people if we are/are not install udev rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,6 +671,7 @@ toggle_iio_feature("${WITH_USB_BACKEND}" usb)
 toggle_iio_feature("${WITH_TESTS}" utils)
 toggle_iio_feature("${WITH_EXAMPLES}" examples)
 toggle_iio_feature("${WITH_IIOD}" iiod)
+toggle_iio_feature("${INSTALL_UDEV_RULE}" udev-rule)
 #add iiod settings
 list(APPEND IIO_FEATURES_ON ${IIOD_FEATURES_ON})
 list(APPEND IIO_FEATURES_OFF ${IIOD_FEATURES_OFF})


### PR DESCRIPTION
we currently don't tell people if we are or aren't installing udev rules (which I think is an oversight). So do that.