### PR TITLE
local: change exclusionary language

### DIFF
--- a/local.c
+++ b/local.c
@@ -96,7 +96,7 @@ struct iio_channel_pdata {
 	unsigned int nb_protected_attrs;
 };
 
-static const char * const device_attrs_blacklist[] = {
+static const char * const device_attrs_denylist[] = {
 	"dev",
 	"uevent",
 };
@@ -1265,8 +1265,8 @@ static int add_attr_to_device(struct iio_device *dev, const char *attr)
 {
 	unsigned int i;
 
-	for (i = 0; i < ARRAY_SIZE(device_attrs_blacklist); i++)
-		if (!strcmp(device_attrs_blacklist[i], attr))
+	for (i = 0; i < ARRAY_SIZE(device_attrs_denylist); i++)
+		if (!strcmp(device_attrs_denylist[i], attr))
 			return 0;
 
 	if (!strcmp(attr, "name"))


### PR DESCRIPTION
No functional change.

Per: https://www.ietf.org/archive/id/draft-knodel-terminology-09.html remove some exclusionary language that was in the codebase.