### PR TITLE
local-mmap: Fix block allocation

### DIFF
--- a/local-mmap.c
+++ b/local-mmap.c
@@ -119,16 +119,11 @@ local_create_mmap_block(struct iio_buffer_pdata *pdata,
 		req.id = 0;
 		req.type = 0;
 		req.size = size;
-		req.count = priv->idx + 1;
+		req.count = 1;
 
 		ret = ioctl_nointr(pdata->fd, BLOCK_ALLOC_IOCTL, &req);
 		if (ret < 0)
 			goto out_free_priv;
-
-		if (req.count < priv->idx + 1) {
-			ret = -ENOMEM;
-			goto out_free_priv;
-		}
 
 		ppdata->nb_blocks++;
 	} else {


### PR DESCRIPTION
The algorithm for allocating new blocks was broken, as it was requesting an allocation of (nb_blocks + 1) blocks instead of a single block.

Fixes #1042.