### PR TITLE
Add FreeBSD CI build

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,0 +1,32 @@
+
+name: FreeBSD Test
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: macos-12
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["12.3", "13.2"]
+    name: Test FreeBSD
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install libiio dependencies of FreeBSD
+      id: test
+      uses: vmactions/freebsd-vm@v0
+      with:
+        release: ${{ matrix.os }}
+        usesh: true
+        prepare: |
+          pkg update
+          pkg install -y git cmake ninja libxml2 bison flex libserialport avahi doxygen graphviz
+        run: |
+         mkdir build
+         cd build
+         cmake .. -DWITH_SERIAL_BACKEND=ON
+         make
+
+
+


### PR DESCRIPTION
PR adds FreeBSD as a CI job. Right now USB and avahi are disabled since the build fails. Looks like Avahi is broken in ports for 12.x at least

Please comment if this should include other BSD versions or flavors or something else