### PR TITLE
IIOD: Better handle errors of iio_buffer_{refill,push}

### DIFF
--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -678,9 +678,22 @@ static void rw_thd(struct thread_pool *pool, void *d)
 			}
 
 			if (ret < 0) {
-				IIO_ERROR("Reading from device failed: %i\n",
-						(int) ret);
-				break;
+				/* Reading from the device failed - signal the
+				 * error to all connected clients. */
+
+				/* Don't use SLIST_FOREACH - see comment below */
+				for (thd = SLIST_FIRST(&entry->thdlist_head);
+				     thd; thd = next_thd) {
+					next_thd = SLIST_NEXT(thd, dev_list_entry);
+
+					if (!thd->active || thd->is_writer)
+						continue;
+
+					signal_thread(thd, ret);
+				}
+
+				pthread_mutex_unlock(&entry->thdlist_lock);
+				continue;
 			}
 
 			nb_bytes = ret;
@@ -750,18 +763,18 @@ static void rw_thd(struct thread_pool *pool, void *d)
 				pthread_mutex_unlock(&entry->thdlist_lock);
 				continue;
 			}
-			if (ret < 0) {
-				IIO_ERROR("Writing to device failed: %i\n",
-						(int) ret);
-				break;
-			}
 
 			/* Signal threads which completed their RW command */
 			for (thd = SLIST_FIRST(&entry->thdlist_head);
 					thd; thd = next_thd) {
 				next_thd = SLIST_NEXT(thd, dev_list_entry);
-				if (thd->active && thd->is_writer &&
-						thd->nb < sample_size)
+
+				if (!thd->active || !thd->is_writer)
+					continue;
+
+				if (ret < 0)
+					signal_thread(thd, ret);
+				else if (thd->nb < sample_size)
 					signal_thread(thd, thd->nb);
 			}
 


### PR DESCRIPTION
Pass the error code to the connected clients, instead of disconnecting them.

This means that for a very slow device, a connected client will simply get a -ETIMEDOUT error when a configured timeout expires, and will still be able to communicate with the server.

Fixes: #981.