### PR TITLE
channel: Don't lookup attributes in special case of reading all attrs

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -387,9 +387,11 @@ const char * iio_channel_find_attr(const struct iio_channel *chn,
 ssize_t iio_channel_attr_read(const struct iio_channel *chn,
 		const char *attr, char *dst, size_t len)
 {
-	attr = iio_channel_find_attr(chn, attr);
-	if (!attr)
-		return -ENOENT;
+	if (attr) {
+		attr = iio_channel_find_attr(chn, attr);
+		if (!attr)
+			return -ENOENT;
+	}
 
 	if (chn->dev->ctx->ops->read_channel_attr)
 		return chn->dev->ctx->ops->read_channel_attr(chn,


### PR DESCRIPTION
In the case where we want to read all attributes of a channel, we need to call iio_channel_attr_read() with the 'attr' argument set to NULL. So we skip searching for an attribute in this case.

This was found when calling iio_channel_attr_read_all() which was causing a segmentation fault:
0: __strcmp_avx2 () at ../sysdeps/x86_64/multiarch/strcmp-avx2.S:116
1: iio_channel_do_find_attr  (chn=0x555555ddf950, name=0x0)
2: iio_channel_find_attr (chn=0x555555ddf950, name=0x0)
3: iio_channel_attr_read ()
4: iio_channel_attr_read_all ()