### PR TITLE
tests: Standardize programs error codes when scanning

### DIFF
--- a/examples/iio_adi_xflow_check.c
+++ b/examples/iio_adi_xflow_check.c
@@ -153,13 +153,13 @@ int main(int argc, char **argv)
 	const char *device_name;
 	struct iio_device *dev;
 	char unit;
-	int ret;
+	int ret = EXIT_FAILURE;
 	struct option *opts;
-	bool do_scan = false;
 
 	argw = dup_argv(MY_NAME, argc, argv);
 
-	ctx = handle_common_opts(MY_NAME, argc, argw, MY_OPTS, options, options_descriptions);
+	ctx = handle_common_opts(MY_NAME, argc, argw, MY_OPTS,
+				 options, options_descriptions, &ret);
 	opts = add_common_options(options);
 	if (!opts) {
 		fprintf(stderr, "Failed to add common options\n");
@@ -177,8 +177,6 @@ int main(int argc, char **argv)
 		case 'T':
 			break;
 		case 'S':
-			do_scan = true;
-			/* FALLTHROUGH */
 		case 'a':
 			if (!optarg && argc > optind && argv[optind] != NULL
 					&& argv[optind][0] != '-')
@@ -206,9 +204,6 @@ int main(int argc, char **argv)
 	}
 	free(opts);
 
-	if (do_scan)
-		return EXIT_SUCCESS;
-
 	if (optind + 1 != argc) {
 		fprintf(stderr, "Incorrect number of arguments.\n\n");
 		usage(MY_NAME, options, options_descriptions);
@@ -216,7 +211,7 @@ int main(int argc, char **argv)
 	}
 
 	if (!ctx)
-		return EXIT_FAILURE;
+		return ret;
 
 #ifndef _WIN32
 	set_handler(SIGHUP, &quit_all);

--- a/tests/iio_attr.c
+++ b/tests/iio_attr.c
@@ -346,10 +346,10 @@ int main(int argc, char **argv)
 	bool found_err = false, read_err = false, write_err = false,
 		dev_found = false, attr_found = false, ctx_found = false,
 		debug_found = false, channel_found = false ;
-	bool context_scan = false;
 	unsigned int i;
 	char *wbuf = NULL;
 	struct option *opts;
+	int ret = EXIT_FAILURE;
 
 	argw = dup_argv(MY_NAME, argc, argv);
 
@@ -364,7 +364,8 @@ int main(int argc, char **argv)
 		argd--;
 	}
 
-	ctx = handle_common_opts(MY_NAME, argd, argw, MY_OPTS, options, options_descriptions);
+	ctx = handle_common_opts(MY_NAME, argd, argw, MY_OPTS,
+				 options, options_descriptions, &ret);
 	opts = add_common_options(options);
 	if (!opts) {
 		fprintf(stderr, "Failed to add common options\n");
@@ -382,8 +383,6 @@ int main(int argc, char **argv)
 		case 'T':
 			break;
 		case 'S':
-			context_scan = true;
-			/* FALLTHRU */
 		case 'a':
 			if (!optarg && argc > optind && argv[optind] != NULL
 					&& argv[optind][0] != '-')
@@ -443,11 +442,8 @@ int main(int argc, char **argv)
 
 	free(opts);
 
-	if (context_scan)
-		return EXIT_SUCCESS;
-
 	if (!ctx)
-		return EXIT_FAILURE;
+		return ret;
 
 	if (gen_code) {
 		if (!gen_test_path(gen_file)) {
@@ -600,7 +596,6 @@ int main(int argc, char **argv)
 		ctx_found = true;
 		for (i = 0; i < nb_ctx_attrs; i++) {
 			const char *key, *value;
-			ssize_t ret;
 
 			ret = iio_context_get_attr(ctx, i, &key, &value);
 			if (!ret) {
@@ -776,7 +771,6 @@ int main(int argc, char **argv)
 					continue;
 
 				for (k = 0; k < nb_attrs; k++) {
-					int ret;
 					const char *attr =
 						iio_channel_get_attr(ch, k);
 
@@ -808,7 +802,6 @@ int main(int argc, char **argv)
 			}
 
 			if (search_device && device_index && nb_attrs) {
-				int ret;
 				for (j = 0; j < nb_attrs; j++) {
 					const char *attr = iio_device_get_attr(dev, j);
 
@@ -841,7 +834,6 @@ int main(int argc, char **argv)
 
 			if (search_buffer && device_index && nb_attrs) {
 				for (j = 0; j < nb_attrs; j++) {
-					int ret;
 					const char *attr = iio_device_get_buffer_attr(dev, j);
 
 					if ((attr_index && str_match(attr, argw[attr_index],
@@ -867,7 +859,6 @@ int main(int argc, char **argv)
 
 			if (search_debug && device_index && nb_attrs) {
 				for (j = 0; j < nb_attrs; j++) {
-					int ret;
 					const char *attr = iio_device_get_debug_attr(dev, j);
 
 					if ((attr_index && str_match(attr, argw[attr_index],

--- a/tests/iio_common.h
+++ b/tests/iio_common.h
@@ -31,7 +31,8 @@ enum backend {
 void * xmalloc(size_t n, const char *name);
 char *cmn_strndup(const char *str, size_t n);
 
-struct iio_context * autodetect_context(bool rtn, const char *name, const char *scan);
+struct iio_context * autodetect_context(bool rtn, const char *name,
+					const char *scan, int *err_code);
 unsigned long int sanitize_clamp(const char *name, const char *argv,
 	uint64_t min, uint64_t max);
 int iio_device_enable_channel(const struct iio_device *dev, const char * channel, bool type);
@@ -44,7 +45,8 @@ int iio_device_enable_channel(const struct iio_device *dev, const char * channel
 
 struct iio_context * handle_common_opts(char * name, int argc,
 	char * const argv[], const char *optstring,
-	const struct option *options, const char *options_descriptions[]);
+	const struct option *options, const char *options_descriptions[],
+	int *ret);
 struct option * add_common_options(const struct option * longopts);
 void usage(char *name, const struct option *options, const char *options_descriptions[]);
 void version(char *name);

--- a/tests/iio_genxml.c
+++ b/tests/iio_genxml.c
@@ -31,12 +31,13 @@ int main(int argc, char **argv)
 	char *xml;
 	const char *tmp;
 	struct iio_context *ctx;
-	int c;
 	size_t xml_len;
 	struct option *opts;
+	int c, ret = EXIT_FAILURE;
 
 	argw = dup_argv(MY_NAME, argc, argv);
-	ctx = handle_common_opts(MY_NAME, argc, argw, "", options, options_descriptions);
+	ctx = handle_common_opts(MY_NAME, argc, argw, "",
+				 options, options_descriptions, &ret);
 	opts = add_common_options(options);
 	if (!opts) {
 		fprintf(stderr, "Failed to add common options\n");
@@ -73,7 +74,7 @@ int main(int argc, char **argv)
 	}
 
 	if (!ctx)
-		return EXIT_FAILURE;
+		return ret;
 
 	tmp = iio_context_get_xml(ctx);
 	if (!tmp) {

--- a/tests/iio_info.c
+++ b/tests/iio_info.c
@@ -53,12 +53,13 @@ int main(int argc, char **argv)
 	int c;
 	unsigned int i, major, minor;
 	char git_tag[8];
-	int ret;
 	struct option *opts;
+	int ret = EXIT_FAILURE;
 
 	argw = dup_argv(MY_NAME, argc, argv);
 
-	ctx = handle_common_opts(MY_NAME, argc, argw, MY_OPTS, options, options_descriptions);
+	ctx = handle_common_opts(MY_NAME, argc, argw, MY_OPTS,
+				 options, options_descriptions, &ret);
 	opts = add_common_options(options);
 	if (!opts) {
 		fprintf(stderr, "Failed to add common options\n");
@@ -82,8 +83,8 @@ int main(int argc, char **argv)
 				optind++;
 			break;
 		case 's':
-			autodetect_context(false, MY_NAME, NULL);
-			return EXIT_SUCCESS;
+			autodetect_context(false, MY_NAME, NULL, &ret);
+			return ret;
 		case '?':
 			printf("Unknown argument '%c'\n", c);
 			return EXIT_FAILURE;
@@ -98,7 +99,7 @@ int main(int argc, char **argv)
 	}
 
 	if (!ctx)
-		return EXIT_FAILURE;
+		return ret;
 
 	version(MY_NAME);
 	printf("IIO context created with %s backend.\n",

--- a/tests/iio_readdev.c
+++ b/tests/iio_readdev.c
@@ -193,12 +193,14 @@ int main(int argc, char **argv)
 	struct option *opts;
 	bool mib, benchmark = false;
 	uint64_t before = 0, after, rate, total;
+	int err_code = EXIT_FAILURE;
 
 	argw = dup_argv(MY_NAME, argc, argv);
 
 	setup_sig_handler();
 
-	ctx = handle_common_opts(MY_NAME, argc, argw, MY_OPTS, options, options_descriptions);
+	ctx = handle_common_opts(MY_NAME, argc, argw, MY_OPTS,
+				 options, options_descriptions, &err_code);
 	opts = add_common_options(options);
 	if (!opts) {
 		fprintf(stderr, "Failed to add common options\n");
@@ -260,7 +262,7 @@ int main(int argc, char **argv)
 	}
 
 	if (!ctx)
-		return EXIT_FAILURE;
+		return err_code;
 
 	if (!argw[optind]) {
 		unsigned int nb_devices = iio_context_get_devices_count(ctx);

--- a/tests/iio_reg.c
+++ b/tests/iio_reg.c
@@ -66,14 +66,14 @@ int main(int argc, char **argv)
 	unsigned long addr;
 	struct iio_context *ctx;
 	struct iio_device *dev;
-	int c;
+	int c, ret = EXIT_FAILURE;
 	char * name;
 	struct option *opts;
-	bool do_scan = false;
 
 	argw = dup_argv(MY_NAME, argc, argv);
 
-	ctx = handle_common_opts(MY_NAME, argc, argw, "", options, options_descriptions);
+	ctx = handle_common_opts(MY_NAME, argc, argw, "",
+				 options, options_descriptions, &ret);
 	opts = add_common_options(options);
 	if (!opts) {
 		fprintf(stderr, "Failed to add common options\n");
@@ -91,8 +91,6 @@ int main(int argc, char **argv)
 		case 'T':
 			break;
 		case 'S':
-			do_scan = true;
-			/* FALLTHRU */
 		case 'a':
 			if (!optarg && argc > optind && argv[optind] != NULL
 					&& argv[optind][0] != '-')
@@ -105,13 +103,13 @@ int main(int argc, char **argv)
 	}
 	free(opts);
 
-	if (do_scan)
-		return EXIT_SUCCESS;
-
 	if ((argc - optind) < 2 || (argc - optind) > 3) {
 		usage(MY_NAME, options, options_descriptions);
 		return EXIT_SUCCESS;
 	}
+
+	if (!ctx)
+		return ret;
 
 	name = cmn_strndup(argw[optind], NAME_MAX);
 	dev = iio_context_find_device(ctx, name);

--- a/tests/iio_writedev.c
+++ b/tests/iio_writedev.c
@@ -204,12 +204,14 @@ int main(int argc, char **argv)
 	ssize_t ret;
 	struct option *opts;
 	uint64_t before = 0, after, rate, total;
+	int err_code = EXIT_FAILURE;
 
 	argw = dup_argv(MY_NAME, argc, argv);
 
 	setup_sig_handler();
 
-	ctx = handle_common_opts(MY_NAME, argc, argw, MY_OPTS, options, options_descriptions);
+	ctx = handle_common_opts(MY_NAME, argc, argw, MY_OPTS,
+				 options, options_descriptions, &err_code);
 	opts = add_common_options(options);
 	if (!opts) {
 		fprintf(stderr, "Failed to add common options\n");
@@ -272,7 +274,7 @@ int main(int argc, char **argv)
 	}
 
 	if (!ctx)
-		return EXIT_FAILURE;
+		return err_code;
 
 	if (!argw[optind]) {
 		unsigned int nb_devices = iio_context_get_devices_count(ctx);


### PR DESCRIPTION
The tools (as well as the iio_adi_xflow_check program) will now return 1 when scanning failed, or 0 when scanning detected at least one IIO context.