### PR TITLE
utils: add 'version' option to each util

### DIFF
--- a/examples/iio_adi_xflow_check.c
+++ b/examples/iio_adi_xflow_check.c
@@ -170,6 +170,7 @@ int main(int argc, char **argv)
 		switch (c) {
 		/* All these are handled in the common */
 		case 'h':
+		case 'V':
 		case 'n':
 		case 'x':
 		case 'u':

--- a/man/iio_common_cmds.1
+++ b/man/iio_common_cmds.1
@@ -4,6 +4,13 @@ Tells
 .I ##APP_NAME##
 to display some help, and then quit.
 .TP
+.B \-V, \-\-version
+Prints the version information for this particular copy of
+.I ##APP_NAME##
+and the version of the libiio library it is using. This is useful for knowing if the version of the library and
+.I ##APP_NAME##
+on your system are up to date. This is also useful when reporting bugs.
+.TP
 .B \-S, \-\-scan [backends]
 Scan for available IIO contexts, optional arg of specific backend(s) 'ip', 'usb' or 'ip:usb'.
 Specific options for USB include Vendor ID, Product ID to limit scanning to specific devices 'usb=0456,b673'.

--- a/tests/iio_attr.c
+++ b/tests/iio_attr.c
@@ -375,6 +375,7 @@ int main(int argc, char **argv)
 		switch (c) {
 		/* All these are handled in the common */
 		case 'h':
+		case 'V':
 		case 'n':
 		case 'x':
 		case 'u':

--- a/tests/iio_common.c
+++ b/tests/iio_common.c
@@ -192,6 +192,7 @@ void free_argw(int argc, char * argw[])
 
 static const struct option common_options[] = {
 	{"help", no_argument, 0, 'h'},
+	{"version", no_argument, 0, 'V'},
 	{"xml", required_argument, 0, 'x'},
 	{"uri", required_argument, 0, 'u'},
 	{"scan", optional_argument, 0, 'S'},
@@ -239,6 +240,7 @@ struct option * add_common_options(const struct option * longopts)
 
 static const char *common_options_descriptions[] = {
 	"Show this help and quit.",
+	"Display libiio version information.",
 	"Use the XML backend with the provided XML file.",
 	("Use the context at the provided URI."
 		"\n\t\t\teg: 'ip:192.168.2.1', 'ip:pluto.local', or 'ip:'"
@@ -286,6 +288,10 @@ struct iio_context * handle_common_opts(char * name, int argc,
 		switch (c) {
 		case 'h':
 			usage(name, options, options_descriptions);
+			break;
+		case 'V':
+			version(name);
+			exit(0);
 			break;
 		case 'n':
 			if (backend != IIO_LOCAL) {
@@ -432,6 +438,19 @@ void usage(char *name, const struct option *options,
 			"warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n");
 
 	exit(0);
+}
+
+void version(char *name)
+{
+	unsigned int i, major, minor;
+        char git_tag[8];
+
+	printf("%s version: %u.%u (git tag:%s)\n", name, LIBIIO_VERSION_MAJOR, LIBIIO_VERSION_MINOR, LIBIIO_VERSION_GIT);
+	iio_library_get_version(&major, &minor, git_tag);
+        printf("Libiio version: %u.%u (git tag: %s) backends:", major, minor, git_tag);
+        for (i = 0; i < iio_get_backends_count(); i++)
+                printf(" %s", iio_get_backend(i));
+        printf("\n");
 }
 
 uint64_t get_time_us(void)

--- a/tests/iio_common.h
+++ b/tests/iio_common.h
@@ -40,13 +40,14 @@ int iio_device_enable_channel(const struct iio_device *dev, const char * channel
  * If such a character is followed by a colon, the option  requires  an  argument.
  * Two colons mean an option takes an optional argument.
  */
-#define COMMON_OPTIONS "hn:x:u:a::S::T:"
+#define COMMON_OPTIONS "hVn:x:u:a::S::T:"
 
 struct iio_context * handle_common_opts(char * name, int argc,
 	char * const argv[], const char *optstring,
 	const struct option *options, const char *options_descriptions[]);
 struct option * add_common_options(const struct option * longopts);
 void usage(char *name, const struct option *options, const char *options_descriptions[]);
+void version(char *name);
 
 char ** dup_argv(char * name, int argc, char * argv[]);
 void free_argw(int argc, char * argw[]);

--- a/tests/iio_genxml.c
+++ b/tests/iio_genxml.c
@@ -47,6 +47,7 @@ int main(int argc, char **argv)
 		switch (c) {
 		/* All these are handled in the common */
 		case 'h':
+		case 'V':
 		case 'n':
 		case 'x':
 		case 'u':

--- a/tests/iio_info.c
+++ b/tests/iio_info.c
@@ -58,14 +58,6 @@ int main(int argc, char **argv)
 
 	argw = dup_argv(MY_NAME, argc, argv);
 
-	iio_library_get_version(&major, &minor, git_tag);
-	printf("Library version: %u.%u (git tag: %s)\n", major, minor, git_tag);
-
-	printf("Compiled with backends:");
-	for (i = 0; i < iio_get_backends_count(); i++)
-		printf(" %s", iio_get_backend(i));
-	printf("\n");
-
 	ctx = handle_common_opts(MY_NAME, argc, argw, MY_OPTS, options, options_descriptions);
 	opts = add_common_options(options);
 	if (!opts) {
@@ -77,6 +69,7 @@ int main(int argc, char **argv)
 		switch (c) {
 			/* All these are handled in the common */
 		case 'h':
+		case 'V':
 		case 'n':
 		case 'x':
 		case 'u':
@@ -107,6 +100,7 @@ int main(int argc, char **argv)
 	if (!ctx)
 		return EXIT_FAILURE;
 
+	version(MY_NAME);
 	printf("IIO context created with %s backend.\n",
 			iio_context_get_name(ctx));
 

--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -210,6 +210,7 @@ int main(int argc, char **argv)
 		switch (c) {
 		/* All these are handled in the common */
 		case 'h':
+		case 'V':
 		case 'n':
 		case 'x':
 		case 'u':

--- a/tests/iio_reg.c
+++ b/tests/iio_reg.c
@@ -84,6 +84,7 @@ int main(int argc, char **argv)
 		switch (c) {
 		/* All these are handled in the common */
 		case 'h':
+		case 'V':
 		case 'n':
 		case 'x':
 		case 'u':


### PR DESCRIPTION
Today, when debugging things - its sometimes tricky to tell which version of things are installed, since downstream distirbutions split iio-utils and libiio. This commit adds an new option "-V" or "--version" to things to print out the utility version, and the library version (which hopefully matches) seperately.