### PR TITLE
debug.h: Update log macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -712,3 +712,4 @@ string(REPLACE ";" " " IIO_FEATURES_OFF "${IIO_FEATURES_OFF}")
 
 message(STATUS "Features enabled : ${IIO_FEATURES_ON}")
 message(STATUS "Features disabled: ${IIO_FEATURES_OFF}")
+message(STATUS "LOG_LEVEL set to \"${LOG_LEVEL}\"")

--- a/debug.h
+++ b/debug.h
@@ -21,20 +21,6 @@
 
 /* -------------------- */
 
-#ifdef WITH_COLOR_DEBUG
-#ifndef COLOR_DEBUG
-#define COLOR_DEBUG   "\e[0;32m"
-#endif
-#ifndef COLOR_WARNING
-#define COLOR_WARNING "\e[01;35m"
-#endif
-#ifndef COLOR_ERROR
-#define COLOR_ERROR   "\e[01;31m"
-#endif
-
-#define COLOR_END "\e[0m"
-#endif
-
 /* Many of these debug printf include a Flawfinder: ignore, this is because,
  * according to https://cwe.mitre.org/data/definitions/134.html which describes
  * functions that accepts a format string as an argument, but the format
@@ -42,52 +28,28 @@
  * IIO_WARNING, and IIO_ERRRO functions are called internally from the
  * library, have fixed format strings and can not be modified externally.
  */
-#if (LOG_LEVEL >= Debug_L)
-# ifdef COLOR_DEBUG
-#  define IIO_DEBUG(str, ...) \
-    fprintf(stdout, COLOR_DEBUG "DEBUG: " str COLOR_END, ##__VA_ARGS__) /* Flawfinder: ignore */
-# else
-#  define IIO_DEBUG(...) \
-    fprintf(stdout, "DEBUG: " __VA_ARGS__) /* Flawfinder: ignore */
-# endif
-#else
-#define IIO_DEBUG(...) do { } while (0)
-#endif
+#define IIO_DEBUG(...) \
+    do { \
+	if (LOG_LEVEL >= Debug_L) \
+            fprintf(stdout, "DEBUG: " __VA_ARGS__); /* Flawfinder: ignore */ \
+    } while (0)
 
-#if (LOG_LEVEL >= Info_L)
-# ifdef COLOR_INFO
-#  define IIO_INFO(str, ...) \
-    fprintf(stdout, COLOR_INFO str COLOR_END, ##__VA_ARGS__) /* Flawfinder: ignore */
-# else
-#  define IIO_INFO(...) \
-    fprintf(stdout, __VA_ARGS__) /* Flawfinder: ignore */
-# endif
-#else
-#define IIO_INFO(...) do { } while (0)
-#endif
+#define IIO_INFO(...) \
+    do { \
+	if (LOG_LEVEL >= Info_L) \
+            fprintf(stdout, __VA_ARGS__); /* Flawfinder: ignore */ \
+    } while (0)
 
-#if (LOG_LEVEL >= Warning_L)
-# ifdef COLOR_WARNING
-#  define IIO_WARNING(str, ...) \
-    fprintf(stderr, COLOR_WARNING "WARNING: " str COLOR_END, ##__VA_ARGS__) /* Flawfinder: ignore */
-# else
-#  define IIO_WARNING(...) \
-    fprintf(stderr, "WARNING: " __VA_ARGS__) /* Flawfinder: ignore */
-# endif
-#else
-#define IIO_WARNING(...) do { } while (0)
-#endif
+#define IIO_WARNING(...) \
+    do { \
+	if (LOG_LEVEL >= Warning_L) \
+            fprintf(stderr, "WARNING: " __VA_ARGS__); /* Flawfinder: ignore */ \
+    } while (0)
 
-#if (LOG_LEVEL >= Error_L)
-# ifdef COLOR_ERROR
-#  define IIO_ERROR(str, ...) \
-    fprintf(stderr, COLOR_ERROR "ERROR: " str COLOR_END, ##__VA_ARGS__) /* Flawfinder: ignore */
-# else
-#  define IIO_ERROR(...) \
-    fprintf(stderr, "ERROR: " __VA_ARGS__) /* Flawfinder: ignore */
-# endif
-#else
-#define IIO_ERROR(...) do { } while (0)
-#endif
+#define IIO_ERROR(...) \
+    do { \
+	if (LOG_LEVEL >= Error_L) \
+            fprintf(stderr, "ERROR: " __VA_ARGS__); /* Flawfinder: ignore */ \
+    } while (0)
 
 #endif


### PR DESCRIPTION
Remove the coloring feature, because the WITH_COLOR_DEBUG macro was not set anywhere, and would trigger compilation errors when set (since we enforce strict C99 compliance).

The log macros are also not conditionally-compiled anymore, and rely on the compiler detecting them as dead code instead. This should fix all issues with variables detected as unused by the compiler when the 'NoLog' level is used.