### PR TITLE
Remove API function iio_device_identify_filename()

### DIFF
--- a/device.c
+++ b/device.c
@@ -720,45 +720,6 @@ int iio_device_debug_attr_write_bool(const struct iio_device *dev,
 	return (int) (ret < 0 ? ret : 0);
 }
 
-int iio_device_identify_filename(const struct iio_device *dev,
-		const char *filename, struct iio_channel **chn,
-		const char **attr)
-{
-	unsigned int i;
-
-	for (i = 0; i < dev->nb_channels; i++) {
-		struct iio_channel *ch = dev->channels[i];
-		unsigned int j;
-
-		for (j = 0; j < ch->nb_attrs; j++) {
-			if (!strcmp(ch->attrs[j].filename, filename)) {
-				*attr = ch->attrs[j].name;
-				*chn = ch;
-				return 0;
-			}
-		}
-	}
-
-	for (i = 0; i < dev->attrs.num; i++) {
-		/* Devices attributes are named after their filename */
-		if (!strcmp(dev->attrs.names[i], filename)) {
-			*attr = dev->attrs.names[i];
-			*chn = NULL;
-			return 0;
-		}
-	}
-
-	for (i = 0; i < dev->debug_attrs.num; i++) {
-		if (!strcmp(dev->debug_attrs.names[i], filename)) {
-			*attr = dev->debug_attrs.names[i];
-			*chn = NULL;
-			return 0;
-		}
-	}
-
-	return -EINVAL;
-}
-
 int iio_device_reg_write(struct iio_device *dev,
 		uint32_t address, uint32_t value)
 {

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1606,23 +1606,6 @@ iio_device_debug_attr_write_raw(const struct iio_device *dev,
 		 double: iio_device_debug_attr_write_double)(dev, attr, val)
 
 
-/** @brief Identify the channel or debug attribute corresponding to a filename
- * @param dev A pointer to an iio_device structure
- * @param filename A NULL-terminated string corresponding to the filename
- * @param chn A pointer to a pointer of an iio_channel structure. The pointed
- * pointer will be set to the address of the iio_channel structure if the
- * filename correspond to the attribute of a channel, or NULL otherwise.
- * @param attr A pointer to a NULL-terminated string. The pointer
- * pointer will be set to point to the name of the attribute corresponding to
- * the filename.
- * @return On success, 0 is returned, and *chn and *attr are modified.
- * @return On error, a negative errno code is returned. *chn and *attr are not
- * modified. */
-__api __check_ret int iio_device_identify_filename(const struct iio_device *dev,
-		const char *filename, struct iio_channel **chn,
-		const char **attr);
-
-
 /** @brief Set the value of a hardware register
  * @param dev A pointer to an iio_device structure
  * @param address The address of the register


### PR DESCRIPTION
This function can be implemented with other libiio functions. The
callers that need it should implement it themselves.