### PR TITLE
device: Fix sample size calculation

### DIFF
--- a/device.c
+++ b/device.c
@@ -442,7 +442,7 @@ ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 		const uint32_t *mask, size_t words)
 {
 	ssize_t size = 0;
-	unsigned int i;
+	unsigned int i, largest = 1;
 	const struct iio_channel *prev = NULL;
 
 	if (words != (dev->nb_channels + 31) / 32)
@@ -463,6 +463,9 @@ ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 			continue;
 		}
 
+		if (length > largest)
+			largest = length;
+
 		if (size % length)
 			size += 2 * length - (size % length);
 		else
@@ -470,6 +473,10 @@ ssize_t iio_device_get_sample_size_mask(const struct iio_device *dev,
 
 		prev = chn;
 	}
+
+	if (size % largest)
+		size += largest - (size % largest);
+
 	return size;
 }
 


### PR DESCRIPTION
If we consider a system where channel 0 delivers 32-bit data and channel 1 delivers 16-bit data, the sample size computed would be (4 + 2) == 6 bytes.

This is not correct, as it does not take into account the padding needed until the next sample, which must be computed in a way that all the elements of the next sample are aligned to their own size.

This new algorithm follows what the Linux kernel does (see: iio_compute_scan_bytes() in drivers/iio/industrialio-buffer.c as of v6.4).

This should fix a practical issue with the ADIS16475 driver, reported by @rbolboac.