### PR TITLE
CMake: Bump minimal required version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 message(STATUS "cmake version: ${CMAKE_VERSION}")
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(libiio C)
 
 if (MINGW)
@@ -93,13 +93,6 @@ elseif (CMAKE_COMPILER_IS_GNUCC)
 	check_c_compiler_flag(-Wshadow HAS_WSHADOW)
 	if (HAS_WSHADOW)
 		set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wshadow")
-	endif()
-	# cmake 2.8 doesn't support C_STANDARD defined in set_target_properties
-	if (${CMAKE_VERSION} VERSION_LESS "3.2")
-		check_c_compiler_flag(-std=c99 HAS_C99)
-		if (HAS_C99)
-			set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
-		endif()
 	endif()
 
 	# Per http://www.mingw.org/wiki/Use_more_recent_defined_functions

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 project(iiopp-enum CXX)
 add_executable(iiopp-enum examples/iiopp-enum.cpp iiopp.h ${LIBIIO_RC})

--- a/bindings/csharp/CMakeLists.txt
+++ b/bindings/csharp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(libiio-sharp NONE)
 
 if (WIN32)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(libiio-py NONE)
 
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 
@@ -42,10 +42,6 @@ else()
 endif()
 
 if(WITH_DOC)
-	if(${CMAKE_VERSION} VERSION_LESS "3.2.0")
-		# cmake -E env was added in 3.2
-		message(FATAL_ERROR "Sorry, you can't build python doc with ancient cmake, please update")
-	endif()
 	find_program(SPHINX_EXECUTABLE
 		NAMES sphinx-build
 		DOC "Sphinx Documentation Builder (sphinx-doc.org)"

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 project(ad9361-iiostream C)
 project(ad9371-iiostream C)

--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(iiod C)
 
 include(FindBISON)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 
 project(iio_genxml  C)
 project(iio_info    C)


### PR DESCRIPTION
CMake v3.10 is from 2018. All stable distributions like Ubuntu 18.04, OpenSUSE 15 or CentOS 7 provide a version of CMake >= 3.10.

Since CMake v3.27 refuses to build anything that claims compatibility with CMake 2.x, bump the minimal required version to CMake 3.10.