### PR TITLE
CI/publish_deps.ps1: Fixing ghcup version

### DIFF
--- a/CI/publish_deps.ps1
+++ b/CI/publish_deps.ps1
@@ -15,11 +15,11 @@ if ($COMPILER -eq "MinGW Makefiles") {
 	cp $src_dir\dependencies\libs\64\libserialport-0.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 	cp $src_dir\dependencies\libs\64\libusb-1.0.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 	cp C:\ghcup\ghc\9.2.8\mingw\bin\libgcc_s_seh-1.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
-	cp C:\ghcup\ghc\9.4.5\mingw\bin\libiconv-2.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
-	cp C:\ghcup\ghc\9.4.5\mingw\bin\zlib1.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
-	cp C:\ghcup\ghc\9.4.5\mingw\bin\liblzma-5.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
-	cp C:\ghcup\ghc\9.4.5\mingw\bin\libwinpthread-1.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
-	cp C:\ghcup\ghc\9.4.5\mingw\bin\libxml2-2.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+	cp C:\ghcup\ghc\9.6.2\mingw\bin\libiconv-2.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+	cp C:\ghcup\ghc\9.6.2\mingw\bin\zlib1.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+	cp C:\ghcup\ghc\9.6.2\mingw\bin\liblzma-5.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+	cp C:\ghcup\ghc\9.6.2\mingw\bin\libwinpthread-1.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+	cp C:\ghcup\ghc\9.6.2\mingw\bin\libxml2-2.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 	cp C:\ghcup\ghc\9.2.8\mingw\bin\libstdc++-6.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 } else {
 	cp $src_dir\dependencies\libs\64\libxml2.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY


### PR DESCRIPTION
The Azure Pipelines 'windows-2022' image uses the latest version of GHC (9.6.2).