### PR TITLE
dns_sd_windows: Fix invalid printf format string

### DIFF
--- a/dns_sd_windows.c
+++ b/dns_sd_windows.c
@@ -453,7 +453,7 @@ int dnssd_find_hosts(struct dns_sd_discovery_data **ddata)
 	for (isock = 0; isock < num_sockets; ++isock)
 		mdns_socket_close(sockets[isock]);
 
-	IIO_DEBUG("Closed %i socket%s, processed %i record%s\n",
+	IIO_DEBUG("Closed %i socket%s, processed %zu record%s\n",
 		   num_sockets, (num_sockets > 1) ? "s" : "",
 		   records, (records > 1) ? "s" : "" );
 


### PR DESCRIPTION
It should use "%zu" to print a size_t.

This fixes a compiler warning under MinGW when the log level is set to Debug.