### PR TITLE
cmake: Fix invalid Provides: field in Debian packages

### DIFF
--- a/cmake/LinuxPackaging.cmake
+++ b/cmake/LinuxPackaging.cmake
@@ -140,10 +140,8 @@ endif()
 
 # Make sure the generated .deb cannot be installed alongside the Debian ones
 set(CPACK_DEBIAN_PACKAGE_PROVIDES
-	"libiio0 (= ${LIBIIO_VERSION}), "
-	"libiio-dev (= ${LIBIIO_VERSION}), "
-	"libiio-utils (= ${LIBIIO_VERSION}), "
-	"iiod (= ${LIBIIO_VERSION})")
+	"libiio0 (= ${LIBIIO_VERSION}), libiio-dev (= ${LIBIIO_VERSION}), libiio-utils (= ${LIBIIO_VERSION}), iiod (= ${LIBIIO_VERSION})"
+)
 set(CPACK_DEBIAN_PACKAGE_CONFLICTS "libiio0, libiio-dev, libiio-utils, iiod")
 set(CPACK_DEBIAN_PACKAGE_REPLACES "libiio0, libiio-dev, libiio-utils, iiod")
 


### PR DESCRIPTION
CMake doesn't really like multi-line strings and considers it as a semicolon-separated list.