### PR TITLE
iiod: Re-create IIO context when receiving USR1 signal

### DIFF
--- a/iiod/iiod.c
+++ b/iiod/iiod.c
@@ -37,6 +37,11 @@
 #define _STRINGIFY(x) #x
 #define STRINGIFY(x) _STRINGIFY(x)
 
+static int start_iiod(const char *uri, const char *ffs_mountpoint,
+		      const char *uart_params, bool debug, bool interactive,
+		      bool use_aio, uint16_t port, unsigned int nb_pipes,
+		      int ep0_fd);
+
 struct client_data {
 	int fd;
 	bool debug;
@@ -128,6 +133,14 @@ static void set_handler(int signal, void (*handler)(int))
 
 static void sig_handler(int sig)
 {
+	thread_pool_stop(main_thread_pool);
+}
+
+static bool restart_usr1;
+
+static void sig_handler_usr1(int sig)
+{
+	restart_usr1 = true;
 	thread_pool_stop(main_thread_pool);
 }
 
@@ -376,15 +389,12 @@ int main(int argc, char **argv)
 	long nb_pipes = 3, val;
 	char *end;
 	const char *arg = "local:";
-	struct iio_context *ctx;
 	int c, option_index = 0;
 	char *ffs_mountpoint = NULL;
 	char *uart_params = NULL;
 	char err_str[1024];
-	void *xml_zstd;
-	size_t xml_zstd_len = 0;
 	uint16_t port = IIOD_PORT;
-	int ret;
+	int ret, ep0_fd = 0;
 
 	while ((c = getopt_long(argc, argv, "+hVdDiaF:n:s:p:u:",
 					options, &option_index)) != -1) {
@@ -459,8 +469,60 @@ int main(int argc, char **argv)
 		}
 	}
 
-	ctx = iio_create_context_from_uri(arg);
+	main_thread_pool = thread_pool_new();
+	if (!main_thread_pool) {
+		iio_strerror(errno, err_str, sizeof(err_str));
+		IIO_ERROR("Unable to create thread pool: %s\n", err_str);
+		return EXIT_FAILURE;
+	}
 
+	if (WITH_IIOD_USBD && ffs_mountpoint) {
+		ret = init_usb_daemon(ffs_mountpoint, nb_pipes);
+		if (ret < 0) {
+			iio_strerror(errno, err_str, sizeof(err_str));
+			IIO_ERROR("Unable to init USB: %s\n", err_str);
+
+			thread_pool_destroy(main_thread_pool);
+			return EXIT_FAILURE;
+		}
+
+		ep0_fd = ret;
+	}
+
+	set_handler(SIGHUP, sig_handler);
+	set_handler(SIGPIPE, sig_handler);
+	set_handler(SIGINT, sig_handler);
+	set_handler(SIGTERM, sig_handler);
+	set_handler(SIGUSR1, sig_handler_usr1);
+
+	do {
+		thread_pool_restart(main_thread_pool);
+		restart_usr1 = false;
+
+		ret = start_iiod(arg, ffs_mountpoint, uart_params, debug,
+				 interactive, use_aio, port, nb_pipes, ep0_fd);
+	} while (!ret && restart_usr1);
+
+	thread_pool_destroy(main_thread_pool);
+
+	if (WITH_IIOD_USBD && ffs_mountpoint)
+		close(ep0_fd);
+
+	return ret;
+}
+
+static int start_iiod(const char *uri, const char *ffs_mountpoint,
+		      const char *uart_params, bool debug, bool interactive,
+		      bool use_aio, uint16_t port, unsigned int nb_pipes,
+		      int ep0_fd)
+{
+	struct iio_context *ctx;
+	char err_str[1024];
+	void *xml_zstd;
+	size_t xml_zstd_len = 0;
+	int ret;
+
+	ctx = iio_create_context_from_uri(uri);
 	if (!ctx) {
 		iio_strerror(errno, err_str, sizeof(err_str));
 		IIO_ERROR("Unable to create local context: %s\n", err_str);
@@ -469,30 +531,17 @@ int main(int argc, char **argv)
 
 	xml_zstd = get_xml_zstd_data(ctx, &xml_zstd_len);
 
-	main_thread_pool = thread_pool_new();
-	if (!main_thread_pool) {
-		iio_strerror(errno, err_str, sizeof(err_str));
-		IIO_ERROR("Unable to create thread pool: %s\n", err_str);
-		ret = EXIT_FAILURE;
-		goto out_destroy_context;
-	}
-
-	set_handler(SIGHUP, sig_handler);
-	set_handler(SIGPIPE, sig_handler);
-	set_handler(SIGINT, sig_handler);
-	set_handler(SIGTERM, sig_handler);
-
 	if (WITH_IIOD_USBD && ffs_mountpoint) {
 		/* We pass use_aio == true directly, this is ensured to be true
 		 * by the CMake script. */
 		ret = start_usb_daemon(ctx, ffs_mountpoint,
-				debug, true, (unsigned int) nb_pipes,
+				debug, true, (unsigned int) nb_pipes, ep0_fd,
 				main_thread_pool, xml_zstd, xml_zstd_len);
 		if (ret) {
 			iio_strerror(-ret, err_str, sizeof(err_str));
 			IIO_ERROR("Unable to start USB daemon: %s\n", err_str);
 			ret = EXIT_FAILURE;
-			goto out_destroy_thread_pool;
+			goto out_free_xml_data;
 		}
 	}
 
@@ -504,7 +553,7 @@ int main(int argc, char **argv)
 			iio_strerror(-ret, err_str, sizeof(err_str));
 			IIO_ERROR("Unable to start serial daemon: %s\n", err_str);
 			ret = EXIT_FAILURE;
-			goto out_destroy_thread_pool;
+			goto out_thread_pool_stop;
 		}
 	}
 
@@ -513,16 +562,13 @@ int main(int argc, char **argv)
 	else
 		ret = main_server(ctx, debug, xml_zstd, xml_zstd_len, port);
 
+out_thread_pool_stop:
 	/*
 	 * In case we got here through an error in the main thread make sure all
 	 * the worker threads are signaled to shutdown.
 	 */
-
-out_destroy_thread_pool:
 	thread_pool_stop_and_wait(main_thread_pool);
-	thread_pool_destroy(main_thread_pool);
-
-out_destroy_context:
+out_free_xml_data:
 	free(xml_zstd);
 	iio_context_destroy(ctx);
 

--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -92,9 +92,10 @@ void interpreter(struct iio_context *ctx, int fd_in, int fd_out, bool verbose,
 		 bool is_socket, bool is_usb, bool use_aio, struct thread_pool *pool,
 		 const void *xml_zstd, size_t xml_zstd_len);
 
+int init_usb_daemon(const char *ffs, unsigned int nb_pipes);
 int start_usb_daemon(struct iio_context *ctx, const char *ffs,
 		bool debug, bool use_aio, unsigned int nb_pipes,
-		struct thread_pool *pool,
+		int ep0_fd, struct thread_pool *pool,
 		const void *xml_zstd, size_t xml_zstd_len);
 int start_serial_daemon(struct iio_context *ctx, const char *uart_params,
 			bool debug, struct thread_pool *pool,

--- a/iiod/thread-pool.c
+++ b/iiod/thread-pool.c
@@ -185,6 +185,14 @@ bool thread_pool_is_stopped(const struct thread_pool *pool)
 	return pool->stop;
 }
 
+void thread_pool_restart(struct thread_pool *pool)
+{
+	if (pool->stop) {
+		thread_pool_purge_events(pool);
+		pool->stop = false;
+	}
+}
+
 void thread_pool_destroy(struct thread_pool *pool)
 {
 	pthread_mutex_destroy(&pool->thread_count_lock);

--- a/iiod/thread-pool.c
+++ b/iiod/thread-pool.c
@@ -157,11 +157,18 @@ void thread_pool_stop(struct thread_pool *pool)
 	} while (ret == -1 && errno == EINTR);
 }
 
-void thread_pool_stop_and_wait(struct thread_pool *pool)
+static void thread_pool_purge_events(struct thread_pool *pool)
 {
 	uint64_t e;
 	int ret;
 
+	do {
+		ret = read(pool->stop_fd, &e, sizeof(e));
+	} while (ret != -1 || errno == EINTR);
+}
+
+void thread_pool_stop_and_wait(struct thread_pool *pool)
+{
 	thread_pool_stop(pool);
 
 	pthread_mutex_lock(&pool->thread_count_lock);
@@ -170,9 +177,7 @@ void thread_pool_stop_and_wait(struct thread_pool *pool)
 				&pool->thread_count_lock);
 	pthread_mutex_unlock(&pool->thread_count_lock);
 
-	do {
-		ret = read(pool->stop_fd, &e, sizeof(e));
-	} while (ret != -1 || errno == EINTR);
+	thread_pool_purge_events(pool);
 }
 
 bool thread_pool_is_stopped(const struct thread_pool *pool)

--- a/iiod/thread-pool.h
+++ b/iiod/thread-pool.h
@@ -19,6 +19,7 @@ int thread_pool_get_poll_fd(const struct thread_pool *pool);
 void thread_pool_stop(struct thread_pool *pool);
 void thread_pool_stop_and_wait(struct thread_pool *pool);
 bool thread_pool_is_stopped(const struct thread_pool *pool);
+void thread_pool_restart(struct thread_pool *pool);
 
 void thread_pool_destroy(struct thread_pool *pool);
 


### PR DESCRIPTION
Handle USR1 as a signal that IIOD should re-create the IIO context.
This allows support for hot-plugging IIO devices at runtime; the USR1
signal can then be sent from a udev script, for instance.