### PR TITLE
CI: fix macOS tar balls

### DIFF
--- a/CI/azure/macos_tar_fixup.sh
+++ b/CI/azure/macos_tar_fixup.sh
@@ -64,6 +64,9 @@ do
 done
 cd ../../../../
 
+# Create links to libusb-1.0.0.dylib
+ln -s libusb-1.0.dylib usr/local/lib/libusb-1.0.0.dylib
+
 # Remove old tar and create new one
 rm "../${tarname}"
 tar -czf "../${tarname}" .


### PR DESCRIPTION
Create a symbolic link for libusb-1.0.0.dylib because iio tools is linked to libusb-1.0.0.dylib but we have libusb-1.0.dylib on machines.