### PR TITLE
codespell: ignore 'MiS'

### DIFF
--- a/.codespell-ignore.txt
+++ b/.codespell-ignore.txt
@@ -1,6 +1,7 @@
 SOM
 som
 mitre
+mis
 tread
 elease
 tREAD


### PR DESCRIPTION
Otherwise Codespell fails when processing the examples.