### PR TITLE
CI: OSX: Fix rpath of libiio + dependencies

### DIFF
--- a/CI/azure/macos_tar_fixup.sh
+++ b/CI/azure/macos_tar_fixup.sh
@@ -14,58 +14,35 @@ tar -xzf "${tarname}" -C temp_tar
 mv "temp_tar/${subfoldername}" temp
 cd temp
 
-# Update rpath of library and tools
-libusb_loc=$(find $(brew --cellar) -name libusb-1.0.dylib)
-libxml_loc=$(find $(brew --cellar) -name libxml2.dylib)
-libserialport_loc=$(find $(brew --cellar) -name libserialport.dylib)
-libiio_loc=$(find . -name iio | grep Versions)
-libiioheader_loc=$(find . -name iio.h)
+deps_dir=Library/Frameworks/iio.framework/Versions/Current/Dependencies
+libiio_loc=Library/Frameworks/iio.framework/Versions/Current/iio
+libiioheader_loc=Library/Frameworks/iio.framework/Versions/Current/Headers/iio.h
 
-if [ ! -f "${libusb_loc}" ]; then
-        echo "libusb library not found"
-        exit 1
-fi
-if [ ! -f "${libxml_loc}" ]; then
-        echo "libxml library not found"
-        exit 1
-fi
-if [ ! -f "${libserialport_loc}" ]; then
-        echo "libserialport library not found"
-        exit 1
-fi
+mkdir -p "${deps_dir}"
 
 # Create links to framework files
 mkdir -p usr/local/{lib,include}
-ln -fs "${libiio_loc}" usr/local/lib/libiio.dylib
-ln -fs "${libiioheader_loc}" usr/local/include/iio.h
-
-# Copy dependent libs to local libs
-cp "${libusb_loc}" usr/local/lib/
-cp "${libxml_loc}" usr/local/lib/
-cp "${libserialport_loc}" usr/local/lib/
-chmod +w usr/local/lib/libusb-1.0.dylib
-chmod +w usr/local/lib/libxml2.dylib
-chmod +w usr/local/lib/libserialport.dylib
-install_name_tool -id @rpath/libusb-1.0.dylib usr/local/lib/libusb-1.0.dylib
-install_name_tool -id @rpath/libxml2.dylib usr/local/lib/libxml2.dylib
-install_name_tool -id @rpath/libserialport.dylib usr/local/lib/libserialport.dylib
+ln -fs "../../../${libiio_loc}" usr/local/lib/libiio.dylib
+ln -fs "../../../${libiioheader_loc}" usr/local/include/iio.h
 
 # Update rpath of library
-install_name_tool -change "${libusb_loc}" "@rpath/libusb-1.0.dylib" "${libiio_loc}"
-install_name_tool -change "${libxml_loc}" "@rpath/libxml2.dylib" "${libiio_loc}"
-install_name_tool -change "${libserialport_loc}" "@rpath/libserialport.dylib" "${libiio_loc}"
 install_name_tool -add_rpath @loader_path/. "${libiio_loc}"
 
+# Copy dependent libs to local libs, and update rpath of dependencies
+for each in $(otool -L "${libiio_loc}" |grep homebrew |cut -f2 | cut -d' ' -f1) ; do
+	name=$(basename "${each}")
+	cp "${each}" "${deps_dir}"
+	chmod +w "${deps_dir}/${name}"
+	install_name_tool -id "@rpath/Dependencies/${name}" "${deps_dir}/${name}"
+	install_name_tool -change "${each}" "@rpath/Dependencies/${name}" "${libiio_loc}"
+	codesign --force -s - "${deps_dir}/${name}"
+done
+
 # Update tools
-cd Library/Frameworks/iio.framework/Tools
-for tool in *;
+for tool in Library/Frameworks/iio.framework/Tools/*;
 do
         install_name_tool -add_rpath @loader_path/../.. "${tool}"
 done
-cd ../../../../
-
-# Create links to libusb-1.0.0.dylib
-ln -s libusb-1.0.dylib usr/local/lib/libusb-1.0.0.dylib
 
 # Remove old tar and create new one
 rm "../${tarname}"


### PR DESCRIPTION
- Install the dependencies to Library/Frameworks/iio.framework/Versions/Current/Dependencies, and fix the rpath which did not work properly.

- Fix the broken symbolic links in /usr/local/{lib,include}