### PR TITLE
fix device names in scan

### DIFF
--- a/dns_sd.c
+++ b/dns_sd.c
@@ -123,7 +123,7 @@ static int dnssd_fill_context_info(struct iio_context_info *info,
 	} else {
 		iio_snprintf(description, sizeof(description), "%s (", addr_str);
 		p = description + strlen(description);
-		for (i = 0; i < iio_context_get_devices_count(ctx) - 1; i++) {
+		for (i = 0; i < iio_context_get_devices_count(ctx); i++) {
 			const struct iio_device *dev = iio_context_get_device(ctx, i);
 			const char *name = iio_device_get_name(dev);
 			if (name) {

--- a/local.c
+++ b/local.c
@@ -2177,7 +2177,7 @@ static int build_names(void *d, const char *path)
 	dst = cat_file(buf);
 	if (dst) {
 		len = strnlen(names, sizeof(buf));
-		iio_snprintf(&names[len], BUF_SIZE - len - 1, "%s, ", dst);
+		iio_snprintf(&names[len], BUF_SIZE - len - 1, "%s,", dst);
 		free(dst);
 	}
 	return 0;
@@ -2212,7 +2212,7 @@ int local_context_scan(struct iio_scan_result *scan_result)
 	if (machine) {
 		if (names[0]) {
 			ret = strnlen(names, sizeof(names));
-			names[ret - 2] = '\0';
+			names[ret - 1] = '\0';
 			iio_snprintf(buf, sizeof(buf), "(%s on %s)", names, machine);
 		} else
 			iio_snprintf(buf, sizeof(buf), "(Local IIO devices on %s)", machine);


### PR DESCRIPTION
This fixes two minor things in the scan context.
- an off by one error (we never printed out all the device names)
- an extra space in the device names in local contexts, so it matches usb and network scan contexts.

-Robin