### PR TITLE
DMABUF API v3

### DIFF
--- a/README_BUILD.md
+++ b/README_BUILD.md
@@ -109,6 +109,7 @@ Cmake Options       | Default | Description                                    |
 `WITH_IIOD_NETWORK` |  ON | Add network (TCP/IP) support                         |
 `WITH_IIOD_SERIAL`  |  ON | Add serial (UART) support                            |
 `WITH_IIOD_USBD`    |  ON | Add support for USB through FunctionFS within IIOD   |
+`WITH_IIOD_USB_DMABUF` | OFF | Enable DMABUF support on the USB stack            |
 `WITH_IIOD_V0_COMPAT` |  ON | Add support for Libiio v0.x protocol and clients |
 `WITH_LIBTINYIIOD`  | OFF | Build libtinyiiod                                    |
 `WITH_AIO`          |  ON | Build IIOD with async. I/O support                   |

--- a/block.c
+++ b/block.c
@@ -21,6 +21,8 @@ struct iio_block {
 
 	struct iio_task_token *token;
 	size_t bytes_used;
+
+	int dmabuf_fd;
 };
 
 struct iio_block *
@@ -41,13 +43,19 @@ iio_buffer_create_block(struct iio_buffer *buf, size_t size)
 	if (!block)
 		return iio_ptr(-ENOMEM);
 
+	block->dmabuf_fd = -EINVAL;
+
 	if (ops->create_block) {
 		pdata = ops->create_block(buf->pdata, size, &block->data);
 		ret = iio_err(pdata);
-		if (!ret)
+		if (!ret) {
 			block->pdata = pdata;
-		else if (ret != -ENOSYS)
+
+			if (ops->get_dmabuf_fd)
+				block->dmabuf_fd = ops->get_dmabuf_fd(pdata);
+		} else if (ret != -ENOSYS) {
 			goto err_free_block;
+		}
 	}
 
 	if (!block->pdata) {
@@ -294,6 +302,11 @@ iio_block_foreach_sample(const struct iio_block *block,
 struct iio_buffer * iio_block_get_buffer(const struct iio_block *block)
 {
 	return block->buffer;
+}
+
+int iio_block_get_dmabuf_fd(const struct iio_block *block)
+{
+	return block->dmabuf_fd;
 }
 
 int iio_block_disable_cpu_access(struct iio_block *block, bool disable)

--- a/block.c
+++ b/block.c
@@ -295,3 +295,13 @@ struct iio_buffer * iio_block_get_buffer(const struct iio_block *block)
 {
 	return block->buffer;
 }
+
+int iio_block_disable_cpu_access(struct iio_block *block, bool disable)
+{
+	const struct iio_backend_ops *ops = block->buffer->dev->ctx->ops;
+
+	if (ops->disable_cpu_access)
+		return ops->disable_cpu_access(block->pdata, disable);
+
+	return -ENOSYS;
+}

--- a/iio-config.h.cmakein
+++ b/iio-config.h.cmakein
@@ -32,6 +32,7 @@
 #cmakedefine01 WITH_IIOD_NETWORK
 #cmakedefine01 WITH_IIOD_USBD
 #cmakedefine01 WITH_IIOD_SERIAL
+#cmakedefine01 WITH_IIOD_USB_DMABUF
 #cmakedefine01 WITH_IIOD_V0_COMPAT
 #cmakedefine01 WITH_LOCAL_CONFIG
 #cmakedefine01 WITH_LOCAL_DMABUF_API

--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -68,6 +68,12 @@ if (WITH_AIO)
 		endif()
 
 		target_sources(iiod PRIVATE usbd.c)
+
+
+		option(WITH_IIOD_USB_DMABUF "Enable DMABUF support on the USB stack" OFF)
+		if (WITH_IIOD_USB_DMABUF)
+			target_sources(iiod PRIVATE usb-dmabuf.c)
+		endif()
 	endif()
 
 	target_include_directories(iiod PRIVATE ${LIBAIO_INCLUDE_DIR})

--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -47,6 +47,7 @@ struct iio_mutex;
 struct iio_task;
 struct iiod_io;
 struct pollfd;
+struct parser_pdata;
 struct thread_pool;
 extern struct thread_pool *main_thread_pool;
 struct DevEntry;
@@ -61,6 +62,8 @@ struct block_entry {
 	uint64_t bytes_used;
 	uint16_t idx;
 	bool cyclic;
+	int dmabuf_fd;
+	int ep_fd;
 };
 
 struct buffer_entry {
@@ -71,6 +74,7 @@ struct buffer_entry {
 	struct iio_task *enqueue_task, *dequeue_task;
 	uint32_t *words;
 	uint16_t idx;
+	bool is_tx;
 
 	SLIST_HEAD(BlockList, block_entry) blocklist;
 	struct iio_mutex *lock;
@@ -138,6 +142,10 @@ int start_serial_daemon(struct iio_context *ctx, const char *uart_params,
 int start_network_daemon(struct iio_context *ctx,
 			 struct thread_pool *pool, const void *xml_zstd,
 			 size_t xml_zstd_len, uint16_t port);
+
+int usb_attach_dmabuf(int ep_fd, int fd);
+int usb_detach_dmabuf(int ep_fd, int fd);
+int usb_transfer_dmabuf(int ep_fd, int fd, uint64_t size);
 
 int binary_parse(struct parser_pdata *pdata);
 

--- a/iiod/usb-dmabuf.c
+++ b/iiod/usb-dmabuf.c
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * libiio - Library for interfacing industrial I/O (IIO) devices
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ * Author: Paul Cercueil <paul.cercueil@analog.com>
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <sys/ioctl.h>
+
+#define IIO_FFS_DMABUF_ATTACH	_IOW('g', 131, int)
+#define IIO_FFS_DMABUF_DETACH	_IOW('g', 132, int)
+#define IIO_FFS_DMABUF_TRANSFER	_IOW('g', 133, struct iio_ffs_dmabuf_transfer)
+
+struct iio_ffs_dmabuf_transfer {
+	int fd;
+	uint32_t flags;
+	uint64_t length;
+};
+
+int usb_attach_dmabuf(int ep_fd, int fd)
+{
+	int ret;
+
+	ret = ioctl(ep_fd, IIO_FFS_DMABUF_ATTACH, &fd);
+	if (ret == -1)
+		return -errno;
+
+	return 0;
+}
+
+int usb_detach_dmabuf(int ep_fd, int fd)
+{
+	int ret;
+
+	ret = ioctl(ep_fd, IIO_FFS_DMABUF_DETACH, &fd);
+	if (ret == -1)
+		return -errno;
+
+	return 0;
+}
+
+int usb_transfer_dmabuf(int ep_fd, int fd, uint64_t size)
+{
+	struct iio_ffs_dmabuf_transfer req;
+	int ret;
+
+	req.fd = fd;
+	req.length = size;
+	req.flags = 0;
+
+	ret = ioctl(ep_fd, IIO_FFS_DMABUF_TRANSFER, &req);
+	if (ret == -1)
+		return -errno;
+
+	return 0;
+}

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -125,6 +125,7 @@ struct iio_backend_ops {
 	int (*dequeue_block)(struct iio_block_pdata *pdata, bool nonblock);
 
 	int (*get_dmabuf_fd)(struct iio_block_pdata *pdata);
+	int (*disable_cpu_access)(struct iio_block_pdata *pdata, bool disable);
 
 	struct iio_event_stream_pdata *(*open_ev)(const struct iio_device *dev);
 	void (*close_ev)(struct iio_event_stream_pdata *pdata);

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1139,6 +1139,17 @@ iio_buffer_create_block(struct iio_buffer *buffer, size_t size);
 __api void iio_block_destroy(struct iio_block *block);
 
 
+/** @brief Disable CPU access of a given block
+ * @param block A pointer to an iio_block structure
+ * @param disable Whether or not to disable CPU access
+ *
+ * <b>NOTE:</b>Disabling CPU access is useful when manipulating DMABUF objects.
+ * If CPU access is disabled, the block's internal buffer of samples should not
+ * be accessed. Therefore, the following functions should not be called:
+ * iio_block_start, iio_block_first, iio_block_end, iio_block_foreach_sample. */
+__api int iio_block_disable_cpu_access(struct iio_block *block, bool disable);
+
+
 /** @brief Get the start address of the block
  * @param block A pointer to an iio_block structure
  * @return A pointer corresponding to the start address of the block */

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1139,6 +1139,14 @@ iio_buffer_create_block(struct iio_buffer *buffer, size_t size);
 __api void iio_block_destroy(struct iio_block *block);
 
 
+/** @brief Get the file descriptor of the underlying DMABUF object
+ * @param block A pointer to an iio_block structure
+ * @return The file descriptor of the underlying DMABUF object.
+ * If the iio_block is not backed by a DMABUF object, -EINVAL is returned.
+ * Otherwise, the file descriptor will be valid until the block is destroyed. */
+__api __check_ret int iio_block_get_dmabuf_fd(const struct iio_block *block);
+
+
 /** @brief Disable CPU access of a given block
  * @param block A pointer to an iio_block structure
  * @param disable Whether or not to disable CPU access

--- a/local-dmabuf.c
+++ b/local-dmabuf.c
@@ -164,6 +164,11 @@ void local_free_dmabuf(struct iio_block_pdata *pdata)
 	free(pdata);
 }
 
+int local_dmabuf_get_fd(struct iio_block_pdata *pdata)
+{
+	return (int)(intptr_t) pdata->pdata;
+}
+
 int local_enqueue_dmabuf(struct iio_block_pdata *pdata,
 			 size_t bytes_used, bool cyclic)
 {

--- a/local-dmabuf.c
+++ b/local-dmabuf.c
@@ -6,20 +6,35 @@
  * Author: Paul Cercueil <paul.cercueil@analog.com>
  */
 
+#define _GNU_SOURCE
 #include "local.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #include <iio/iio.h>
 #include <iio/iio-backend.h>
+#include <iio/iio-debug.h>
 #include <poll.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
+#include <sys/syscall.h>
 #include <time.h>
 #include <unistd.h>
 
-#define IIO_DMABUF_ALLOC_IOCTL		_IOW('i', 0x92, struct iio_dmabuf_req)
-#define IIO_DMABUF_ENQUEUE_IOCTL	_IOW('i', 0x93, struct iio_dmabuf)
+struct iio_dmabuf_heap_data {
+	uint64_t len;
+	uint32_t fd;
+	uint32_t fd_flags;
+	uint64_t heap_flags;
+};
+
+#define IIO_DMA_HEAP_ALLOC		_IOWR('H', 0x0, struct iio_dmabuf_heap_data)
+
+#define IIO_DMABUF_ATTACH_IOCTL		_IOW('i', 0x92, int)
+#define IIO_DMABUF_DETACH_IOCTL		_IOW('i', 0x93, int)
+#define IIO_DMABUF_ENQUEUE_IOCTL	_IOW('i', 0x94, struct iio_dmabuf)
 #define IIO_DMABUF_SYNC_IOCTL		_IOW('b', 0, struct dma_buf_sync)
 
 #define IIO_DMABUF_FLAG_CYCLIC		(1 << 0)
@@ -29,11 +44,6 @@
 #define DMA_BUF_SYNC_RW        (DMA_BUF_SYNC_READ | DMA_BUF_SYNC_WRITE)
 #define DMA_BUF_SYNC_START     (0 << 2)
 #define DMA_BUF_SYNC_END       (1 << 2)
-
-struct iio_dmabuf_req {
-	uint64_t size;
-	uint64_t resv;
-};
 
 struct iio_dmabuf {
 	int32_t fd;
@@ -45,30 +55,54 @@ struct dma_buf_sync {
 	uint64_t flags;
 };
 
+static int enable_cpu_access(struct iio_block_pdata *pdata, bool enable)
+{
+	struct dma_buf_sync dbuf_sync = { 0 };
+	int fd = (int)(intptr_t) pdata->pdata;
+
+	dbuf_sync.flags = DMA_BUF_SYNC_RW;
+
+	if (enable)
+		dbuf_sync.flags |= DMA_BUF_SYNC_START;
+	else
+		dbuf_sync.flags |= DMA_BUF_SYNC_END;
+
+	return ioctl_nointr(fd, IIO_DMABUF_SYNC_IOCTL, &dbuf_sync);
+}
+
 struct iio_block_pdata *
 local_create_dmabuf(struct iio_buffer_pdata *pdata, size_t size, void **data)
 {
+	struct iio_dmabuf_heap_data req = {
+		.len = size,
+		.fd_flags = O_CLOEXEC | O_RDWR,
+	};
 	struct iio_block_pdata *priv;
-	struct iio_dmabuf_req req;
-	int ret, fd;
+	int ret, fd, devfd;
 
 	priv = zalloc(sizeof(*priv));
 	if (!priv)
 		return iio_ptr(-ENOMEM);
 
-	req.size = size;
-	req.resv = 0;
+	devfd = open("/dev/dma_heap/system", O_RDONLY | O_CLOEXEC | O_NOFOLLOW); /* Flawfinder: ignore */
+	if (devfd < 0) {
+		ret = -errno;
 
-	ret = ioctl_nointr(pdata->fd, IIO_DMABUF_ALLOC_IOCTL, &req);
+		/* If we're running on an old kernel, return -ENOSYS to mark
+		 * the DMABUF interface as unavailable */
+		if (ret == -ENOENT)
+			ret = -ENOSYS;
 
-	/* If we get -ENODEV or -EINVAL errors here, the ioctl is wrong and the
-	 * high-speed DMABUF interface is not supported. */
-	if (ret == -ENODEV || ret == -EINVAL || ret == -ENOTTY)
-		ret = -ENOSYS;
-	if (ret < 0)
 		goto err_free_priv;
+	}
 
-	fd = ret;
+	ret = ioctl(devfd, IIO_DMA_HEAP_ALLOC, &req);
+	if (ret < 0) {
+		ret = -errno;
+		goto err_close_devfd;
+	}
+
+	fd = req.fd;
 
 	*data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 	if (*data == MAP_FAILED) {
@@ -83,10 +117,35 @@ local_create_dmabuf(struct iio_buffer_pdata *pdata, size_t size, void **data)
 	priv->dequeued = true;
 	pdata->dmabuf_supported = true;
 
+	/* The new block is dequeued by default, so enable CPU access */
+	ret = enable_cpu_access(priv, true);
+	if (ret)
+		goto err_data_unmap;
+
+	/* Attach DMABUF to the buffer */
+	ret = ioctl(pdata->fd, IIO_DMABUF_ATTACH_IOCTL, &fd);
+	if (ret) {
+		ret = -errno;
+
+		if (ret == -ENODEV) {
+			/* If the ioctl is not available, return -ENOSYS to mark
+			 * the DMABUF interface as unavailable */
+			ret = -ENOSYS;
+		}
+
+		goto err_data_unmap;
+	}
+
+	close(devfd);
+
 	return priv;
 
+err_data_unmap:
+	munmap(priv->data, priv->size);
 err_close_fd:
 	close(fd);
+err_close_devfd:
+	close(devfd);
 err_free_priv:
 	free(priv);
 	return iio_ptr(ret);
@@ -94,7 +153,11 @@ err_free_priv:
 
 void local_free_dmabuf(struct iio_block_pdata *pdata)
 {
-	int fd = (int)(intptr_t) pdata->pdata;
+	int ret, fd = (int)(intptr_t) pdata->pdata;
+
+	ret = ioctl(pdata->buf->fd, IIO_DMABUF_DETACH_IOCTL, &fd);
+	if (ret)
+		dev_perror(pdata->buf->dev, ret, "Unable to detach DMABUF");
 
 	munmap(pdata->data, pdata->size);
 	close(fd);
@@ -104,30 +167,34 @@ void local_free_dmabuf(struct iio_block_pdata *pdata)
 int local_enqueue_dmabuf(struct iio_block_pdata *pdata,
 			 size_t bytes_used, bool cyclic)
 {
-	struct dma_buf_sync dbuf_sync;
 	struct iio_dmabuf dmabuf;
 	int ret, fd = (int)(intptr_t) pdata->pdata;
 
 	if (!pdata->dequeued)
 		return -EPERM;
 
+	if (bytes_used > pdata->size || bytes_used == 0)
+		return -EINVAL;
+
 	dmabuf.fd = fd;
 	dmabuf.flags = 0;
 	dmabuf.bytes_used = bytes_used;
 
 	if (cyclic)
-	      dmabuf.flags |= IIO_DMABUF_FLAG_CYCLIC;
+		dmabuf.flags |= IIO_DMABUF_FLAG_CYCLIC;
 
-	dbuf_sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_RW;
-
-	/* Disable CPU access to last block */
-	ret = ioctl_nointr(fd, IIO_DMABUF_SYNC_IOCTL, &dbuf_sync);
-	if (ret)
-		return ret;
+	if (!pdata->cpu_access_disabled) {
+		/* Disable CPU access to last block */
+		ret = enable_cpu_access(pdata, false);
+		if (ret)
+			return ret;
+	}
 
 	ret = ioctl_nointr(pdata->buf->fd, IIO_DMABUF_ENQUEUE_IOCTL, &dmabuf);
-	if (ret)
+	if (ret) {
+		dev_perror(pdata->buf->dev, ret, "Unable to enqueue DMABUF");
 		return ret;
+	}
 
 	pdata->dequeued = false;
 
@@ -137,7 +204,6 @@ int local_enqueue_dmabuf(struct iio_block_pdata *pdata,
 int local_dequeue_dmabuf(struct iio_block_pdata *pdata, bool nonblock)
 {
 	struct iio_buffer_pdata *buf_pdata = pdata->buf;
-	struct dma_buf_sync dbuf_sync;
 	struct timespec start, *time_ptr = NULL;
 	int ret, fd = (int)(intptr_t) pdata->pdata;
 
@@ -153,12 +219,12 @@ int local_dequeue_dmabuf(struct iio_block_pdata *pdata, bool nonblock)
 	if (ret < 0)
 		return ret;
 
-	dbuf_sync.flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_RW;
-
-	/* Enable CPU access to new block */
-	ret = ioctl_nointr(fd, IIO_DMABUF_SYNC_IOCTL, &dbuf_sync);
-	if (ret < 0)
-		return ret;
+	if (!pdata->cpu_access_disabled) {
+		/* Enable CPU access to new block */
+		ret = enable_cpu_access(pdata, true);
+		if (ret < 0)
+			return ret;
+	}
 
 	pdata->dequeued = true;
 

--- a/local-dmabuf.c
+++ b/local-dmabuf.c
@@ -230,3 +230,18 @@ int local_dequeue_dmabuf(struct iio_block_pdata *pdata, bool nonblock)
 
 	return 0;
 }
+
+int local_dmabuf_disable_cpu_access(struct iio_block_pdata *pdata, bool disable)
+{
+	int ret;
+
+	if (pdata->dequeued) {
+		ret = enable_cpu_access(pdata, !disable);
+		if (ret)
+			return ret;
+	}
+
+	pdata->cpu_access_disabled = disable;
+
+	return 0;
+}

--- a/local-dmabuf.c
+++ b/local-dmabuf.c
@@ -115,7 +115,6 @@ local_create_dmabuf(struct iio_buffer_pdata *pdata, size_t size, void **data)
 	priv->size = size;
 	priv->buf = pdata;
 	priv->dequeued = true;
-	pdata->dmabuf_supported = true;
 
 	/* The new block is dequeued by default, so enable CPU access */
 	ret = enable_cpu_access(priv, true);
@@ -135,6 +134,8 @@ local_create_dmabuf(struct iio_buffer_pdata *pdata, size_t size, void **data)
 
 		goto err_data_unmap;
 	}
+
+	pdata->dmabuf_supported = true;
 
 	close(devfd);
 

--- a/local.c
+++ b/local.c
@@ -1697,6 +1697,18 @@ static int local_read_event(struct iio_event_stream_pdata *pdata,
 	return 0;
 }
 
+static int local_disable_cpu_access(struct iio_block_pdata *pdata, bool disable)
+{
+	if (WITH_LOCAL_DMABUF_API && pdata->buf->dmabuf_supported) {
+		if (pdata->cpu_access_disabled == disable)
+			return 0;
+
+		return local_dmabuf_disable_cpu_access(pdata, disable);
+	}
+
+	return -EINVAL;
+}
+
 static const struct iio_backend_ops local_ops = {
 	.scan = local_context_scan,
 	.create = local_create_context,
@@ -1722,6 +1734,8 @@ static const struct iio_backend_ops local_ops = {
 	.open_ev = local_open_events_fd,
 	.close_ev = local_close_events_fd,
 	.read_ev = local_read_event,
+
+	.disable_cpu_access = local_disable_cpu_access,
 };
 
 const struct iio_backend iio_local_backend = {

--- a/local.c
+++ b/local.c
@@ -1697,6 +1697,14 @@ static int local_read_event(struct iio_event_stream_pdata *pdata,
 	return 0;
 }
 
+static int local_get_dmabuf_fd(struct iio_block_pdata *pdata)
+{
+	if (WITH_LOCAL_DMABUF_API && pdata->buf->dmabuf_supported)
+		return local_dmabuf_get_fd(pdata);
+
+	return -EINVAL;
+}
+
 static int local_disable_cpu_access(struct iio_block_pdata *pdata, bool disable)
 {
 	if (WITH_LOCAL_DMABUF_API && pdata->buf->dmabuf_supported) {
@@ -1735,6 +1743,7 @@ static const struct iio_backend_ops local_ops = {
 	.close_ev = local_close_events_fd,
 	.read_ev = local_read_event,
 
+	.get_dmabuf_fd = local_get_dmabuf_fd,
 	.disable_cpu_access = local_disable_cpu_access,
 };
 

--- a/local.h
+++ b/local.h
@@ -49,6 +49,7 @@ int local_enqueue_dmabuf(struct iio_block_pdata *pdata,
 			 size_t bytes_used, bool cyclic);
 int local_dequeue_dmabuf(struct iio_block_pdata *pdata, bool nonblock);
 
+int local_dmabuf_get_fd(struct iio_block_pdata *pdata);
 int local_dmabuf_disable_cpu_access(struct iio_block_pdata *pdata, bool disable);
 
 struct iio_block_pdata *

--- a/local.h
+++ b/local.h
@@ -33,6 +33,7 @@ struct iio_block_pdata {
 	size_t size;
 	void *data;
 	bool dequeued;
+	bool cpu_access_disabled;
 };
 
 int ioctl_nointr(int fd, unsigned long request, void *data);
@@ -47,6 +48,8 @@ void local_free_dmabuf(struct iio_block_pdata *pdata);
 int local_enqueue_dmabuf(struct iio_block_pdata *pdata,
 			 size_t bytes_used, bool cyclic);
 int local_dequeue_dmabuf(struct iio_block_pdata *pdata, bool nonblock);
+
+int local_dmabuf_disable_cpu_access(struct iio_block_pdata *pdata, bool disable);
 
 struct iio_block_pdata *
 local_create_mmap_block(struct iio_buffer_pdata *pdata,


### PR DESCRIPTION
Follow-up of https://github.com/analogdevicesinc/libiio/pull/928

These commits will modify how the local-DMABUF interface works, because the interface itself in the kernel changed (as it is not yet upstream).

The local backend will now make use of the "udmabuf" kernel driver, which was added in 5.19, to create DMABUF objects from memfd buffers. These DMABUFs can then be attached to the IIO device and/or other devices from other subsystems, and memory-mapped to access the data.

IIOD has also been modified to support enqueueing DMABUFs to the USB (functionfs) interface, and will support passing the buffers between IIO and USB in a zero-copy fashion.

From a Libiio API standpoint, some changes were introduced:
- `iio_block_enqueue` will support partial transfers on RX buffers as well;
- Setting bytes_used=0 in `iio_block_enqueue` will default to transferring the full buffer;
- New API function `iio_block_disable_cpu_access`, to disable CPU synchronization with the buffers when doing zero-copy;
- New API function `iio_block_get_dmabuf_fd` which can be used when doing zero-copy as well.