### PR TITLE
fix: move declaration of iio_device_set_kernel_buffers_count from iio/iio.h into iio-compat.h

### DIFF
--- a/iio-compat.h
+++ b/iio-compat.h
@@ -216,6 +216,18 @@ __api __check_ret int iio_context_get_version(const struct iio_context *ctx,
 					      char git_tag[8]);
 
 
+/** @brief Configure the number of kernel buffers for a device
+ *
+ * This function allows to change the number of buffers on kernel side.
+ * @param dev A pointer to an iio_device structure
+ * @param nb_buffers The number of buffers
+ * @return On success, 0 is returned
+ * @return On error, a negative errno code is returned */
+__api __check_ret int iio_device_set_kernel_buffers_count(const struct iio_device *dev,
+		unsigned int nb_buffers);
+
+
+
 /** @} *//* ------------------------------------------------------------------*/
 
 #undef __api

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -908,15 +908,6 @@ __api __check_ret int iio_device_set_trigger(const struct iio_device *dev,
  * @return True if the device is a trigger, False otherwise */
 __api __check_ret __pure bool iio_device_is_trigger(const struct iio_device *dev);
 
-/** @brief Configure the number of kernel buffers for a device
- *
- * This function allows to change the number of buffers on kernel side.
- * @param dev A pointer to an iio_device structure
- * @param nb_buffers The number of buffers
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_set_kernel_buffers_count(const struct iio_device *dev,
-		unsigned int nb_buffers);
 
 /** @} *//* ------------------------------------------------------------------*/
 /* ------------------------- Channel functions -------------------------------*/


### PR DESCRIPTION
this addresses issue https://github.com/analogdevicesinc/libiio/issues/986