### PR TITLE
New IIO attributes API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 
 option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
-add_library(iio backend.c block.c channel.c device.c context.c buffer.c mask.c utilities.c scan.c sort.c task.c stream.c
+add_library(iio attr.c backend.c block.c channel.c device.c context.c buffer.c mask.c utilities.c scan.c sort.c task.c stream.c
 	${CMAKE_CURRENT_BINARY_DIR}/iio-config.h
 )
 

--- a/attr.c
+++ b/attr.c
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * libiio - Library for interfacing industrial I/O (IIO) devices
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ * Author: Paul Cercueil <paul.cercueil@analog.com>
+ */
+
+#include "iio-private.h"
+
+#include <inttypes.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+static inline unsigned int attr_index(const struct iio_attr_list *list,
+				      const struct iio_attr *attr)
+{
+	uintptr_t diff = (uintptr_t)attr - (uintptr_t)list->attrs;
+	return (unsigned int)diff / sizeof(*attr);
+}
+
+ssize_t iio_attr_read_raw(const struct iio_attr *attr, char *dst, size_t len)
+{
+	const struct iio_device *dev = iio_attr_get_device(attr);
+	unsigned int idx;
+
+	if (attr->type == IIO_ATTR_TYPE_CONTEXT) {
+		idx = attr_index(&attr->iio.ctx->attrlist, attr);
+		return (ssize_t) iio_strlcpy(dst, attr->iio.ctx->values[idx], len);
+	}
+
+	if (dev->ctx->ops->read_attr)
+		return dev->ctx->ops->read_attr(attr, dst, len);
+
+	return -ENOSYS;
+}
+
+int iio_attr_read_longlong(const struct iio_attr *attr, long long *val)
+{
+	char *end, buf[1024];
+	long long value;
+	ssize_t ret;
+
+	ret = iio_attr_read_raw(attr, buf, sizeof(buf));
+	if (ret < 0)
+		return (int) ret;
+
+	errno = 0;
+	value = strtoll(buf, &end, 0);
+	if (end == buf || errno == ERANGE)
+		return -EINVAL;
+	*val = value;
+	return 0;
+}
+
+int iio_attr_read_bool(const struct iio_attr *attr, bool *val)
+{
+	long long value;
+	int ret;
+
+	ret = iio_attr_read_longlong(attr, &value);
+	if (ret < 0)
+		return ret;
+
+	*val = !!value;
+	return 0;
+}
+
+int iio_attr_read_double(const struct iio_attr *attr, double *val)
+{
+	char buf[1024];
+	ssize_t ret;
+
+	ret = iio_attr_read_raw(attr, buf, sizeof(buf));
+	if (ret < 0)
+		return (int) ret;
+
+	return read_double(buf, val);
+}
+
+ssize_t iio_attr_write_raw(const struct iio_attr *attr,
+			   const void *src, size_t len)
+{
+	const struct iio_device *dev = iio_attr_get_device(attr);
+
+	if (attr->type == IIO_ATTR_TYPE_CONTEXT)
+		return -EPERM;
+
+	if (dev->ctx->ops->write_attr)
+		return dev->ctx->ops->write_attr(attr, src, len);
+
+	return -ENOSYS;
+}
+
+ssize_t iio_attr_write_string(const struct iio_attr *attr, const char *src)
+{
+	return iio_attr_write_raw(attr, src, strlen(src) + 1); /* Flawfinder: ignore */
+}
+
+int iio_attr_write_longlong(const struct iio_attr *attr, long long val)
+{
+	size_t len;
+	ssize_t ret;
+	char buf[1024];
+
+	len = iio_snprintf(buf, sizeof(buf), "%lld", val);
+	ret = iio_attr_write_raw(attr, buf, len + 1);
+
+	return (int) (ret < 0 ? ret : 0);
+}
+
+int iio_attr_write_double(const struct iio_attr *attr, double val)
+{
+	ssize_t ret;
+	char buf[1024];
+
+	ret = (ssize_t) write_double(buf, sizeof(buf), val);
+	if (!ret)
+		ret = iio_attr_write_string(attr, buf);
+	return (int) (ret < 0 ? ret : 0);
+}
+
+int iio_attr_write_bool(const struct iio_attr *attr, bool val)
+{
+	ssize_t ret;
+
+	if (val)
+		ret = iio_attr_write_raw(attr, "1", 2);
+	else
+		ret = iio_attr_write_raw(attr, "0", 2);
+
+	return (int) (ret < 0 ? ret : 0);
+}
+
+const struct iio_attr *
+iio_attr_get(const struct iio_attr_list *attrs, unsigned int idx)
+{
+	if (idx >= attrs->num)
+		return NULL;
+
+	return &attrs->attrs[idx];
+}
+
+const struct iio_attr *
+iio_attr_find(const struct iio_attr_list *attrs, const char *name)
+{
+	unsigned int i;
+
+	for (i = 0; i < attrs->num; i++)
+		if (!strcmp(attrs->attrs[i].name, name))
+			return iio_attr_get(attrs, i);
+
+	return NULL;
+}
+
+const char *
+iio_attr_get_name(const struct iio_attr *attr)
+{
+	return attr->name;
+}
+
+const char *
+iio_attr_get_filename(const struct iio_attr *attr)
+{
+	return attr->filename;
+}
+
+const char *
+iio_attr_get_static_value(const struct iio_attr *attr)
+{
+	unsigned int idx;
+
+	switch (attr->type) {
+	case IIO_ATTR_TYPE_CONTEXT:
+		idx = attr_index(&attr->iio.ctx->attrlist, attr);
+		return attr->iio.ctx->values[idx];
+	default:
+		return NULL;
+	}
+}
+
+int iio_add_attr(union iio_pointer p, struct iio_attr_list *attrs,
+		 const char *name, const char *filename,
+		 enum iio_attr_type type)
+{
+	struct iio_attr *attr;
+
+	attr = realloc(attrs->attrs, (1 + attrs->num) * sizeof(*attrs->attrs));
+	if (!attr)
+		return -ENOMEM;
+
+	attrs->attrs = attr;
+	attr[attrs->num] = (struct iio_attr){
+		.iio = p,
+		.type = type,
+		.name = iio_strdup(name),
+		.filename = NULL,
+	};
+
+	if (!attr[attrs->num].name)
+		return -ENOMEM;
+
+	if (filename) {
+		attr[attrs->num].filename = iio_strdup(filename);
+
+		if (!attr[attrs->num].filename) {
+			free((char *) attr[attrs->num].name);
+			return -ENOMEM;
+		}
+	} else {
+		attr[attrs->num].filename = attr[attrs->num].name;
+	}
+
+	attrs->num++;
+
+	return 0;
+}
+
+static const char * const attr_type_string[] = {
+	"",
+	" debug",
+	" buffer",
+};
+
+int iio_device_add_attr(struct iio_device *dev,
+			const char *name, enum iio_attr_type type)
+{
+	union iio_pointer p = { .dev = dev, };
+	int ret;
+
+	ret = iio_add_attr(p, &dev->attrlist[type], name, NULL, type);
+	if (ret < 0)
+		return ret;
+
+	dev_dbg(dev, "Added%s attr \'%s\' to device \'%s\'\n",
+		attr_type_string[type], name, dev->id);
+	return 0;
+}
+
+int iio_channel_add_attr(struct iio_channel *chn,
+			 const char *name, const char *filename)
+{
+	union iio_pointer p = { .chn = chn, };
+	int ret;
+
+	ret = iio_add_attr(p, &chn->attrlist, name, filename,
+			   IIO_ATTR_TYPE_CHANNEL);
+	if (ret < 0)
+		return ret;
+
+	chn_dbg(chn, "Added attr \'%s\' (\'%s\') to channel \'%s\'\n",
+		name, filename, chn->id);
+	return 0;
+}
+
+int iio_context_add_attr(struct iio_context *ctx,
+			 const char *key, const char *value)
+{
+	char **values, *new_val;
+	union iio_pointer p = { .ctx = ctx, };
+	unsigned int i;
+	int ret;
+
+	new_val = iio_strdup(value);
+	if (!new_val)
+		return -ENOMEM;
+
+	for (i = 0; i < ctx->attrlist.num; i++) {
+		if(!strcmp(ctx->attrlist.attrs[i].name, key)) {
+			free(ctx->values[i]);
+			ctx->values[i] = new_val;
+			return 0;
+		}
+	}
+
+	values = realloc(ctx->values,
+			(ctx->attrlist.num + 1) * sizeof(*ctx->values));
+	if (!values) {
+		free(new_val);
+		return -ENOMEM;
+	}
+
+	values[ctx->attrlist.num] = new_val;
+	ctx->values = values;
+
+	ret = iio_add_attr(p, &ctx->attrlist, key, NULL, IIO_ATTR_TYPE_CONTEXT);
+	if (ret) {
+		free(new_val);
+		return ret;
+	}
+
+	return 0;
+}
+
+void iio_free_attr_data(struct iio_attr *attr)
+{
+	if (attr->filename != attr->name)
+		free((char *) attr->filename);
+
+	free((char *) attr->name);
+
+	attr->filename = NULL;
+	attr->name = NULL;
+}
+
+void iio_free_attrs(const struct iio_attr_list *attrs)
+{
+	unsigned int i;
+
+	for (i = 0; i < attrs->num; i++)
+		iio_free_attr_data(&attrs->attrs[i]);
+
+	free(attrs->attrs);
+}

--- a/attr.h
+++ b/attr.h
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/*
+ * libiio - Library for interfacing industrial I/O (IIO) devices
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ * Author: Paul Cercueil <paul.cercueil@analog.com>
+ */
+
+#ifndef __IIO_ATTR_H__
+#define __IIO_ATTR_H__
+
+#include <iio/iio-backend.h>
+
+struct iio_attr_list;
+struct iio_context;
+struct iio_device;
+
+const struct iio_attr *
+iio_attr_get(const struct iio_attr_list *attrs, unsigned int idx);
+const struct iio_attr *
+iio_attr_find(const struct iio_attr_list *attrs, const char *name);
+
+void iio_free_attr_data(struct iio_attr *attr);
+void iio_free_attrs(const struct iio_attr_list *attrs);
+
+int iio_add_attr(union iio_pointer p, struct iio_attr_list *attrs,
+		 const char *name, const char *filename,
+		 enum iio_attr_type type);
+
+int iio_context_add_attr(struct iio_context *ctx,
+			 const char *key, const char *value);
+int iio_device_add_attr(struct iio_device *dev,
+			const char *name, enum iio_attr_type type);
+int iio_channel_add_attr(struct iio_channel *chn,
+			 const char *name, const char *filename);
+
+#endif /* __IIO_ATTR_H__ */

--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -118,6 +118,9 @@ class _Block(Structure):
 class _Stream(Structure):
     pass
 
+class _Attr(Structure):
+    pass
+
 class ContextParams(Structure):
     pass # TODO
 
@@ -239,6 +242,7 @@ _BlockPtr = _POINTER(_Block)
 _DataFormatPtr = _POINTER(DataFormat)
 _ContextParamsPtr = _POINTER(ContextParams)
 _StreamPtr = _POINTER(_Stream)
+_AttrPtr = _POINTER(_Attr)
 
 if "Windows" in _system():
     _iiolib = "libiio.dll"
@@ -324,9 +328,9 @@ _get_attrs_count.restype = c_uint
 _get_attrs_count.argtypes = (_ContextPtr,)
 
 _get_attr = _lib.iio_context_get_attr
-_get_attr.restype = c_int
-_get_attr.argtypes = (_ContextPtr, c_uint, _POINTER(c_char_p), _POINTER(c_char_p))
-_get_attr.errcheck = _check_negative
+_get_attr.restype = _AttrPtr
+_get_attr.argtypes = (_ContextPtr, c_uint)
+_get_attr.errcheck = _check_null
 
 _devices_count = _lib.iio_context_get_devices_count
 _devices_count.restype = c_uint
@@ -350,6 +354,29 @@ _set_timeout.argtypes = (
 )
 _set_timeout.errcheck = _check_negative
 
+_a_get_name = _lib.iio_attr_get_name
+_a_get_name.restype = c_char_p
+_a_get_name.argtypes = (_AttrPtr,)
+
+_a_get_fname = _lib.iio_attr_get_filename
+_a_get_fname.restype = c_char_p
+_a_get_fname.argtypes = (_AttrPtr,)
+
+_a_get_value = _lib.iio_attr_get_static_value
+_a_get_value.restype = c_char_p
+_a_get_value.argtypes = (_AttrPtr,)
+_a_get_value.errcheck = _check_null
+
+_a_read = _lib.iio_attr_read_raw
+_a_read.restype = c_ssize_t
+_a_read.argtypes = (_AttrPtr, c_char_p, c_size_t)
+_a_read.errcheck = _check_negative
+
+_a_write = _lib.iio_attr_write_string
+_a_write.restype = c_ssize_t
+_a_write.argtypes = (_AttrPtr, c_char_p)
+_a_write.errcheck = _check_negative
+
 _d_get_id = _lib.iio_device_get_id
 _d_get_id.restype = c_char_p
 _d_get_id.argtypes = (_DevicePtr,)
@@ -368,57 +395,27 @@ _d_attr_count.restype = c_uint
 _d_attr_count.argtypes = (_DevicePtr,)
 
 _d_get_attr = _lib.iio_device_get_attr
-_d_get_attr.restype = c_char_p
+_d_get_attr.restype = _AttrPtr
 _d_get_attr.argtypes = (_DevicePtr, c_uint)
 _d_get_attr.errcheck = _check_null
-
-_d_read_attr = _lib.iio_device_attr_read_raw
-_d_read_attr.restype = c_ssize_t
-_d_read_attr.argtypes = (_DevicePtr, c_char_p, c_char_p, c_size_t)
-_d_read_attr.errcheck = _check_negative
-
-_d_write_attr = _lib.iio_device_attr_write_string
-_d_write_attr.restype = c_ssize_t
-_d_write_attr.argtypes = (_DevicePtr, c_char_p, c_char_p)
-_d_write_attr.errcheck = _check_negative
 
 _d_debug_attr_count = _lib.iio_device_get_debug_attrs_count
 _d_debug_attr_count.restype = c_uint
 _d_debug_attr_count.argtypes = (_DevicePtr,)
 
 _d_get_debug_attr = _lib.iio_device_get_debug_attr
-_d_get_debug_attr.restype = c_char_p
+_d_get_debug_attr.restype = _AttrPtr
 _d_get_debug_attr.argtypes = (_DevicePtr, c_uint)
 _d_get_debug_attr.errcheck = _check_null
 
-_d_read_debug_attr = _lib.iio_device_debug_attr_read_raw
-_d_read_debug_attr.restype = c_ssize_t
-_d_read_debug_attr.argtypes = (_DevicePtr, c_char_p, c_char_p, c_size_t)
-_d_read_debug_attr.errcheck = _check_negative
+_b_attr_count = _lib.iio_buffer_get_attrs_count
+_b_attr_count.restype = c_uint
+_b_attr_count.argtypes = (_BufferPtr,)
 
-_d_write_debug_attr = _lib.iio_device_debug_attr_write_string
-_d_write_debug_attr.restype = c_ssize_t
-_d_write_debug_attr.argtypes = (_DevicePtr, c_char_p, c_char_p)
-_d_write_debug_attr.errcheck = _check_negative
-
-_d_buffer_attr_count = _lib.iio_device_get_buffer_attrs_count
-_d_buffer_attr_count.restype = c_uint
-_d_buffer_attr_count.argtypes = (_DevicePtr,)
-
-_d_get_buffer_attr = _lib.iio_device_get_buffer_attr
-_d_get_buffer_attr.restype = c_char_p
-_d_get_buffer_attr.argtypes = (_DevicePtr, c_uint)
-_d_get_buffer_attr.errcheck = _check_null
-
-_d_read_buffer_attr = _lib.iio_device_buffer_attr_read_raw
-_d_read_buffer_attr.restype = c_ssize_t
-_d_read_buffer_attr.argtypes = (_DevicePtr, c_char_p, c_char_p, c_size_t)
-_d_read_buffer_attr.errcheck = _check_negative
-
-_d_write_buffer_attr = _lib.iio_device_buffer_attr_write_string
-_d_write_buffer_attr.restype = c_ssize_t
-_d_write_buffer_attr.argtypes = (_DevicePtr, c_char_p, c_char_p)
-_d_write_buffer_attr.errcheck = _check_negative
+_b_get_attr = _lib.iio_buffer_get_attr
+_b_get_attr.restype = _AttrPtr
+_b_get_attr.argtypes = (_BufferPtr, c_uint)
+_b_get_attr.errcheck = _check_null
 
 _d_get_context = _lib.iio_device_get_context
 _d_get_context.restype = _ContextPtr
@@ -495,27 +492,9 @@ _c_attr_count.restype = c_uint
 _c_attr_count.argtypes = (_ChannelPtr,)
 
 _c_get_attr = _lib.iio_channel_get_attr
-_c_get_attr.restype = c_char_p
+_c_get_attr.restype = _AttrPtr
 _c_get_attr.argtypes = (_ChannelPtr, c_uint)
 _c_get_attr.errcheck = _check_null
-
-_c_get_filename = _lib.iio_channel_attr_get_filename
-_c_get_filename.restype = c_char_p
-_c_get_filename.argtypes = (
-    _ChannelPtr,
-    c_char_p,
-)
-_c_get_filename.errcheck = _check_null
-
-_c_read_attr = _lib.iio_channel_attr_read_raw
-_c_read_attr.restype = c_ssize_t
-_c_read_attr.argtypes = (_ChannelPtr, c_char_p, c_char_p, c_size_t)
-_c_read_attr.errcheck = _check_negative
-
-_c_write_attr = _lib.iio_channel_attr_write_string
-_c_write_attr.restype = c_ssize_t
-_c_write_attr.argtypes = (_ChannelPtr, c_char_p, c_char_p)
-_c_write_attr.errcheck = _check_negative
 
 _create_channels_mask = _lib.iio_create_channels_mask
 _create_channels_mask.argtypes = (c_uint,)
@@ -675,148 +654,6 @@ version = _get_lib_version()
 backends = [_get_backend(b).decode("ascii") for b in range(0, _get_backends_count())]
 
 
-class _Attr(object):
-    def __init__(self, name, filename=None):
-        self._name = name
-        self._name_ascii = name.encode("ascii")
-        self._filename = name if filename is None else filename
-
-    def __str__(self):
-        return self._name
-
-    @abc.abstractmethod
-    def _read(self):
-        pass
-
-    @abc.abstractmethod
-    def _write(self, value):
-        pass
-
-    name = property(
-        lambda self: self._name, None, None, "The name of this attribute.\n\ttype=str"
-    )
-    filename = property(
-        lambda self: self._filename,
-        None,
-        None,
-        "The filename in sysfs to which this attribute is bound.\n\ttype=str",
-    )
-    value = property(
-        lambda self: self._read(),
-        lambda self, x: self._write(x),
-        None,
-        "Current value of this attribute.\n\ttype=str",
-    )
-
-
-class ChannelAttr(_Attr):
-    """Represents an attribute of a channel."""
-
-    def __init__(self, channel, name):
-        """
-        Initialize a new instance of the ChannelAttr class.
-
-        :param channel: type=iio.Channel
-            A valid instance of the iio.Channel class.
-        :param name: type=str
-            The channel attribute's name
-
-        returns: type=iio.ChannelAttr
-            A new instance of this class
-        """
-        super(ChannelAttr, self).__init__(
-            name, _c_get_filename(channel, name.encode("ascii")).decode("ascii")
-        )
-        self._channel = channel
-
-    def _read(self):
-        buf = create_string_buffer(1024)
-        _c_read_attr(self._channel, self._name_ascii, buf, len(buf))
-        return buf.value.decode("ascii")
-
-    def _write(self, value):
-        _c_write_attr(self._channel, self._name_ascii, value.encode("ascii"))
-
-
-class DeviceAttr(_Attr):
-    """Represents an attribute of an IIO device."""
-
-    def __init__(self, device, name):
-        """
-        Initialize a new instance of the DeviceAttr class.
-
-        :param device: type=iio.Device
-            A valid instance of the iio.Device class.
-        :param name: type=str
-            The device attribute's name
-
-        returns: type=iio.DeviceAttr
-            A new instance of this class
-        """
-        super(DeviceAttr, self).__init__(name)
-        self._device = device
-
-    def _read(self):
-        buf = create_string_buffer(1024)
-        _d_read_attr(self._device, self._name_ascii, buf, len(buf))
-        return buf.value.decode("ascii")
-
-    def _write(self, value):
-        _d_write_attr(self._device, self._name_ascii, value.encode("ascii"))
-
-
-class DeviceDebugAttr(DeviceAttr):
-    """Represents a debug attribute of an IIO device."""
-
-    def __init__(self, device, name):
-        """
-        Initialize a new instance of the DeviceDebugAttr class.
-
-        :param device: type=iio.Device
-             A valid instance of the iio.Device class.
-        :param name: type=str
-             The device debug attribute's name
-
-        returns: type=iio.DeviceDebugAttr
-            A new instance of this class
-        """
-        super(DeviceDebugAttr, self).__init__(device, name)
-
-    def _read(self):
-        buf = create_string_buffer(1024)
-        _d_read_debug_attr(self._device, self._name_ascii, buf, len(buf))
-        return buf.value.decode("ascii")
-
-    def _write(self, value):
-        _d_write_debug_attr(self._device, self._name_ascii, value.encode("ascii"))
-
-
-class DeviceBufferAttr(DeviceAttr):
-    """Represents a buffer attribute of an IIO device."""
-
-    def __init__(self, device, name):
-        """
-        Initialize a new instance of the DeviceBufferAttr class.
-
-        :param device: type=iio.Device
-            A valid instance of the iio.Device class.
-        :param name: type=str
-            The device buffer attribute's name
-
-        returns: type=iio.DeviceBufferAttr
-            A new instance of this class
-        """
-        super(DeviceBufferAttr, self).__init__(device, name)
-
-    def _read(self):
-        buf = create_string_buffer(1024)
-        _d_read_buffer_attr(self._device, self._name_ascii, buf, len(buf))
-        return buf.value.decode("ascii")
-
-    def _write(self, value):
-        _d_write_buffer_attr(self._device, self._name_ascii, value.encode("ascii"))
-
-
 class _IIO_Object(object):
     def __init__(self, hdl, parent):
         self._hdl = hdl
@@ -827,6 +664,54 @@ class _IIO_Object(object):
 
     def __eq__(self, other):
         return cast(self._hdl, c_void_p).value == cast(other._hdl, c_void_p).value
+
+
+class Attr(_IIO_Object):
+    """Represents an attribute."""
+
+    def __init__(self, parent, attr):
+        """
+        Initialize a new instance of the Attr class.
+
+        :param attr: type=_AttrPtr
+            Pointer to an IIO attribute.
+
+        returns: type=iio.Attr
+            A new instance of this class
+        """
+        self._attr = attr
+        self._name = _a_get_name(attr).decode("ascii")
+        self._filename = _a_get_fname(attr).decode("ascii")
+        super().__init__(self._attr, parent)
+
+    def __str__(self):
+        return self._name
+
+    def _read(self):
+        buf = create_string_buffer(1024)
+        _a_read(self._attr, buf, len(buf))
+        return buf.value.decode("ascii")
+
+    def _write(self, value):
+        _a_write(self._attr, value.encode("ascii"))
+
+    name = property(
+        lambda self: self._name, None, None, "The name of this attribute.\n\ttype=str"
+    )
+
+    filename = property(
+        lambda self: self._filename,
+        None,
+        None,
+        "The filename in sysfs to which this attribute is bound.\n\ttype=str",
+    )
+
+    value = property(
+        lambda self: self._read(),
+        lambda self, x: self._write(x),
+        None,
+        "Current value of this attribute.\n\ttype=str",
+    )
 
 class ChannelsMask(_IIO_Object):
     """A bitmask where each bit corresponds to an enabled channel."""
@@ -882,13 +767,6 @@ class Channel(_IIO_Object):
         self._channel = _channel
         super(Channel, self).__init__(self._channel, dev)
 
-        self._attrs = {
-            name: ChannelAttr(_channel, name)
-            for name in [
-                _c_get_attr(_channel, x).decode("ascii")
-                for x in range(0, _c_attr_count(_channel))
-            ]
-        }
         self._id = _c_get_id(self._channel).decode("ascii")
 
         name_raw = _c_get_name(self._channel)
@@ -944,10 +822,13 @@ class Channel(_IIO_Object):
         lambda self: self._name, None, None, "The name of this channel.\n\ttype=str"
     )
     attrs = property(
-        lambda self: self._attrs,
+        lambda self: {attr.name: attr for attr in [
+            Attr(self, _c_get_attr(self._channel, x))
+            for x in range(0, _c_attr_count(self._channel))
+        ]},
         None,
         None,
-        "List of attributes for this channel.\n\ttype=dict of iio.ChannelAttr",
+        "List of attributes for this channel.\n\ttype=dict of iio.Attr",
     )
     output = property(
         lambda self: self._output,
@@ -1161,6 +1042,16 @@ class Buffer(_IIO_Object):
             "Represents the state (enabled/disabled) of the hardware buffer.",
     )
 
+    attrs = property(
+        lambda self: {attr.name: attr for attr in [
+            Attr(self, _b_get_attr(self._buffer, x))
+            for x in range(0, _b_attr_count(self._buffer))
+        ]},
+        None,
+        None,
+        "List of attributes for this buffer.\n\ttype=dict of iio.Attr",
+    )
+
 
 class Stream(_IIO_Object):
     def __init__(self, buffer, samples_count, nb_blocks = 4):
@@ -1196,28 +1087,6 @@ class _DeviceOrTrigger(_IIO_Object):
 
         self._device = _device
         self._context = _d_get_context(_device)
-        self._attrs = {
-            name: DeviceAttr(_device, name)
-            for name in [
-                _d_get_attr(_device, x).decode("ascii")
-                for x in range(0, _d_attr_count(_device))
-            ]
-        }
-        self._debug_attrs = {
-            name: DeviceDebugAttr(_device, name)
-            for name in [
-                _d_get_debug_attr(_device, x).decode("ascii")
-                for x in range(0, _d_debug_attr_count(_device))
-            ]
-        }
-        self._buffer_attrs = {
-            name: DeviceBufferAttr(_device, name)
-            for name in [
-                _d_get_buffer_attr(_device, x).decode("ascii")
-                for x in range(0, _d_buffer_attr_count(_device))
-            ]
-        }
-
         self._id = _d_get_id(self._device).decode("ascii")
 
         name_raw = _d_get_name(self._device)
@@ -1280,22 +1149,22 @@ class _DeviceOrTrigger(_IIO_Object):
         lambda self: self._label, None, None, "The label of this device.\n\ttype=str",
     )
     attrs = property(
-        lambda self: self._attrs,
+        lambda self: {attr.name: attr for attr in [
+            Attr(self, _d_get_attr(self._device, x))
+            for x in range(0, _d_attr_count(self._device))
+        ]},
         None,
         None,
-        "List of attributes for this IIO device.\n\ttype=dict of iio.DeviceAttr",
+        "List of attributes for this IIO device.\n\ttype=dict of iio.Attr",
     )
     debug_attrs = property(
-        lambda self: self._debug_attrs,
+        lambda self: {attr.name: attr for attr in [
+            Attr(self, _d_get_debug_attr(self._device, x))
+            for x in range(0, _d_debug_attr_count(self._device))
+        ]},
         None,
         None,
-        "List of debug attributes for this IIO device.\n\ttype=dict of iio.DeviceDebugAttr",
-    )
-    buffer_attrs = property(
-        lambda self: self._buffer_attrs,
-        None,
-        None,
-        "List of buffer attributes for this IIO device.\n\ttype=dict of iio.DeviceBufferAttr",
+        "List of debug attributes for this IIO device.\n\ttype=dict of iio.Attr",
     )
     channels = property(
         lambda self: sorted([
@@ -1324,10 +1193,10 @@ class Trigger(_DeviceOrTrigger):
         super(Trigger, self).__init__(ctx, _device)
 
     def _get_rate(self):
-        return int(self._attrs["sampling_frequency"].value)
+        return int(self.attrs["sampling_frequency"].value)
 
     def _set_rate(self, value):
-        self._attrs["sampling_frequency"].value = str(value)
+        self.attrs["sampling_frequency"].value = str(value)
 
     frequency = property(
         _get_rate,
@@ -1418,13 +1287,6 @@ class Context(_IIO_Object):
 
         super(Context, self).__init__(self._context, None)
 
-        self._attrs = {}
-        for index in range(0, _get_attrs_count(self._context)):
-            str1 = c_char_p()
-            str2 = c_char_p()
-            _get_attr(self._context, index, _byref(str1), _byref(str2))
-            self._attrs[str1.value.decode("ascii")] = str2.value.decode("ascii")
-
         self._name = _get_name(self._context).decode("ascii")
         self._description = _get_description(self._context).decode("ascii")
         self._xml = _get_xml(self._context).decode("ascii")
@@ -1480,10 +1342,13 @@ class Context(_IIO_Object):
         "Version of the backend.\n\ttype=(int, int, str)",
     )
     attrs = property(
-        lambda self: self._attrs,
+        lambda self: {attr.name: attr.value for attr in [
+            Attr(self, _get_attr(self._context, x))
+            for x in range(0, _get_attrs_count(self._context))
+        ]},
         None,
         None,
-        "List of context-specific attributes\n\ttype=dict of str objects",
+        "List of context-specific attributes\n\ttype=dict of iio.Attr",
     )
     devices = property(
         lambda self: [

--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -248,10 +248,10 @@ else:
 
 _lib = _cdll("libiio.so.1", use_errno=True, use_last_error=True)
 
-_get_backends_count = _lib.iio_get_backends_count
+_get_backends_count = _lib.iio_get_builtin_backends_count
 _get_backends_count.restype = c_uint
 
-_get_backend = _lib.iio_get_backend
+_get_backend = _lib.iio_get_builtin_backend
 _get_backend.argtypes = (c_uint,)
 _get_backend.restype = c_char_p
 _get_backend.errcheck = _check_null

--- a/compat.c
+++ b/compat.c
@@ -32,6 +32,7 @@ typedef ptrdiff_t ssize_t;
 #include <sys/types.h>
 #endif
 
+struct iio_attr;
 struct iio_block;
 struct iio_buffer;
 struct iio_channel;
@@ -85,10 +86,10 @@ struct compat {
 
 	/* Context attributes */
 	unsigned int (*iio_context_get_attrs_count)(const struct iio_context *);
-	int (*iio_context_get_attr)(const struct iio_context *, unsigned int,
-				    const char **, const char **);
-	const char * (*iio_context_get_attr_value)(const struct iio_context *,
-						   const char *);
+	const struct iio_attr * (*iio_context_get_attr)(const struct iio_context *,
+							unsigned int);
+	const struct iio_attr * (*iio_context_find_attr)(const struct iio_context *,
+							 const char *);
 
 	/* Devices */
 	const struct iio_context * (*iio_device_get_context)(const struct iio_device *);
@@ -109,77 +110,15 @@ struct compat {
 							const char *, bool);
 
 	unsigned int (*iio_device_get_attrs_count)(const struct iio_device *);
-	const char * (*iio_device_get_attr)(const struct iio_device *,
-					    unsigned int);
-	const char * (*iio_device_find_attr)(const struct iio_device *,
-					     const char *);
-	ssize_t (*iio_device_attr_read_raw)(const struct iio_device *,
-					    const char *, char *, size_t);
-	int (*iio_device_attr_read_bool)(const struct iio_device *,
-					 const char *, bool *);
-	int (*iio_device_attr_read_longlong)(const struct iio_device *,
-					     const char *, long long *);
-	int (*iio_device_attr_read_double)(const struct iio_device *,
-					   const char *, double *);
-	ssize_t (*iio_device_attr_write_raw)(const struct iio_device *,
-					     const char *, const void *,
-					     size_t);
-	ssize_t (*iio_device_attr_write_string)(const struct iio_device *,
-						const char *, const char *);
-	int (*iio_device_attr_write_bool)(const struct iio_device *,
-					  const char *, bool);
-	int (*iio_device_attr_write_longlong)(const struct iio_device *,
-					      const char *, long long);
-	int (*iio_device_attr_write_double)(const struct iio_device *,
-					    const char *, double);
-	unsigned int (*iio_device_get_buffer_attrs_count)(const struct iio_device *);
-	const char * (*iio_device_get_buffer_attr)(const struct iio_device *,
-						   unsigned int);
-	const char * (*iio_device_find_buffer_attr)(const struct iio_device *,
-						    const char *);
-	ssize_t (*iio_device_buffer_attr_read_raw)(const struct iio_device *,
-						   const char *, char *, size_t);
-	int (*iio_device_buffer_attr_read_bool)(const struct iio_device *,
-						const char *, bool *);
-	int (*iio_device_buffer_attr_read_longlong)(const struct iio_device *,
-						    const char *, long long *);
-	int (*iio_device_buffer_attr_read_double)(const struct iio_device *,
-						  const char *, double *);
-	ssize_t (*iio_device_buffer_attr_write_raw)(const struct iio_device *,
-						    const char *, const void *,
-						    size_t);
-	ssize_t (*iio_device_buffer_attr_write_string)(const struct iio_device *,
-						       const char *, const char *);
-	int (*iio_device_buffer_attr_write_bool)(const struct iio_device *,
-						 const char *, bool);
-	int (*iio_device_buffer_attr_write_longlong)(const struct iio_device *,
-						     const char *, long long);
-	int (*iio_device_buffer_attr_write_double)(const struct iio_device *,
-						   const char *, double);
+	const struct iio_attr * (*iio_device_get_attr)(const struct iio_device *,
+						       unsigned int);
+	const struct iio_attr * (*iio_device_find_attr)(const struct iio_device *,
+							const char *);
 	unsigned int (*iio_device_get_debug_attrs_count)(const struct iio_device *);
-	const char * (*iio_device_get_debug_attr)(const struct iio_device *,
-						  unsigned int);
-	const char * (*iio_device_find_debug_attr)(const struct iio_device *,
-						   const char *);
-	ssize_t (*iio_device_debug_attr_read_raw)(const struct iio_device *,
-						  const char *, char *, size_t);
-	int (*iio_device_debug_attr_read_bool)(const struct iio_device *,
-					       const char *, bool *);
-	int (*iio_device_debug_attr_read_longlong)(const struct iio_device *,
-						   const char *, long long *);
-	int (*iio_device_debug_attr_read_double)(const struct iio_device *,
-						 const char *, double *);
-	ssize_t (*iio_device_debug_attr_write_raw)(const struct iio_device *,
-						   const char *, const void *,
-						   size_t);
-	ssize_t (*iio_device_debug_attr_write_string)(const struct iio_device *,
-						      const char *, const char *);
-	int (*iio_device_debug_attr_write_bool)(const struct iio_device *,
-						const char *, bool);
-	int (*iio_device_debug_attr_write_longlong)(const struct iio_device *,
-						    const char *, long long);
-	int (*iio_device_debug_attr_write_double)(const struct iio_device *,
-						  const char *, double);
+	const struct iio_attr * (*iio_device_get_debug_attr)(const struct iio_device *,
+							     unsigned int);
+	const struct iio_attr * (*iio_device_find_debug_attr)(const struct iio_device *,
+							      const char *);
 
 	const struct iio_device * (*iio_device_get_trigger)(const struct iio_device *);
 	int (*iio_device_set_trigger)(const struct iio_device *,
@@ -200,30 +139,10 @@ struct compat {
 	void * (*iio_channel_get_data)(const struct iio_channel *);
 
 	unsigned int (*iio_channel_get_attrs_count)(const struct iio_channel *);
-	const char * (*iio_channel_get_attr)(const struct iio_channel *,
-					     unsigned int);
-	const char * (*iio_channel_find_attr)(const struct iio_channel *,
-					      const char *);
-	const char * (*iio_channel_attr_get_filename)(const struct iio_channel *,
-						      const char *);
-	ssize_t (*iio_channel_attr_read_raw)(const struct iio_channel *,
-					     const char *, char *, size_t);
-	int (*iio_channel_attr_read_bool)(const struct iio_channel *,
-					  const char *, bool *);
-	int (*iio_channel_attr_read_longlong)(const struct iio_channel *,
-					      const char *, long long *);
-	int (*iio_channel_attr_read_double)(const struct iio_channel *,
-					    const char *, double *);
-	ssize_t (*iio_channel_attr_write_raw)(const struct iio_channel *,
-					      const char *, const void *, size_t);
-	ssize_t (*iio_channel_attr_write_string)(const struct iio_channel *,
-						 const char *, const char *);
-	int (*iio_channel_attr_write_bool)(const struct iio_channel *,
-					   const char *, bool);
-	int (*iio_channel_attr_write_longlong)(const struct iio_channel *,
-					       const char *, long long);
-	int (*iio_channel_attr_write_double)(const struct iio_channel *,
-					     const char *, double);
+	const struct iio_attr * (*iio_channel_get_attr)(const struct iio_channel *,
+							unsigned int);
+	const struct iio_attr * (*iio_channel_find_attr)(const struct iio_channel *,
+							 const char *);
 	unsigned int (*iio_channel_get_type)(const struct iio_channel *);
 	unsigned int (*iio_channel_get_modifier)(const struct iio_channel *);
 	long (*iio_channel_get_index)(const struct iio_channel *);
@@ -255,6 +174,12 @@ struct compat {
 	int (*iio_buffer_enable)(struct iio_buffer *);
 	int (*iio_buffer_disable)(struct iio_buffer *);
 
+	unsigned int (*iio_buffer_get_attrs_count)(const struct iio_buffer *);
+	const struct iio_attr * (*iio_buffer_get_attr)(const struct iio_buffer *,
+						       unsigned int);
+	const struct iio_attr * (*iio_buffer_find_attr)(const struct iio_buffer *,
+							const char *);
+
 	const struct iio_device * (*iio_buffer_get_device)(const struct iio_buffer *);
 	const struct iio_channels_mask *
 		(*iio_buffer_get_channels_mask)(const struct iio_buffer *);
@@ -276,6 +201,20 @@ struct compat {
 					    ssize_t (*callback)(const struct iio_channel *,
 								void *, size_t, void *),
 					    void *);
+
+	/* Attributes */
+	const char * (*iio_attr_get_name)(const struct iio_attr *);
+	const char * (*iio_attr_get_filename)(const struct iio_attr *);
+	const char * (*iio_attr_get_static_value)(const struct iio_attr *);
+	ssize_t (*iio_attr_read_raw)(const struct iio_attr *, char *, size_t);
+	int (*iio_attr_read_bool)(const struct iio_attr *, bool *);
+	int (*iio_attr_read_longlong)(const struct iio_attr *, long long *);
+	int (*iio_attr_read_double)(const struct iio_attr *, double *);
+	ssize_t (*iio_attr_write_raw)(const struct iio_attr *, const void *, size_t);
+	int (*iio_attr_write_string)(const struct iio_attr *, const char *);
+	int (*iio_attr_write_bool)(const struct iio_attr *, bool);
+	int (*iio_attr_write_longlong)(const struct iio_attr *, long long);
+	int (*iio_attr_write_double)(const struct iio_attr *, double);
 
 	/* Misc */
 	size_t (*iio_strlcpy)(char * __restrict, const char * __restrict, size_t);
@@ -313,6 +252,8 @@ struct iio_device_compat {
 	bool is_tx;
 
 	unsigned int nb_channels;
+
+	struct iio_buffer *buf;
 };
 
 struct iio_context_compat {
@@ -456,14 +397,16 @@ err_set_errno:
 struct iio_context * iio_context_clone(const struct iio_context *old_ctx)
 {
 	const struct iio_context_params *params;
+	const struct iio_attr *attr;
 	struct iio_context *ctx;
 	const char *uri;
 	int err = -ENOENT;
 
-	uri = IIO_CALL(iio_context_get_attr_value)(old_ctx, "uri");
-	if (!uri)
+	attr = IIO_CALL(iio_context_find_attr)(old_ctx, "uri");
+	if (!attr)
 		goto err_set_errno;
 
+	uri = IIO_CALL(iio_attr_get_static_value)(attr);
 	params = IIO_CALL(iio_context_get_params)(old_ctx);
 
 	ctx = IIO_CALL(iio_create_context)(params, uri);
@@ -775,13 +718,30 @@ unsigned int iio_context_get_attrs_count(const struct iio_context *ctx)
 int iio_context_get_attr(const struct iio_context *ctx, unsigned int index,
 			 const char **name, const char **value)
 {
-	return IIO_CALL(iio_context_get_attr)(ctx, index, name, value);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_context_get_attr)(ctx, index);
+	if (!attr)
+		return -ENOENT;
+
+	if (name)
+		*name = IIO_CALL(iio_attr_get_name)(attr);
+	if (value)
+		*value = IIO_CALL(iio_attr_get_static_value)(attr);
+
+	return 0;
 }
 
 const char * iio_context_get_attr_value(const struct iio_context *ctx,
 					const char *name)
 {
-	return IIO_CALL(iio_context_get_attr_value)(ctx, name);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_context_find_attr)(ctx, name);
+	if (!attr)
+		return NULL;
+
+	return IIO_CALL(iio_attr_get_static_value)(attr);
 }
 
 const struct iio_context * iio_device_get_context(const struct iio_device *dev)
@@ -820,9 +780,10 @@ void iio_device_set_data(struct iio_device *dev, void *data)
 
 int iio_device_identify_filename(const struct iio_device *dev,
 				 const char *filename, struct iio_channel **chn,
-				 const char **attr)
+				 const char **attr_out)
 {
 	unsigned int i, j, nb_channels, nb_attrs;
+	const struct iio_attr *attr;
 	struct iio_channel *ch;
 	const char *fn, *name;
 
@@ -833,11 +794,11 @@ int iio_device_identify_filename(const struct iio_device *dev,
 		nb_attrs = IIO_CALL(iio_channel_get_attrs_count)(ch);
 
 		for (j = 0; j < nb_attrs; j++) {
-			name = IIO_CALL(iio_channel_get_attr)(ch, j);
-			fn = IIO_CALL(iio_channel_attr_get_filename)(ch, name);
+			attr = IIO_CALL(iio_channel_get_attr)(ch, j);
+			fn = IIO_CALL(iio_attr_get_filename)(attr);
 
 			if (!strcmp(fn, filename)) {
-				*attr = name;
+				*attr_out = IIO_CALL(iio_attr_get_name)(attr);
 				*chn = ch;
 				return 0;
 			}
@@ -847,11 +808,12 @@ int iio_device_identify_filename(const struct iio_device *dev,
 	nb_attrs = IIO_CALL(iio_device_get_attrs_count)(dev);
 
 	for (i = 0; i < nb_attrs; i++) {
-		name = IIO_CALL(iio_device_get_attr)(dev, i);
+		attr = IIO_CALL(iio_device_get_attr)(dev, i);
+		name = IIO_CALL(iio_attr_get_name)(attr);
 
 		/* Devices attributes are named after their filename */
 		if (!strcmp(name, filename)) {
-			*attr = name;
+			*attr_out = name;
 			*chn = NULL;
 			return 0;
 		}
@@ -860,10 +822,11 @@ int iio_device_identify_filename(const struct iio_device *dev,
 	nb_attrs = IIO_CALL(iio_device_get_debug_attrs_count)(dev);
 
 	for (i = 0; i < nb_attrs; i++) {
-		name = IIO_CALL(iio_device_get_debug_attr)(dev, i);
+		attr = IIO_CALL(iio_device_get_debug_attr)(dev, i);
+		name = IIO_CALL(iio_attr_get_name)(attr);
 
 		if (!strcmp(name, filename)) {
-			*attr = name;
+			*attr_out = name;
 			*chn = NULL;
 			return 0;
 		}
@@ -897,30 +860,68 @@ unsigned int iio_device_get_attrs_count(const struct iio_device *dev)
 const char * iio_device_get_attr(const struct iio_device *dev,
 				 unsigned int index)
 {
-	return IIO_CALL(iio_device_get_attr)(dev, index);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_get_attr)(dev, index);
+	if (!attr)
+		return NULL;
+
+	return IIO_CALL(iio_attr_get_name)(attr);
 }
 
 const char * iio_device_find_attr(const struct iio_device *dev,
 				  const char *name)
 {
-	return IIO_CALL(iio_device_find_attr)(dev, name);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_attr)(dev, name);
+	if (!attr)
+		return NULL;
+
+	return IIO_CALL(iio_attr_get_name)(attr);
 }
 
 unsigned int iio_device_get_buffer_attrs_count(const struct iio_device *dev)
 {
-	return IIO_CALL(iio_device_get_buffer_attrs_count)(dev);
+	struct iio_device_compat *dev_compat = IIO_CALL(iio_device_get_data)(dev);
+
+	if (dev_compat->buf)
+		return IIO_CALL(iio_buffer_get_attrs_count)(dev_compat->buf);
+
+	/* We don't have access to an iio_buffer structure... */
+	return 0;
 }
 
 const char * iio_device_get_buffer_attr(const struct iio_device *dev,
 					unsigned int index)
 {
-	return IIO_CALL(iio_device_get_buffer_attr)(dev, index);
+	struct iio_device_compat *dev_compat = IIO_CALL(iio_device_get_data)(dev);
+	const struct iio_attr *attr;
+
+	if (dev_compat->buf) {
+		attr = IIO_CALL(iio_buffer_get_attr)(dev_compat->buf, index);
+
+		return attr ? IIO_CALL(iio_attr_get_name)(attr) : NULL;
+	}
+
+	/* We don't have access to an iio_buffer structure... */
+	return NULL;
 }
 
 const char * iio_device_find_buffer_attr(const struct iio_device *dev,
 					 const char *name)
 {
-	return IIO_CALL(iio_device_find_buffer_attr)(dev, name);
+	struct iio_device_compat *dev_compat = IIO_CALL(iio_device_get_data)(dev);
+	const struct iio_attr *attr;
+
+	if (dev_compat->buf) {
+		attr = IIO_CALL(iio_buffer_find_attr)(dev_compat->buf, name);
+
+		return attr ? IIO_CALL(iio_attr_get_name)(attr) : NULL;
+	}
+
+	/* We don't have access to an iio_buffer structure... */
+	return NULL;
 }
 
 unsigned int iio_device_get_debug_attrs_count(const struct iio_device *dev)
@@ -931,13 +932,25 @@ unsigned int iio_device_get_debug_attrs_count(const struct iio_device *dev)
 const char * iio_device_get_debug_attr(const struct iio_device *dev,
 				       unsigned int index)
 {
-	return IIO_CALL(iio_device_get_debug_attr)(dev, index);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_get_debug_attr)(dev, index);
+	if (!attr)
+		return NULL;
+
+	return IIO_CALL(iio_attr_get_name)(attr);
 }
 
 const char * iio_device_find_debug_attr(const struct iio_device *dev,
 					const char *name)
 {
-	return IIO_CALL(iio_device_find_debug_attr)(dev, name);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_debug_attr)(dev, name);
+	if (!attr)
+		return NULL;
+
+	return IIO_CALL(iio_attr_get_name)(attr);
 }
 
 struct iio_channel * iio_device_get_channel(const struct iio_device *dev,
@@ -953,27 +966,39 @@ struct iio_channel * iio_device_find_channel(const struct iio_device *dev,
 }
 
 ssize_t iio_device_attr_read(const struct iio_device *dev,
-			     const char *attr, char *dst, size_t len)
+			     const char *name, char *dst, size_t len)
 {
-	return IIO_CALL(iio_device_attr_read_raw)(dev, attr, dst, len);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_attr)(dev, name);
+	return IIO_CALL(iio_attr_read_raw)(attr, dst, len);
 }
 
 int iio_device_attr_read_bool(const struct iio_device *dev,
-			      const char *attr, bool *val)
+			      const char *name, bool *val)
 {
-	return IIO_CALL(iio_device_attr_read_bool)(dev, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_attr)(dev, name);
+	return IIO_CALL(iio_attr_read_bool)(attr, val);
 }
 
 int iio_device_attr_read_longlong(const struct iio_device *dev,
-				  const char *attr, long long *val)
+				  const char *name, long long *val)
 {
-	return IIO_CALL(iio_device_attr_read_longlong)(dev, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_attr)(dev, name);
+	return IIO_CALL(iio_attr_read_longlong)(attr, val);
 }
 
 int iio_device_attr_read_double(const struct iio_device *dev,
-				const char *attr, double *val)
+				const char *name, double *val)
 {
-	return IIO_CALL(iio_device_attr_read_double)(dev, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_attr)(dev, name);
+	return IIO_CALL(iio_attr_read_double)(attr, val);
 }
 
 int iio_device_attr_read_all(struct iio_device *dev,
@@ -981,9 +1006,10 @@ int iio_device_attr_read_all(struct iio_device *dev,
 				       const char *value, size_t len, void *d),
 			     void *data)
 {
+	const struct iio_attr *attr;
 	unsigned int i, nb_attrs;
 	size_t len = 0x100000;
-	const char *attr;
+	const char *name;
 	char *buf;
 	ssize_t count;
 	int ret = 0;
@@ -996,13 +1022,15 @@ int iio_device_attr_read_all(struct iio_device *dev,
 
 	for (i = 0; i < nb_attrs; i++) {
 		attr = IIO_CALL(iio_device_get_attr)(dev, i);
-		count = IIO_CALL(iio_device_attr_read_raw)(dev, attr, buf, len);
+		count = IIO_CALL(iio_attr_read_raw)(attr, buf, len);
 		if (count < 0) {
 			ret = (int) count;
 			goto out_free_buffer;
 		}
 
-		ret = (*cb)(dev, attr, buf, (size_t) count, data);
+		name = IIO_CALL(iio_attr_get_name)(attr);
+
+		ret = (*cb)(dev, name, buf, (size_t) count, data);
 		if (ret < 0)
 			goto out_free_buffer;
 	}
@@ -1013,27 +1041,67 @@ out_free_buffer:
 }
 
 ssize_t iio_device_buffer_attr_read(const struct iio_device *dev,
-				    const char *attr, char *dst, size_t len)
+				    const char *name, char *dst, size_t len)
 {
-	return IIO_CALL(iio_device_buffer_attr_read_raw)(dev, attr, dst, len);
+	struct iio_device_compat *dev_compat = IIO_CALL(iio_device_get_data)(dev);
+	const struct iio_attr *attr;
+
+	if (dev_compat->buf) {
+		attr = IIO_CALL(iio_buffer_find_attr)(dev_compat->buf, name);
+		if (attr)
+			return IIO_CALL(iio_attr_read_raw)(attr, dst, len);
+	}
+
+	/* We don't have access to an iio_buffer structure... */
+	return -ENOENT;
 }
 
 int iio_device_buffer_attr_read_bool(const struct iio_device *dev,
-				     const char *attr, bool *val)
+				     const char *name, bool *val)
 {
-	return IIO_CALL(iio_device_buffer_attr_read_bool)(dev, attr, val);
+	struct iio_device_compat *dev_compat = IIO_CALL(iio_device_get_data)(dev);
+	const struct iio_attr *attr;
+
+	if (dev_compat->buf) {
+		attr = IIO_CALL(iio_buffer_find_attr)(dev_compat->buf, name);
+		if (attr)
+			return IIO_CALL(iio_attr_read_bool)(attr, val);
+	}
+
+	/* We don't have access to an iio_buffer structure... */
+	return -ENOENT;
 }
 
 int iio_device_buffer_attr_read_longlong(const struct iio_device *dev,
-					 const char *attr, long long *val)
+					 const char *name, long long *val)
 {
-	return IIO_CALL(iio_device_buffer_attr_read_longlong)(dev, attr, val);
+	struct iio_device_compat *dev_compat = IIO_CALL(iio_device_get_data)(dev);
+	const struct iio_attr *attr;
+
+	if (dev_compat->buf) {
+		attr = IIO_CALL(iio_buffer_find_attr)(dev_compat->buf, name);
+		if (attr)
+			return IIO_CALL(iio_attr_read_longlong)(attr, val);
+	}
+
+	/* We don't have access to an iio_buffer structure... */
+	return -ENOENT;
 }
 
 int iio_device_buffer_attr_read_double(const struct iio_device *dev,
-				       const char *attr, double *val)
+				       const char *name, double *val)
 {
-	return IIO_CALL(iio_device_buffer_attr_read_double)(dev, attr, val);
+	struct iio_device_compat *dev_compat = IIO_CALL(iio_device_get_data)(dev);
+	const struct iio_attr *attr;
+
+	if (dev_compat->buf) {
+		attr = IIO_CALL(iio_buffer_find_attr)(dev_compat->buf, name);
+		if (attr)
+			return IIO_CALL(iio_attr_read_double)(attr, val);
+	}
+
+	/* We don't have access to an iio_buffer structure... */
+	return -ENOENT;
 }
 
 int iio_device_buffer_attr_read_all(struct iio_device *dev,
@@ -1043,29 +1111,38 @@ int iio_device_buffer_attr_read_all(struct iio_device *dev,
 					      size_t len, void *d),
 			     void *data)
 {
+	struct iio_device_compat *dev_compat = IIO_CALL(iio_device_get_data)(dev);
+	const struct iio_buffer *buffer = dev_compat->buf;
+	const struct iio_attr *attr;
 	unsigned int i, nb_attrs;
 	size_t len = 0x100000;
-	const char *attr;
+	const char *name;
 	char *buf;
 	ssize_t count;
 	int ret = 0;
+
+	if (!buffer) {
+		/* We don't have access to an iio_buffer structure... */
+		return -ENOENT;
+	}
 
 	buf = malloc(len);
 	if (!buf)
 		return -ENOMEM;
 
-	nb_attrs = IIO_CALL(iio_device_get_buffer_attrs_count)(dev);
+	nb_attrs = IIO_CALL(iio_buffer_get_attrs_count)(buffer);
 
 	for (i = 0; i < nb_attrs; i++) {
-		attr = IIO_CALL(iio_device_get_buffer_attr)(dev, i);
-		count = IIO_CALL(iio_device_buffer_attr_read_raw)(dev, attr,
-								  buf, len);
+		attr = IIO_CALL(iio_buffer_get_attr)(buffer, i);
+		name = IIO_CALL(iio_attr_get_name)(attr);
+
+		count = IIO_CALL(iio_attr_read_raw)(attr, buf, len);
 		if (count < 0) {
 			ret = (int) count;
 			goto out_free_buffer;
 		}
 
-		ret = (*cb)(dev, attr, buf, (size_t) count, data);
+		ret = (*cb)(dev, name, buf, (size_t) count, data);
 		if (ret < 0)
 			goto out_free_buffer;
 	}
@@ -1076,27 +1153,39 @@ out_free_buffer:
 }
 
 ssize_t iio_device_debug_attr_read(const struct iio_device *dev,
-				   const char *attr, char *dst, size_t len)
+				   const char *name, char *dst, size_t len)
 {
-	return IIO_CALL(iio_device_debug_attr_read_raw)(dev, attr, dst, len);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_debug_attr)(dev, name);
+	return IIO_CALL(iio_attr_read_raw)(attr, dst, len);
 }
 
 int iio_device_debug_attr_read_bool(const struct iio_device *dev,
-				    const char *attr, bool *val)
+				    const char *name, bool *val)
 {
-	return IIO_CALL(iio_device_debug_attr_read_bool)(dev, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_debug_attr)(dev, name);
+	return IIO_CALL(iio_attr_read_bool)(attr, val);
 }
 
 int iio_device_debug_attr_read_longlong(const struct iio_device *dev,
-					const char *attr, long long *val)
+					const char *name, long long *val)
 {
-	return IIO_CALL(iio_device_debug_attr_read_longlong)(dev, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_debug_attr)(dev, name);
+	return IIO_CALL(iio_attr_read_longlong)(attr, val);
 }
 
 int iio_device_debug_attr_read_double(const struct iio_device *dev,
-				      const char *attr, double *val)
+				      const char *name, double *val)
 {
-	return IIO_CALL(iio_device_debug_attr_read_double)(dev, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_debug_attr)(dev, name);
+	return IIO_CALL(iio_attr_read_double)(attr, val);
 }
 
 int iio_device_debug_attr_read_all(struct iio_device *dev,
@@ -1106,9 +1195,10 @@ int iio_device_debug_attr_read_all(struct iio_device *dev,
 					     size_t len, void *d),
 			     void *data)
 {
+	const struct iio_attr *attr;
 	unsigned int i, nb_attrs;
 	size_t len = 0x100000;
-	const char *attr;
+	const char *name;
 	char *buf;
 	ssize_t count;
 	int ret = 0;
@@ -1121,14 +1211,15 @@ int iio_device_debug_attr_read_all(struct iio_device *dev,
 
 	for (i = 0; i < nb_attrs; i++) {
 		attr = IIO_CALL(iio_device_get_debug_attr)(dev, i);
-		count = IIO_CALL(iio_device_debug_attr_read_raw)(dev, attr,
-								 buf, len);
+		count = IIO_CALL(iio_attr_read_raw)(attr, buf, len);
 		if (count < 0) {
 			ret = (int) count;
 			goto out_free_buffer;
 		}
 
-		ret = (*cb)(dev, attr, buf, (size_t) count, data);
+		name = IIO_CALL(iio_attr_get_name)(attr);
+
+		ret = (*cb)(dev, name, buf, (size_t) count, data);
 		if (ret < 0)
 			goto out_free_buffer;
 	}
@@ -1139,33 +1230,48 @@ out_free_buffer:
 }
 
 ssize_t iio_device_attr_write_raw(const struct iio_device *dev,
-				  const char *attr, const void *src, size_t len)
+				  const char *name, const void *src, size_t len)
 {
-	return IIO_CALL(iio_device_attr_write_raw)(dev, attr, src, len);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_attr)(dev, name);
+	return IIO_CALL(iio_attr_write_raw)(attr, src, len);
 }
 
 ssize_t iio_device_attr_write(const struct iio_device *dev,
-			      const char *attr, const char *src)
+			      const char *name, const char *src)
 {
-	return IIO_CALL(iio_device_attr_write_string)(dev, attr, src);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_attr)(dev, name);
+	return IIO_CALL(iio_attr_write_string)(attr, src);
 }
 
 int iio_device_attr_write_bool(const struct iio_device *dev,
-			       const char *attr, bool val)
+			       const char *name, bool val)
 {
-	return IIO_CALL(iio_device_attr_write_bool)(dev, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_attr)(dev, name);
+	return IIO_CALL(iio_attr_write_bool)(attr, val);
 }
 
 int iio_device_attr_write_longlong(const struct iio_device *dev,
-				   const char *attr, long long val)
+				   const char *name, long long val)
 {
-	return IIO_CALL(iio_device_attr_write_longlong)(dev, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_attr)(dev, name);
+	return IIO_CALL(iio_attr_write_longlong)(attr, val);
 }
 
 int iio_device_attr_write_double(const struct iio_device *dev,
-				 const char *attr, double val)
+				 const char *name, double val)
 {
-	return IIO_CALL(iio_device_attr_write_double)(dev, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_attr)(dev, name);
+	return IIO_CALL(iio_attr_write_double)(attr, val);
 }
 
 int iio_device_attr_write_all(struct iio_device *dev,
@@ -1174,9 +1280,10 @@ int iio_device_attr_write_all(struct iio_device *dev,
 					    size_t len, void *d),
 			      void *data)
 {
+	const struct iio_attr *attr;
 	unsigned int i, nb_attrs;
 	size_t len = 0x100000;
-	const char *attr;
+	const char *name;
 	char *buf;
 	ssize_t count;
 	int ret = 0;
@@ -1189,15 +1296,15 @@ int iio_device_attr_write_all(struct iio_device *dev,
 
 	for (i = 0; i < nb_attrs; i++) {
 		attr = IIO_CALL(iio_device_get_attr)(dev, i);
+		name = IIO_CALL(iio_attr_get_name)(attr);
 
-		count = (*cb)(dev, attr, buf, len, data);
+		count = (*cb)(dev, name, buf, len, data);
 		if (count < 0) {
 			ret = (int) count;
 			goto out_free_buffer;
 		}
 
-		count = IIO_CALL(iio_device_attr_write_raw)(dev, attr,
-							    buf, count);
+		count = IIO_CALL(iio_attr_write_raw)(attr, buf, count);
 		if (count < 0) {
 			ret = (int) count;
 			goto out_free_buffer;
@@ -1210,34 +1317,84 @@ out_free_buffer:
 }
 
 ssize_t iio_device_buffer_attr_write_raw(const struct iio_device *dev,
-					 const char *attr, const void *src,
+					 const char *name, const void *src,
 					 size_t len)
 {
-	return IIO_CALL(iio_device_buffer_attr_write_raw)(dev, attr, src, len);
+	struct iio_device_compat *dev_compat = IIO_CALL(iio_device_get_data)(dev);
+	const struct iio_attr *attr;
+
+	if (dev_compat->buf) {
+		attr = IIO_CALL(iio_buffer_find_attr)(dev_compat->buf, name);
+		if (attr)
+			return IIO_CALL(iio_attr_write_raw)(attr, src, len);
+	}
+
+	/* We don't have access to an iio_buffer structure... */
+	return -ENOENT;
 }
 
 ssize_t iio_device_buffer_attr_write(const struct iio_device *dev,
-				     const char *attr, const char *src)
+				     const char *name, const char *src)
 {
-	return IIO_CALL(iio_device_buffer_attr_write_string)(dev, attr, src);
+	struct iio_device_compat *dev_compat = IIO_CALL(iio_device_get_data)(dev);
+	const struct iio_attr *attr;
+
+	if (dev_compat->buf) {
+		attr = IIO_CALL(iio_buffer_find_attr)(dev_compat->buf, name);
+		if (attr)
+			return IIO_CALL(iio_attr_write_string)(attr, src);
+	}
+
+	/* We don't have access to an iio_buffer structure... */
+	return -ENOENT;
 }
 
 int iio_device_buffer_attr_write_bool(const struct iio_device *dev,
-				      const char *attr, bool val)
+				      const char *name, bool val)
 {
-	return IIO_CALL(iio_device_buffer_attr_write_bool)(dev, attr, val);
+	struct iio_device_compat *dev_compat = IIO_CALL(iio_device_get_data)(dev);
+	const struct iio_attr *attr;
+
+	if (dev_compat->buf) {
+		attr = IIO_CALL(iio_buffer_find_attr)(dev_compat->buf, name);
+		if (attr)
+			return IIO_CALL(iio_attr_write_bool)(attr, val);
+	}
+
+	/* We don't have access to an iio_buffer structure... */
+	return -ENOENT;
 }
 
 int iio_device_buffer_attr_write_longlong(const struct iio_device *dev,
-					  const char *attr, long long val)
+					  const char *name, long long val)
 {
-	return IIO_CALL(iio_device_buffer_attr_write_longlong)(dev, attr, val);
+	struct iio_device_compat *dev_compat = IIO_CALL(iio_device_get_data)(dev);
+	const struct iio_attr *attr;
+
+	if (dev_compat->buf) {
+		attr = IIO_CALL(iio_buffer_find_attr)(dev_compat->buf, name);
+		if (attr)
+			return IIO_CALL(iio_attr_write_longlong)(attr, val);
+	}
+
+	/* We don't have access to an iio_buffer structure... */
+	return -ENOENT;
 }
 
 int iio_device_buffer_attr_write_double(const struct iio_device *dev,
-					const char *attr, double val)
+					const char *name, double val)
 {
-	return IIO_CALL(iio_device_buffer_attr_write_double)(dev, attr, val);
+	struct iio_device_compat *dev_compat = IIO_CALL(iio_device_get_data)(dev);
+	const struct iio_attr *attr;
+
+	if (dev_compat->buf) {
+		attr = IIO_CALL(iio_buffer_find_attr)(dev_compat->buf, name);
+		if (attr)
+			return IIO_CALL(iio_attr_write_double)(attr, val);
+	}
+
+	/* We don't have access to an iio_buffer structure... */
+	return -ENOENT;
 }
 
 int iio_device_buffer_attr_write_all(struct iio_device *dev,
@@ -1246,30 +1403,38 @@ int iio_device_buffer_attr_write_all(struct iio_device *dev,
 						   size_t len, void *d),
 				     void *data)
 {
+	struct iio_device_compat *dev_compat = IIO_CALL(iio_device_get_data)(dev);
+	const struct iio_buffer *buffer = dev_compat->buf;
+	const struct iio_attr *attr;
 	unsigned int i, nb_attrs;
 	size_t len = 0x100000;
-	const char *attr;
+	const char *name;
 	char *buf;
 	ssize_t count;
 	int ret = 0;
+
+	if (!buffer) {
+		/* We don't have access to an iio_buffer structure... */
+		return -ENOENT;
+	}
 
 	buf = malloc(len);
 	if (!buf)
 		return -ENOMEM;
 
-	nb_attrs = IIO_CALL(iio_device_get_buffer_attrs_count)(dev);
+	nb_attrs = IIO_CALL(iio_buffer_get_attrs_count)(buffer);
 
 	for (i = 0; i < nb_attrs; i++) {
-		attr = IIO_CALL(iio_device_get_buffer_attr)(dev, i);
+		attr = IIO_CALL(iio_buffer_get_attr)(buffer, i);
+		name = IIO_CALL(iio_attr_get_name)(attr);
 
-		count = (*cb)(dev, attr, buf, len, data);
+		count = (*cb)(dev, name, buf, len, data);
 		if (count < 0) {
 			ret = (int) count;
 			goto out_free_buffer;
 		}
 
-		count = IIO_CALL(iio_device_buffer_attr_write_raw)(dev, attr,
-								   buf, count);
+		count = IIO_CALL(iio_attr_write_raw)(attr, buf, count);
 		if (count < 0) {
 			ret = (int) count;
 			goto out_free_buffer;
@@ -1282,34 +1447,49 @@ out_free_buffer:
 }
 
 ssize_t iio_device_debug_attr_write_raw(const struct iio_device *dev,
-					const char *attr, const void *src,
+					const char *name, const void *src,
 					size_t len)
 {
-	return IIO_CALL(iio_device_debug_attr_write_raw)(dev, attr, src, len);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_debug_attr)(dev, name);
+	return IIO_CALL(iio_attr_write_raw)(attr, src, len);
 }
 
 ssize_t iio_device_debug_attr_write(const struct iio_device *dev,
-				    const char *attr, const char *src)
+				    const char *name, const char *src)
 {
-	return IIO_CALL(iio_device_debug_attr_write_string)(dev, attr, src);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_debug_attr)(dev, name);
+	return IIO_CALL(iio_attr_write_string)(attr, src);
 }
 
 int iio_device_debug_attr_write_bool(const struct iio_device *dev,
-				     const char *attr, bool val)
+				     const char *name, bool val)
 {
-	return IIO_CALL(iio_device_debug_attr_write_bool)(dev, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_debug_attr)(dev, name);
+	return IIO_CALL(iio_attr_write_bool)(attr, val);
 }
 
 int iio_device_debug_attr_write_longlong(const struct iio_device *dev,
-					 const char *attr, long long val)
+					 const char *name, long long val)
 {
-	return IIO_CALL(iio_device_debug_attr_write_longlong)(dev, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_debug_attr)(dev, name);
+	return IIO_CALL(iio_attr_write_longlong)(attr, val);
 }
 
 int iio_device_debug_attr_write_double(const struct iio_device *dev,
-				       const char *attr, double val)
+				       const char *name, double val)
 {
-	return IIO_CALL(iio_device_debug_attr_write_double)(dev, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_device_find_debug_attr)(dev, name);
+	return IIO_CALL(iio_attr_write_double)(attr, val);
 }
 
 int iio_device_debug_attr_write_all(struct iio_device *dev,
@@ -1318,9 +1498,10 @@ int iio_device_debug_attr_write_all(struct iio_device *dev,
 						  size_t len, void *d),
 				    void *data)
 {
+	const struct iio_attr *attr;
 	unsigned int i, nb_attrs;
 	size_t len = 0x100000;
-	const char *attr;
+	const char *name;
 	char *buf;
 	ssize_t count;
 	int ret = 0;
@@ -1333,15 +1514,15 @@ int iio_device_debug_attr_write_all(struct iio_device *dev,
 
 	for (i = 0; i < nb_attrs; i++) {
 		attr = IIO_CALL(iio_device_get_debug_attr)(dev, i);
+		name = IIO_CALL(iio_attr_get_name)(attr);
 
-		count = (*cb)(dev, attr, buf, len, data);
+		count = (*cb)(dev, name, buf, len, data);
 		if (count < 0) {
 			ret = (int) count;
 			goto out_free_buffer;
 		}
 
-		count = IIO_CALL(iio_device_debug_attr_write_raw)(dev, attr,
-								  buf, count);
+		count = IIO_CALL(iio_attr_write_raw)(attr, buf, count);
 		if (count < 0) {
 			ret = (int) count;
 			goto out_free_buffer;
@@ -1458,43 +1639,61 @@ unsigned int iio_channel_get_attrs_count(const struct iio_channel *chn)
 const char * iio_channel_get_attr(const struct iio_channel *chn,
 				  unsigned int index)
 {
-	return IIO_CALL(iio_channel_get_attr)(chn, index);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_channel_get_attr)(chn, index);
+	if (!attr)
+		return NULL;
+
+	return IIO_CALL(iio_attr_get_name)(attr);
 }
 
 const char * iio_channel_find_attr(const struct iio_channel *chn,
 				   const char *name)
 {
-	return IIO_CALL(iio_channel_find_attr)(chn, name);
-}
+	const struct iio_attr *attr;
 
-const char * iio_channel_attr_get_filename(const struct iio_channel *chn,
-					   const char *name)
-{
-	return IIO_CALL(iio_channel_attr_get_filename)(chn, name);
+	attr = IIO_CALL(iio_channel_find_attr)(chn, name);
+	if (!attr)
+		return NULL;
+
+	return IIO_CALL(iio_attr_get_name)(attr);
 }
 
 ssize_t iio_channel_attr_read(const struct iio_channel *chn,
-			      const char *attr, char *dst, size_t len)
+			      const char *name, char *dst, size_t len)
 {
-	return IIO_CALL(iio_channel_attr_read_raw)(chn, attr, dst, len);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_channel_find_attr)(chn, name);
+	return IIO_CALL(iio_attr_read_raw)(attr, dst, len);
 }
 
 int iio_channel_attr_read_bool(const struct iio_channel *chn,
-			       const char *attr, bool *val)
+			       const char *name, bool *val)
 {
-	return IIO_CALL(iio_channel_attr_read_bool)(chn, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_channel_find_attr)(chn, name);
+	return IIO_CALL(iio_attr_read_bool)(attr, val);
 }
 
 int iio_channel_attr_read_longlong(const struct iio_channel *chn,
-				   const char *attr, long long *val)
+				   const char *name, long long *val)
 {
-	return IIO_CALL(iio_channel_attr_read_longlong)(chn, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_channel_find_attr)(chn, name);
+	return IIO_CALL(iio_attr_read_longlong)(attr, val);
 }
 
 int iio_channel_attr_read_double(const struct iio_channel *chn,
-				 const char *attr, double *val)
+				 const char *name, double *val)
 {
-	return IIO_CALL(iio_channel_attr_read_double)(chn, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_channel_find_attr)(chn, name);
+	return IIO_CALL(iio_attr_read_double)(attr, val);
 }
 
 int iio_channel_attr_read_all(struct iio_channel *chn,
@@ -1503,9 +1702,10 @@ int iio_channel_attr_read_all(struct iio_channel *chn,
 				       const char *value, size_t len, void *d),
 			     void *data)
 {
+	const struct iio_attr *attr;
 	unsigned int i, nb_attrs;
 	size_t len = 0x100000;
-	const char *attr;
+	const char *name;
 	char *buf;
 	ssize_t count;
 	int ret = 0;
@@ -1518,14 +1718,15 @@ int iio_channel_attr_read_all(struct iio_channel *chn,
 
 	for (i = 0; i < nb_attrs; i++) {
 		attr = IIO_CALL(iio_channel_get_attr)(chn, i);
-		count = IIO_CALL(iio_channel_attr_read_raw)(chn, attr,
-							    buf, len);
+		name = IIO_CALL(iio_attr_get_name)(attr);
+
+		count = IIO_CALL(iio_attr_read_raw)(attr, buf, len);
 		if (count < 0) {
 			ret = (int) count;
 			goto out_free_buffer;
 		}
 
-		ret = (*cb)(chn, attr, buf, (size_t) count, data);
+		ret = (*cb)(chn, name, buf, (size_t) count, data);
 		if (ret < 0)
 			goto out_free_buffer;
 	}
@@ -1536,34 +1737,49 @@ out_free_buffer:
 }
 
 ssize_t iio_channel_attr_write_raw(const struct iio_channel *chn,
-				   const char *attr, const void *src,
+				   const char *name, const void *src,
 				   size_t len)
 {
-	return IIO_CALL(iio_channel_attr_write_raw)(chn, attr, src, len);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_channel_find_attr)(chn, name);
+	return IIO_CALL(iio_attr_write_raw)(attr, src, len);
 }
 
 ssize_t iio_channel_attr_write(const struct iio_channel *chn,
-			       const char *attr, const char *src)
+			       const char *name, const char *src)
 {
-	return IIO_CALL(iio_channel_attr_write_string)(chn, attr, src);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_channel_find_attr)(chn, name);
+	return IIO_CALL(iio_attr_write_string)(attr, src);
 }
 
 ssize_t iio_channel_attr_write_bool(const struct iio_channel *chn,
-				    const char *attr, bool val)
+				    const char *name, bool val)
 {
-	return IIO_CALL(iio_channel_attr_write_bool)(chn, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_channel_find_attr)(chn, name);
+	return IIO_CALL(iio_attr_write_bool)(attr, val);
 }
 
 ssize_t iio_channel_attr_write_longlong(const struct iio_channel *chn,
-					const char *attr, long long val)
+					const char *name, long long val)
 {
-	return IIO_CALL(iio_channel_attr_write_longlong)(chn, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_channel_find_attr)(chn, name);
+	return IIO_CALL(iio_attr_write_longlong)(attr, val);
 }
 
 ssize_t iio_channel_attr_write_double(const struct iio_channel *chn,
-				      const char *attr, double val)
+				      const char *name, double val)
 {
-	return IIO_CALL(iio_channel_attr_write_double)(chn, attr, val);
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_channel_find_attr)(chn, name);
+	return IIO_CALL(iio_attr_write_double)(attr, val);
 }
 
 int iio_channel_attr_write_all(struct iio_channel *chn,
@@ -1572,9 +1788,10 @@ int iio_channel_attr_write_all(struct iio_channel *chn,
 					    size_t len, void *d),
 			      void *data)
 {
+	const struct iio_attr *attr;
 	unsigned int i, nb_attrs;
 	size_t len = 0x100000;
-	const char *attr;
+	const char *name;
 	char *buf;
 	ssize_t count;
 	int ret = 0;
@@ -1587,15 +1804,15 @@ int iio_channel_attr_write_all(struct iio_channel *chn,
 
 	for (i = 0; i < nb_attrs; i++) {
 		attr = IIO_CALL(iio_channel_get_attr)(chn, i);
+		name = IIO_CALL(iio_attr_get_name)(attr);
 
-		count = (*cb)(chn, attr, buf, len, data);
+		count = (*cb)(chn, name, buf, len, data);
 		if (count < 0) {
 			ret = (int) count;
 			goto out_free_buffer;
 		}
 
-		count = IIO_CALL(iio_channel_attr_write_raw)(chn, attr,
-							     buf, count);
+		count = IIO_CALL(iio_attr_write_raw)(attr, buf, count);
 		if (count < 0) {
 			ret = (int) count;
 			goto out_free_buffer;
@@ -1750,6 +1967,8 @@ struct iio_buffer * iio_device_create_buffer(const struct iio_device *dev,
 		compat->all_enqueued = true;
 	}
 
+	dev_compat->buf = buf;
+
 	return buf;
 
 err_free_blocks:
@@ -1780,6 +1999,8 @@ void iio_buffer_set_data(struct iio_buffer *buf, void *data)
 void iio_buffer_destroy(struct iio_buffer *buf)
 {
 	struct iio_buffer_compat *compat = IIO_CALL(iio_buffer_get_data)(buf);
+	const struct iio_device *dev = IIO_CALL(iio_buffer_get_device)(buf);
+	struct iio_device_compat *dev_compat = IIO_CALL(iio_device_get_data)(dev);
 	unsigned int i;
 
 	IIO_CALL(iio_buffer_cancel)(buf);
@@ -1792,6 +2013,8 @@ void iio_buffer_destroy(struct iio_buffer *buf)
 
 	IIO_CALL(iio_buffer_destroy)(buf);
 	free(compat);
+
+	dev_compat->buf = NULL;
 }
 
 void iio_buffer_cancel(struct iio_buffer *buf)
@@ -2000,7 +2223,7 @@ static void compat_lib_init(void)
 
 	FIND_SYMBOL(ctx->lib, iio_context_get_attrs_count);
 	FIND_SYMBOL(ctx->lib, iio_context_get_attr);
-	FIND_SYMBOL(ctx->lib, iio_context_get_attr_value);
+	FIND_SYMBOL(ctx->lib, iio_context_find_attr);
 
 	FIND_SYMBOL(ctx->lib, iio_device_get_context);
 	FIND_SYMBOL(ctx->lib, iio_device_get_id);
@@ -2014,41 +2237,11 @@ static void compat_lib_init(void)
 	FIND_SYMBOL(ctx->lib, iio_device_get_attrs_count);
 	FIND_SYMBOL(ctx->lib, iio_device_get_attr);
 	FIND_SYMBOL(ctx->lib, iio_device_find_attr);
-	FIND_SYMBOL(ctx->lib, iio_device_get_buffer_attrs_count);
-	FIND_SYMBOL(ctx->lib, iio_device_get_buffer_attr);
-	FIND_SYMBOL(ctx->lib, iio_device_find_buffer_attr);
 	FIND_SYMBOL(ctx->lib, iio_device_get_debug_attrs_count);
 	FIND_SYMBOL(ctx->lib, iio_device_get_debug_attr);
 	FIND_SYMBOL(ctx->lib, iio_device_find_debug_attr);
 	FIND_SYMBOL(ctx->lib, iio_device_get_channel);
 	FIND_SYMBOL(ctx->lib, iio_device_find_channel);
-	FIND_SYMBOL(ctx->lib, iio_device_attr_read_raw);
-	FIND_SYMBOL(ctx->lib, iio_device_attr_read_bool);
-	FIND_SYMBOL(ctx->lib, iio_device_attr_read_longlong);
-	FIND_SYMBOL(ctx->lib, iio_device_attr_read_double);
-	FIND_SYMBOL(ctx->lib, iio_device_attr_write_raw);
-	FIND_SYMBOL(ctx->lib, iio_device_attr_write_string);
-	FIND_SYMBOL(ctx->lib, iio_device_attr_write_bool);
-	FIND_SYMBOL(ctx->lib, iio_device_attr_write_longlong);
-	FIND_SYMBOL(ctx->lib, iio_device_attr_write_double);
-	FIND_SYMBOL(ctx->lib, iio_device_buffer_attr_read_raw);
-	FIND_SYMBOL(ctx->lib, iio_device_buffer_attr_read_bool);
-	FIND_SYMBOL(ctx->lib, iio_device_buffer_attr_read_longlong);
-	FIND_SYMBOL(ctx->lib, iio_device_buffer_attr_read_double);
-	FIND_SYMBOL(ctx->lib, iio_device_buffer_attr_write_raw);
-	FIND_SYMBOL(ctx->lib, iio_device_buffer_attr_write_string);
-	FIND_SYMBOL(ctx->lib, iio_device_buffer_attr_write_bool);
-	FIND_SYMBOL(ctx->lib, iio_device_buffer_attr_write_longlong);
-	FIND_SYMBOL(ctx->lib, iio_device_buffer_attr_write_double);
-	FIND_SYMBOL(ctx->lib, iio_device_debug_attr_read_raw);
-	FIND_SYMBOL(ctx->lib, iio_device_debug_attr_read_bool);
-	FIND_SYMBOL(ctx->lib, iio_device_debug_attr_read_longlong);
-	FIND_SYMBOL(ctx->lib, iio_device_debug_attr_read_double);
-	FIND_SYMBOL(ctx->lib, iio_device_debug_attr_write_raw);
-	FIND_SYMBOL(ctx->lib, iio_device_debug_attr_write_string);
-	FIND_SYMBOL(ctx->lib, iio_device_debug_attr_write_bool);
-	FIND_SYMBOL(ctx->lib, iio_device_debug_attr_write_longlong);
-	FIND_SYMBOL(ctx->lib, iio_device_debug_attr_write_double);
 	FIND_SYMBOL(ctx->lib, iio_device_get_trigger);
 	FIND_SYMBOL(ctx->lib, iio_device_set_trigger);
 	FIND_SYMBOL(ctx->lib, iio_device_is_trigger);
@@ -2064,16 +2257,6 @@ static void compat_lib_init(void)
 	FIND_SYMBOL(ctx->lib, iio_channel_get_attrs_count);
 	FIND_SYMBOL(ctx->lib, iio_channel_get_attr);
 	FIND_SYMBOL(ctx->lib, iio_channel_find_attr);
-	FIND_SYMBOL(ctx->lib, iio_channel_attr_get_filename);
-	FIND_SYMBOL(ctx->lib, iio_channel_attr_read_raw);
-	FIND_SYMBOL(ctx->lib, iio_channel_attr_read_bool);
-	FIND_SYMBOL(ctx->lib, iio_channel_attr_read_longlong);
-	FIND_SYMBOL(ctx->lib, iio_channel_attr_read_double);
-	FIND_SYMBOL(ctx->lib, iio_channel_attr_write_raw);
-	FIND_SYMBOL(ctx->lib, iio_channel_attr_write_string);
-	FIND_SYMBOL(ctx->lib, iio_channel_attr_write_bool);
-	FIND_SYMBOL(ctx->lib, iio_channel_attr_write_longlong);
-	FIND_SYMBOL(ctx->lib, iio_channel_attr_write_double);
 	FIND_SYMBOL(ctx->lib, iio_channel_get_type);
 	FIND_SYMBOL(ctx->lib, iio_channel_get_modifier);
 	FIND_SYMBOL(ctx->lib, iio_channel_get_index);
@@ -2093,9 +2276,25 @@ static void compat_lib_init(void)
 	FIND_SYMBOL(ctx->lib, iio_buffer_enable);
 	FIND_SYMBOL(ctx->lib, iio_buffer_disable);
 	FIND_SYMBOL(ctx->lib, iio_buffer_get_device);
+	FIND_SYMBOL(ctx->lib, iio_buffer_get_attrs_count);
+	FIND_SYMBOL(ctx->lib, iio_buffer_get_attr);
+	FIND_SYMBOL(ctx->lib, iio_buffer_find_attr);
 	FIND_SYMBOL(ctx->lib, iio_buffer_get_channels_mask);
 	FIND_SYMBOL(ctx->lib, iio_buffer_get_data);
 	FIND_SYMBOL(ctx->lib, iio_buffer_set_data);
+
+	FIND_SYMBOL(ctx->lib, iio_attr_get_name);
+	FIND_SYMBOL(ctx->lib, iio_attr_get_filename);
+	FIND_SYMBOL(ctx->lib, iio_attr_get_static_value);
+	FIND_SYMBOL(ctx->lib, iio_attr_read_raw);
+	FIND_SYMBOL(ctx->lib, iio_attr_read_bool);
+	FIND_SYMBOL(ctx->lib, iio_attr_read_longlong);
+	FIND_SYMBOL(ctx->lib, iio_attr_read_double);
+	FIND_SYMBOL(ctx->lib, iio_attr_write_raw);
+	FIND_SYMBOL(ctx->lib, iio_attr_write_string);
+	FIND_SYMBOL(ctx->lib, iio_attr_write_bool);
+	FIND_SYMBOL(ctx->lib, iio_attr_write_longlong);
+	FIND_SYMBOL(ctx->lib, iio_attr_write_double);
 
 	FIND_SYMBOL(ctx->lib, iio_buffer_create_block);
 	FIND_SYMBOL(ctx->lib, iio_block_destroy);

--- a/context.c
+++ b/context.c
@@ -87,7 +87,8 @@ static ssize_t sanitize_xml(char *ptr, ssize_t len, const char *str)
 }
 
 ssize_t iio_xml_print_and_sanitized_param(char *ptr, ssize_t len,
-					  const char *before, char *param,
+					  const char *before,
+					  const char *param,
 					  const char *after)
 {
 	ssize_t ret, alen = 0;

--- a/context.c
+++ b/context.c
@@ -323,30 +323,10 @@ struct iio_device * iio_context_find_device(const struct iio_context *ctx,
 
 static void reorder_channels(struct iio_device *dev)
 {
-	bool found;
 	unsigned int i;
 
 	/* Reorder channels by index */
-	do {
-		found = false;
-		for (i = 1; i < dev->nb_channels; i++) {
-			struct iio_channel **channels = dev->channels;
-			long ch1 = channels[i - 1]->index;
-			long ch2 = channels[i]->index;
-
-			if (ch1 == ch2 && ch1 >= 0) {
-				ch1 = channels[i - 1]->format.shift;
-				ch2 = channels[i]->format.shift;
-			}
-
-			if (ch2 >= 0 && ((ch1 > ch2) || ch1 < 0)) {
-				struct iio_channel *bak = channels[i];
-				channels[i] = channels[i - 1];
-				channels[i - 1] = bak;
-				found = true;
-			}
-		}
-	} while (found);
+	iio_sort_channels(dev);
 
 	for (i = 0; i < dev->nb_channels; i++)
 		dev->channels[i]->number = i;

--- a/context.c
+++ b/context.c
@@ -481,6 +481,12 @@ const char * iio_context_get_attr_value(
 	return NULL;
 }
 
+const struct iio_attr *
+iio_context_find_attr(const struct iio_context *ctx, const char *name)
+{
+	return iio_attr_find(&ctx->attrlist, name);
+}
+
 int iio_context_add_device(struct iio_context *ctx, struct iio_device *dev)
 {
 	struct iio_device **devices = realloc(ctx->devices,

--- a/context.c
+++ b/context.c
@@ -6,6 +6,7 @@
  * Author: Paul Cercueil <paul.cercueil@analog.com>
  */
 
+#include "attr.h"
 #include "iio-config.h"
 #include "iio-private.h"
 #include "sort.h"
@@ -495,53 +496,6 @@ int iio_context_add_device(struct iio_context *ctx, struct iio_device *dev)
 
 	ctx_dbg(ctx, "Added device \'%s\' to context \'%s\'\n",
 		dev->id, ctx->name);
-	return 0;
-}
-
-int iio_context_add_attr(struct iio_context *ctx,
-		const char *key, const char *value)
-{
-	char **attrs, **values, *new_key, *new_val;
-	unsigned int i;
-
-	for (i = 0; i < ctx->nb_attrs; i++) {
-		if(!strcmp(ctx->attrs[i], key)) {
-			new_val = iio_strdup(value);
-			if (!new_val)
-				return -ENOMEM;
-			free(ctx->values[i]);
-			ctx->values[i] = new_val;
-			return 0;
-		}
-	}
-
-	attrs = realloc(ctx->attrs,
-			(ctx->nb_attrs + 1) * sizeof(*ctx->attrs));
-	if (!attrs)
-		return -ENOMEM;
-
-	ctx->attrs = attrs;
-
-	values = realloc(ctx->values,
-			(ctx->nb_attrs + 1) * sizeof(*ctx->values));
-	if (!values)
-		return -ENOMEM;
-
-	ctx->values = values;
-
-	new_key = iio_strdup(key);
-	if (!new_key)
-		return -ENOMEM;
-
-	new_val = iio_strdup(value);
-	if (!new_val) {
-		free(new_key);
-		return -ENOMEM;
-	}
-
-	ctx->attrs[ctx->nb_attrs] = new_key;
-	ctx->values[ctx->nb_attrs] = new_val;
-	ctx->nb_attrs++;
 	return 0;
 }
 

--- a/dns_sd.c
+++ b/dns_sd.c
@@ -91,7 +91,8 @@ static int dnssd_add_scan_result(const struct iio_context_params *params,
 	struct iio_context *ctx;
 	char uri[sizeof("ip:") + FQDN_LEN + sizeof (":65535") + 1];
 	char description[255], *p;
-	const char *hw_model, *serial;
+	const char *hw_model = NULL, *serial = NULL;
+	const struct iio_attr *attr;
 	unsigned int i;
 
 	if (port == IIOD_PORT) {
@@ -111,8 +112,12 @@ static int dnssd_add_scan_result(const struct iio_context_params *params,
 		return -ENOMEM;
 	}
 
-	hw_model = iio_context_get_attr_value(ctx, "hw_model");
-	serial = iio_context_get_attr_value(ctx, "hw_serial");
+	attr = iio_context_find_attr(ctx, "hw_model");
+	if (attr)
+		hw_model = iio_attr_get_static_value(attr);
+	attr = iio_context_find_attr(ctx, "hw_serial");
+	if (attr)
+		serial = iio_attr_get_static_value(attr);
 
 	if (hw_model && serial) {
 		iio_snprintf(description, sizeof(description), "%s (%s), serial=%s",

--- a/examples/ad9371-iiostream.c
+++ b/examples/ad9371-iiostream.c
@@ -9,6 +9,7 @@
 
 #include "iiostream-common.h"
 
+#include <errno.h>
 #include <iio/iio.h>
 #include <iio/iio-debug.h>
 #include <stdbool.h>
@@ -88,15 +89,18 @@ static void errchk(int v, const char* what) {
 /* write attribute: long long int */
 static void wr_ch_lli(struct iio_channel *chn, const char* what, long long val)
 {
-	errchk(iio_channel_attr_write_longlong(chn, what, val), what);
+	const struct iio_attr *attr = iio_channel_find_attr(chn, what);
+
+	errchk(attr ? iio_attr_write_longlong(attr, val) : -ENOENT, what);
 }
 
 /* write attribute: long long int */
 static long long rd_ch_lli(struct iio_channel *chn, const char* what)
 {
+	const struct iio_attr *attr = iio_channel_find_attr(chn, what);
 	long long val;
 
-	errchk(iio_channel_attr_read_longlong(chn, what, &val), what);
+	errchk(attr ? iio_attr_read_longlong(attr, &val) : -ENOENT, what);
 
 	printf("\t %s: %lld\n", what, val);
 	return val;

--- a/examples/adrv9002-iiostream.c
+++ b/examples/adrv9002-iiostream.c
@@ -115,6 +115,7 @@ static int configure_tx_lo(void)
 {
 	struct iio_device *phy;
 	struct iio_channel *chan;
+	const struct iio_attr *attr;
 	int ret;
 	long long val;
 
@@ -131,13 +132,21 @@ static int configure_tx_lo(void)
 	}
 
 	/* printout some useful info */
-	ret = iio_channel_attr_read_longlong(chan, "rf_bandwidth", &val);
+	attr = iio_channel_find_attr(chan, "rf_bandwidth");
+	if (attr)
+		ret = iio_attr_read_longlong(attr, &val);
+	else
+		ret = -ENOENT;
 	if (ret)
 		return ret;
 
 	info("adrv9002 bandwidth: %lld\n", val);
 
-	ret = iio_channel_attr_read_longlong(chan, "sampling_frequency", &val);
+	attr = iio_channel_find_attr(chan, "sampling_frequency");
+	if (attr)
+		ret = iio_attr_read_longlong(attr, &val);
+	else
+		ret = -ENOENT;
 	if (ret)
 		return ret;
 
@@ -151,7 +160,12 @@ static int configure_tx_lo(void)
 		return -ENODEV;
 	}
 
-	return iio_channel_attr_write_longlong(chan, "TX1_LO_frequency", val);
+	attr = iio_channel_find_attr(chan, "TX1_LO_frequency");
+	if (attr)
+		ret = iio_attr_write_longlong(attr, val);
+	else
+		ret = -ENOENT;
+	return ret;
 }
 
 static void cleanup(void)

--- a/examples/adrv9009-iiostream.c
+++ b/examples/adrv9009-iiostream.c
@@ -9,6 +9,7 @@
 
 #include "iiostream-common.h"
 
+#include <errno.h>
 #include <iio/iio.h>
 #include <iio/iio-debug.h>
 #include <stdbool.h>
@@ -85,15 +86,18 @@ static void errchk(int v, const char* what) {
 /* write attribute: long long int */
 static void wr_ch_lli(struct iio_channel *chn, const char* what, long long val)
 {
-	errchk(iio_channel_attr_write_longlong(chn, what, val), what);
+	const struct iio_attr *attr = iio_channel_find_attr(chn, what);
+
+	errchk(attr ? iio_attr_write_longlong(attr, val) : -ENOENT, what);
 }
 
 /* write attribute: long long int */
 static long long rd_ch_lli(struct iio_channel *chn, const char* what)
 {
+	const struct iio_attr *attr = iio_channel_find_attr(chn, what);
 	long long val;
 
-	errchk(iio_channel_attr_read_longlong(chn, what, &val), what);
+	errchk(attr ? iio_attr_read_longlong(attr, &val) : -ENOENT, what);
 
 	printf("\t %s: %lld\n", what, val);
 	return val;

--- a/examples/iio-monitor.c
+++ b/examples/iio-monitor.c
@@ -44,13 +44,9 @@ static int selected = -1;
 static WINDOW *win, *left, *right;
 static bool stop;
 
-static bool channel_has_attr(struct iio_channel *chn, const char *attr)
+static bool channel_has_attr(struct iio_channel *chn, const char *name)
 {
-	unsigned int i, nb = iio_channel_get_attrs_count(chn);
-	for (i = 0; i < nb; i++)
-		if (!strcmp(attr, iio_channel_get_attr(chn, i)))
-			return true;
-	return false;
+	return !!iio_channel_find_attr(chn, name);
 }
 
 static bool is_valid_channel(struct iio_channel *chn)
@@ -69,6 +65,7 @@ static void err_str(int ret)
 
 static double get_channel_value(struct iio_channel *chn)
 {
+	const struct iio_attr *attr;
 	char *old_locale, *end;
 	char buf[1024];
 	double val;
@@ -77,8 +74,9 @@ static double get_channel_value(struct iio_channel *chn)
 	old_locale = strdup(setlocale(LC_NUMERIC, NULL));
 	setlocale(LC_NUMERIC, "C");
 
-	if (channel_has_attr(chn, "input")) {
-		ret = iio_channel_attr_read_raw(chn, "input", buf, sizeof(buf));
+	attr = iio_channel_find_attr(chn, "input");
+	if (attr) {
+		ret = iio_attr_read_raw(attr, buf, sizeof(buf));
 		if (ret < 0) {
 			err_str(ret);
 			val = 0;
@@ -91,7 +89,8 @@ static double get_channel_value(struct iio_channel *chn)
 			}
 		}
 	} else {
-		ret = iio_channel_attr_read_raw(chn, "raw", buf, sizeof(buf));
+		attr = iio_channel_find_attr(chn, "raw");
+		ret = iio_attr_read_raw(attr, buf, sizeof(buf));
 		if (ret < 0) {
 			err_str(ret);
 			val = 0;
@@ -103,8 +102,10 @@ static double get_channel_value(struct iio_channel *chn)
 				val = 0;
 			}
 		}
-		if (channel_has_attr(chn, "offset")) {
-			ret = iio_channel_attr_read_raw(chn, "offset", buf, sizeof(buf));
+
+		attr = iio_channel_find_attr(chn, "offset");
+		if (attr) {
+			ret = iio_attr_read_raw(attr, buf, sizeof(buf));
 			if (ret < 0)
 				err_str(ret);
 			else {
@@ -115,8 +116,9 @@ static double get_channel_value(struct iio_channel *chn)
 			}
 		}
 
-		if (channel_has_attr(chn, "scale")) {
-			ret = iio_channel_attr_read_raw(chn, "scale", buf, sizeof(buf));
+		attr = iio_channel_find_attr(chn, "scale");
+		if (attr) {
+			ret = iio_attr_read_raw(attr, buf, sizeof(buf));
 			if (ret < 0)
 				err_str(ret);
 			else {

--- a/iio-private.h
+++ b/iio-private.h
@@ -120,11 +120,6 @@ struct iio_channel {
 	unsigned int number;
 };
 
-struct iio_dev_attrs {
-	char **names;
-	unsigned int num;
-};
-
 struct iio_device {
 	const struct iio_context *ctx;
 	struct iio_device_pdata *pdata;
@@ -132,9 +127,6 @@ struct iio_device {
 
 	char *name, *id, *label;
 
-	struct iio_dev_attrs attrs;
-	struct iio_dev_attrs buffer_attrs;
-	struct iio_dev_attrs debug_attrs;
 	struct iio_attr_list attrlist[3];
 
 	struct iio_channel **channels;
@@ -232,9 +224,6 @@ char * iio_getenv (char * envvar);
 uint64_t iio_read_counter_us(void);
 
 int iio_context_add_device(struct iio_context *ctx, struct iio_device *dev);
-
-int add_iio_dev_attr(struct iio_device *dev, struct iio_dev_attrs *attrs,
-		     const char *attr, const char *type);
 
 __cnst const struct iio_context_params *get_default_params(void);
 

--- a/iio-private.h
+++ b/iio-private.h
@@ -73,6 +73,11 @@ struct iio_module;
 struct iio_mutex;
 struct iio_task;
 
+struct iio_attr_list {
+	struct iio_attr *attrs;
+	unsigned int num;
+};
+
 struct iio_channel_attr {
 	char *name;
 	char *filename;
@@ -97,6 +102,7 @@ struct iio_context {
 	char **attrs;
 	char **values;
 	unsigned int nb_attrs;
+	struct iio_attr_list attrlist;
 
 	struct iio_context_params params;
 
@@ -118,6 +124,7 @@ struct iio_channel {
 
 	struct iio_channel_attr *attrs;
 	unsigned int nb_attrs;
+	struct iio_attr_list attrlist;
 
 	unsigned int number;
 };
@@ -137,6 +144,7 @@ struct iio_device {
 	struct iio_dev_attrs attrs;
 	struct iio_dev_attrs buffer_attrs;
 	struct iio_dev_attrs debug_attrs;
+	struct iio_attr_list attrlist[3];
 
 	struct iio_channel **channels;
 	unsigned int nb_channels;
@@ -155,6 +163,8 @@ struct iio_buffer {
 	struct iio_task *worker;
 
 	size_t block_size;
+
+	struct iio_attr_list attrlist;
 
 	/* Mutex to protect nb_blocks. Should really be an atomic... */
 	struct iio_mutex *lock;
@@ -231,9 +241,6 @@ char * iio_getenv (char * envvar);
 uint64_t iio_read_counter_us(void);
 
 int iio_context_add_device(struct iio_context *ctx, struct iio_device *dev);
-
-int iio_context_add_attr(struct iio_context *ctx,
-		const char *key, const char *value);
 
 int add_iio_dev_attr(struct iio_device *dev, struct iio_dev_attrs *attrs,
 		     const char *attr, const char *type);

--- a/iio-private.h
+++ b/iio-private.h
@@ -99,9 +99,7 @@ struct iio_context {
 
 	char *xml;
 
-	char **attrs;
 	char **values;
-	unsigned int nb_attrs;
 	struct iio_attr_list attrlist;
 
 	struct iio_context_params params;

--- a/iio-private.h
+++ b/iio-private.h
@@ -250,7 +250,8 @@ extern const struct iio_backend * const iio_backends[];
 extern const unsigned int iio_backends_size;
 
 ssize_t iio_xml_print_and_sanitized_param(char *ptr, ssize_t len,
-					  const char *before, char *param,
+					  const char *before,
+					  const char *param,
 					  const char *after);
 
 static inline void iio_update_xml_indexes(ssize_t ret, char **ptr, ssize_t *len,

--- a/iio-private.h
+++ b/iio-private.h
@@ -78,11 +78,6 @@ struct iio_attr_list {
 	unsigned int num;
 };
 
-struct iio_channel_attr {
-	char *name;
-	char *filename;
-};
-
 struct iio_context {
 	struct iio_context_pdata *pdata;
 	const struct iio_backend_ops *ops;
@@ -120,8 +115,6 @@ struct iio_channel {
 	enum iio_modifier modifier;
 	enum iio_chan_type type;
 
-	struct iio_channel_attr *attrs;
-	unsigned int nb_attrs;
 	struct iio_attr_list attrlist;
 
 	unsigned int number;

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -549,7 +549,7 @@ static ssize_t iiod_client_read_attr_new(struct iiod_client *client,
 		cmd.op = IIOD_OP_READ_ATTR;
 
 		for (i = 0; i < iio_device_get_attrs_count(dev); i++)
-			if (!strcmp(iio_device_get_attr(dev, i), attr->name))
+			if (iio_device_get_attr(dev, i) == attr)
 				break;
 
 		if (i == iio_device_get_attrs_count(dev))
@@ -562,7 +562,7 @@ static ssize_t iiod_client_read_attr_new(struct iiod_client *client,
 		cmd.op = IIOD_OP_READ_DBG_ATTR;
 
 		for (i = 0; i < iio_device_get_debug_attrs_count(dev); i++)
-			if (!strcmp(iio_device_get_debug_attr(dev, i), attr->name))
+			if (iio_device_get_debug_attr(dev, i) == attr)
 				break;
 
 		if (i == iio_device_get_debug_attrs_count(dev))
@@ -726,7 +726,7 @@ static ssize_t iiod_client_write_attr_new(struct iiod_client *client,
 		cmd.op = IIOD_OP_WRITE_ATTR;
 
 		for (i = 0; i < iio_device_get_attrs_count(dev); i++)
-			if (!strcmp(iio_device_get_attr(dev, i), attr->name))
+			if (iio_device_get_attr(dev, i) == attr)
 				break;
 
 		if (i == iio_device_get_attrs_count(dev))
@@ -739,7 +739,7 @@ static ssize_t iiod_client_write_attr_new(struct iiod_client *client,
 		cmd.op = IIOD_OP_WRITE_DBG_ATTR;
 
 		for (i = 0; i < iio_device_get_debug_attrs_count(dev); i++)
-			if (!strcmp(iio_device_get_debug_attr(dev, i), attr->name))
+			if (iio_device_get_debug_attr(dev, i) == attr)
 				break;
 
 		if (i == iio_device_get_debug_attrs_count(dev))

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -674,17 +674,6 @@ out_unlock:
 	return ret;
 }
 
-ssize_t iiod_client_read_attr(struct iiod_client *client,
-			      const struct iio_device *dev,
-			      const struct iio_channel *chn,
-			      const char *attr, char *dest,
-			      size_t len, enum iio_attr_type type,
-			      unsigned int buf_id)
-{
-	return -ENOSYS;
-}
-
-
 static ssize_t iiod_client_write_attr_new(struct iiod_client *client,
 					  const struct iio_attr *attr,
 					  const char *src, size_t len)
@@ -854,17 +843,6 @@ out_unlock:
 	iio_mutex_unlock(client->lock);
 	return ret;
 }
-
-ssize_t iiod_client_write_attr(struct iiod_client *client,
-			       const struct iio_device *dev,
-			       const struct iio_channel *chn,
-			       const char *attr, const char *src,
-			       size_t len, enum iio_attr_type type,
-			       unsigned int buf_id)
-{
-	return -ENOSYS;
-}
-
 
 static int iiod_client_cmd(const struct iiod_command *cmd,
 			   struct iiod_command_data *data, void *d)

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -536,7 +536,7 @@ static ssize_t iiod_client_read_attr_new(struct iiod_client *client,
 		arg2 = (uint16_t) i;
 
 		for (i = 0; i < iio_channel_get_attrs_count(chn); i++)
-			if (!strcmp(iio_channel_get_attr(chn, i), attr->name))
+			if (iio_channel_get_attr(chn, i) == attr)
 				break;
 
 		if (i == iio_channel_get_attrs_count(chn))
@@ -713,7 +713,7 @@ static ssize_t iiod_client_write_attr_new(struct iiod_client *client,
 		arg2 = (uint16_t) i;
 
 		for (i = 0; i < iio_channel_get_attrs_count(chn); i++)
-			if (!strcmp(iio_channel_get_attr(chn, i), attr->name))
+			if (iio_channel_get_attr(chn, i) == attr)
 				break;
 
 		if (i == iio_channel_get_attrs_count(chn))

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -652,6 +652,8 @@ ssize_t iiod_client_read_attr(struct iiod_client *client,
 				iio_snprintf(buf, sizeof(buf), "READ %s BUFFER %s\r\n",
 						id, attr ? attr : "");
 				break;
+			default:
+				return -EINVAL;
 		}
 	}
 
@@ -839,6 +841,8 @@ ssize_t iiod_client_write_attr(struct iiod_client *client,
 				iio_snprintf(buf, sizeof(buf), "WRITE %s BUFFER %s %lu\r\n",
 						id, attr ? attr : "", (unsigned long) len);
 				break;
+			default:
+				return -EINVAL;
 		}
 	}
 

--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -73,6 +73,9 @@ struct buffer_entry {
 	struct iio_task *enqueue_task, *dequeue_task;
 	uint32_t *words;
 	uint16_t idx;
+
+	SLIST_HEAD(BlockList, block_entry) blocklist;
+	pthread_mutex_t lock;
 };
 
 struct parser_pdata {
@@ -84,7 +87,6 @@ struct parser_pdata {
 	SLIST_HEAD(ParserDataThdHead, ThdEntry) thdlist_head;
 
 	SLIST_HEAD(BufferList, buffer_entry) bufferlist;
-	SLIST_HEAD(BlockList, block_entry) blocklist;
 
 	/* Used as temporaries placements by the lexer */
 	struct iio_device *dev;

--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -68,6 +68,7 @@ struct block_entry {
 
 struct buffer_entry {
 	SLIST_ENTRY(buffer_entry) entry;
+	struct parser_pdata *pdata;
 	struct iio_device *dev;
 	struct iio_buffer *buf;
 	struct iio_task *enqueue_task, *dequeue_task;
@@ -85,8 +86,6 @@ struct parser_pdata {
 	int resp_fd[2];
 
 	SLIST_HEAD(ParserDataThdHead, ThdEntry) thdlist_head;
-
-	SLIST_HEAD(BufferList, buffer_entry) bufferlist;
 
 	/* Used as temporaries placements by the lexer */
 	struct iio_device *dev;

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -86,17 +86,6 @@ struct iio_backend_ops {
 	struct iio_context * (*create)(const struct iio_context_params *params,
 				       const char *uri);
 
-	ssize_t (*read_device_attr)(const struct iio_device *dev,
-				    unsigned int buf_id, const char *attr,
-				    char *dst, size_t len, enum iio_attr_type);
-	ssize_t (*write_device_attr)(const struct iio_device *dev,
-				     unsigned int buf_id, const char *attr,
-				     const char *src, size_t len,
-				     enum iio_attr_type);
-	ssize_t (*read_channel_attr)(const struct iio_channel *chn,
-			const char *attr, char *dst, size_t len);
-	ssize_t (*write_channel_attr)(const struct iio_channel *chn,
-			const char *attr, const char *src, size_t len);
 	ssize_t (*read_attr)(const struct iio_attr *attr,
 			     char *dst, size_t len);
 	ssize_t (*write_attr)(const struct iio_attr *attr,

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -643,6 +643,17 @@ __api __check_ret const char * iio_context_get_attr_value(
 		const struct iio_context *ctx, const char *name);
 
 
+/** @brief Try to find a context-specific attribute by its name
+ * @param ctx A pointer to an iio_context structure
+ * @param name A NULL-terminated string corresponding to the name of the
+ * attribute
+ * @return On success, a pointer to an iio_attr structure
+ * @return If the name does not correspond to any known attribute of the given
+ * context, NULL is returned. */
+__api __check_ret __pure const struct iio_attr *
+iio_context_find_attr(const struct iio_context *ctx, const char *name);
+
+
 /** @brief Enumerate the devices found in the given context
  * @param ctx A pointer to an iio_context structure
  * @return The number of devices found */

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -617,30 +617,13 @@ __api __check_ret __pure unsigned int iio_context_get_attrs_count(
 		const struct iio_context *ctx);
 
 
-/** @brief Retrieve the name and value of a context-specific attribute
+/** @brief Retrieve the context-specific attribute at the given index
  * @param ctx A pointer to an iio_context structure
  * @param index The index corresponding to the attribute
- * @param name A pointer to a const char * pointer (NULL accepted)
- * @param value A pointer to a const char * pointer (NULL accepted)
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned
- *
- * Introduced in version 0.9. */
-__api __check_ret int iio_context_get_attr(
-		const struct iio_context *ctx, unsigned int index,
-		const char **name, const char **value);
-
-
-/** @brief Retrieve the value of a context-specific attribute
- * @param ctx A pointer to an iio_context structure
- * @param name The name of the context attribute to read
- * @return On success, a pointer to a static NULL-terminated string
- * @return If the name does not correspond to any attribute, NULL is
- * returned
- *
- * Introduced in version 0.9. */
-__api __check_ret const char * iio_context_get_attr_value(
-		const struct iio_context *ctx, const char *name);
+ * @return On success, a pointer to an iio_attr structure
+ * @return If the index is out-of-range, NULL is returned */
+__api __check_ret __pure const struct iio_attr *
+iio_context_get_attr(const struct iio_context *ctx, unsigned int index);
 
 
 /** @brief Try to find a context-specific attribute by its name

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -86,6 +86,7 @@ typedef ptrdiff_t ssize_t;
 
 #endif /* DOXYGEN */
 
+struct iio_attr;
 struct iio_block;
 struct iio_context;
 struct iio_device;
@@ -320,6 +321,75 @@ static inline __check_ret void *iio_err_cast(const void *ptr)
 {
 	return (void *) ptr;
 }
+
+/** @} *//* ------------------------------------------------------------------*/
+/* ------------------------- Attributes functions ----------------------------*/
+/** @defgroup Attributes functions
+ * @{
+ * @struct iio_attr
+ * @brief Structure holding meta-data for an attribute
+ */
+
+/** @brief Read the content of the given attribute
+ * @param attr A pointer to an iio_attr structure
+ * @param dst A pointer to the memory area where the read data will be stored
+ * @param len The available length of the memory area, in bytes
+ * @return On success, the number of bytes written to the buffer
+ * @return On error, a negative errno code is returned */
+__api __check_ret ssize_t
+iio_attr_read_raw(const struct iio_attr *attr, char *dst, size_t len);
+
+/** @brief Read the content of the given attribute
+ * @param attr A pointer to an iio_attr structure
+ * @param ptr A pointer to a variable where the value should be stored
+ * @return On success, 0 is returned
+ * @return On error, a negative errno code is returned */
+#define iio_attr_read(attr, ptr)				\
+	_Generic((ptr),						\
+		 bool *: iio_attr_read_bool,			\
+		 long long *: iio_attr_read_longlong,		\
+		 double *: iio_attr_read_double)(chn, attr, ptr)
+
+/** @brief Set the value of the given attribute
+ * @param attr A pointer to an iio_attr structure
+ * @param src A pointer to the data to be written
+ * @param len The number of bytes that should be written
+ * @return On success, the number of bytes written
+ * @return On error, a negative errno code is returned */
+__api __check_ret ssize_t
+iio_attr_write_raw(const struct iio_attr *attr, const void *src, size_t len);
+
+/** @brief Set the value of the given attribute
+ * @param attr A pointer to an iio_attr structure
+ * @param val The value to set the attribute to
+ * @return On success, the number of bytes written
+ * @return On error, a negative errno code is returned. */
+#define iio_attr_write(attr, val)			\
+	_Generic((val),						\
+		 const char *: iio_attr_write_string,		\
+		 char *: iio_attr_write_string,			\
+		 bool: iio_attr_write_bool,			\
+		 long long: iio_attr_write_longlong,		\
+		 double: iio_attr_write_double)(dev, attr, val)
+
+/** @brief Retrieve the name of an attribute
+ * @param attr A pointer to an iio_attr structure
+ * @return A pointer to a static NULL-terminated string */
+__api __pure const char *
+iio_attr_get_name(const struct iio_attr *attr);
+
+/** @brief Retrieve the filename of an attribute
+ * @param attr A pointer to an iio_attr structure
+ * @return A pointer to a static NULL-terminated string */
+__api __check_ret __pure const char *
+iio_attr_get_filename(const struct iio_attr *attr);
+
+/** @brief Retrieve the static value of an attribute
+ * @param attr A pointer to an iio_attr structure
+ * @return On success, a pointer to a static NULL-terminated string
+ * @return If the attribute does not have a static value, NULL is returned. */
+__api __pure const char *
+iio_attr_get_static_value(const struct iio_attr *attr);
 
 /** @} *//* ------------------------------------------------------------------*/
 /* ------------------------- Scan functions ----------------------------------*/
@@ -1721,6 +1791,27 @@ iio_device_debug_attr_write_longlong(const struct iio_device *dev,
 __api __check_ret int
 iio_device_debug_attr_write_double(const struct iio_device *dev,
 				   const char *attr, double val);
+__api __check_ret int
+iio_attr_read_bool(const struct iio_attr *attr, bool *val);
+
+__api __check_ret int
+iio_attr_read_longlong(const struct iio_attr *attr, long long *val);
+
+__api __check_ret int
+iio_attr_read_double(const struct iio_attr *attr, double *val);
+
+__api __check_ret ssize_t
+iio_attr_write_string(const struct iio_attr *attr, const char *src);
+
+__api __check_ret int
+iio_attr_write_bool(const struct iio_attr *attr, bool val);
+
+__api __check_ret int
+iio_attr_write_longlong(const struct iio_attr *attr, long long val);
+
+__api __check_ret int
+iio_attr_write_double(const struct iio_attr *attr, double val);
+
 #endif /* DOXYGEN */
 
 #ifdef __cplusplus

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1022,8 +1022,8 @@ __api __check_ret __pure bool iio_channel_is_scan_element(const struct iio_chann
 /** @brief Enumerate the channel-specific attributes of the given channel
  * @param chn A pointer to an iio_channel structure
  * @return The number of channel-specific attributes found */
-__api __check_ret __pure unsigned int iio_channel_get_attrs_count(
-		const struct iio_channel *chn);
+__api __check_ret __pure unsigned int
+iio_channel_get_attrs_count(const struct iio_channel *chn);
 
 
 /** @brief Get the channel-specific attribute present at the given index
@@ -1031,8 +1031,8 @@ __api __check_ret __pure unsigned int iio_channel_get_attrs_count(
  * @param index The index corresponding to the attribute
  * @return On success, a pointer to a static NULL-terminated string
  * @return If the index is invalid, NULL is returned */
-__api __check_ret __pure const char * iio_channel_get_attr(
-		const struct iio_channel *chn, unsigned int index);
+__api __check_ret __pure const struct iio_attr *
+iio_channel_get_attr(const struct iio_channel *chn, unsigned int index);
 
 
 /** @brief Try to find a channel-specific attribute by its name
@@ -1041,80 +1041,9 @@ __api __check_ret __pure const char * iio_channel_get_attr(
  * attribute
  * @return On success, a pointer to a static NULL-terminated string
  * @return If the name does not correspond to any known attribute of the given
- * channel, NULL is returned
- *
- * <b>NOTE:</b> This function is useful to detect the presence of an attribute.
- * It can also be used to retrieve the name of an attribute as a pointer to a
- * static string from a dynamically allocated string. */
-__api __check_ret __pure const char * iio_channel_find_attr(
-		const struct iio_channel *chn, const char *name);
-
-
-/** @brief Retrieve the filename of an attribute
- * @param chn A pointer to an iio_channel structure
- * @param attr a NULL-terminated string corresponding to the name of the
- * attribute
- * @return On success, a pointer to a static NULL-terminated string
- * @return If the attribute name is unknown, NULL is returned */
-__api __check_ret __pure const char * iio_channel_attr_get_filename(
-		const struct iio_channel *chn, const char *attr);
-
-
-/** @brief Read the content of the given channel-specific attribute
- * @param chn A pointer to an iio_channel structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param dst A pointer to the memory area where the NULL-terminated string
- * corresponding to the value read will be stored
- * @param len The available length of the memory area, in bytes
- * @return On success, the number of bytes written to the buffer
- * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t
-iio_channel_attr_read_raw(const struct iio_channel *chn,
-			  const char *attr, char *dst, size_t len);
-
-
-/** @brief Read the content of the given channel-specific attribute
- * @param chn A pointer to an iio_channel structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param ptr A pointer to the variable where the value should be stored
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-#define iio_channel_attr_read(chn, attr, ptr)			\
-	_Generic((ptr),						\
-		 bool *: iio_channel_attr_read_bool,		\
-		 long long *: iio_channel_attr_read_longlong,	\
-		 double *: iio_channel_attr_read_double)(chn, attr, ptr)
-
-
-/** @brief Set the value of the given channel-specific attribute
- * @param chn A pointer to an iio_channel structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param src A pointer to the data to be written
- * @param len The number of bytes that should be written
- * @return On success, the number of bytes written
- * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t
-iio_channel_attr_write_raw(const struct iio_channel *chn,
-			   const char *attr, const void *src, size_t len);
-
-
-/** @brief Set the value of the given channel-specific attribute
- * @param chn A pointer to an iio_channel structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param val The value to set the attribute to
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-#define iio_channel_attr_write(chn, attr, val)			\
-	_Generic((val),						\
-		 const char *: iio_channel_attr_write_string,	\
-		 char *: iio_channel_attr_write_string,		\
-		 bool: iio_channel_attr_write_bool,		\
-		 long long: iio_channel_attr_write_longlong,	\
-		 double: iio_channel_attr_write_double)(chn, attr, val)
+ * channel, NULL is returned */
+__api __check_ret __pure const struct iio_attr *
+iio_channel_find_attr(const struct iio_channel *chn, const char *name);
 
 
 /** @brief Enable the given channel

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1215,6 +1215,33 @@ __api __check_ret __pure const struct iio_device * iio_buffer_get_device(
 		const struct iio_buffer *buf);
 
 
+/** @brief Enumerate the attributes of the given buffer
+ * @param buf A pointer to an iio_buffer structure
+ * @return The number of buffer-specific attributes found */
+__api __check_ret __pure unsigned int
+iio_buffer_get_attrs_count(const struct iio_buffer *buf);
+
+
+/** @brief Get the buffer-specific attribute present at the given index
+ * @param buf A pointer to an iio_buffer structure
+ * @param index The index corresponding to the attribute
+ * @return On success, a pointer to an iio_attr structure
+ * @return If the index is invalid, NULL is returned */
+__api __check_ret __pure const struct iio_attr *
+iio_buffer_get_attr(const struct iio_buffer *buf, unsigned int index);
+
+
+/** @brief Try to find a buffer-specific attribute by its name
+ * @param buf A pointer to an iio_buffer structure
+ * @param name A NULL-terminated string corresponding to the name of the
+ * attribute
+ * @return On success, a pointer to an iio_attr structure
+ * @return If the name does not correspond to any known attribute of the given
+ * buffer, NULL is returned */
+__api __check_ret __pure const struct iio_attr *
+iio_buffer_find_attr(const struct iio_buffer *buf, const char *name);
+
+
 /** @brief Create an input or output buffer associated to the given device
  * @param dev A pointer to an iio_device structure
  * @param idx The index of the hardware buffer. Should be 0 in most cases.

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -741,14 +741,9 @@ __api __check_ret __pure unsigned int iio_device_get_channels_count(
 /** @brief Enumerate the device-specific attributes of the given device
  * @param dev A pointer to an iio_device structure
  * @return The number of device-specific attributes found */
-__api __check_ret __pure unsigned int iio_device_get_attrs_count(
-		const struct iio_device *dev);
+__api __check_ret __pure unsigned int
+iio_device_get_attrs_count(const struct iio_device *dev);
 
-/** @brief Enumerate the buffer-specific attributes of the given device
- * @param dev A pointer to an iio_device structure
- * @return The number of buffer-specific attributes found */
-__api __check_ret __pure unsigned int iio_device_get_buffer_attrs_count(
-		const struct iio_device *dev);
 
 /** @brief Get the channel present at the given index
  * @param dev A pointer to an iio_device structure
@@ -764,16 +759,9 @@ __api __check_ret __pure struct iio_channel * iio_device_get_channel(
  * @param index The index corresponding to the attribute
  * @return On success, a pointer to a static NULL-terminated string
  * @return If the index is invalid, NULL is returned */
-__api __check_ret __pure const char * iio_device_get_attr(
-		const struct iio_device *dev, unsigned int index);
+__api __check_ret __pure const struct iio_attr *
+iio_device_get_attr(const struct iio_device *dev, unsigned int index);
 
-/** @brief Get the buffer-specific attribute present at the given index
- * @param dev A pointer to an iio_device structure
- * @param index The index corresponding to the attribute
- * @return On success, a pointer to a static NULL-terminated string
- * @return If the index is invalid, NULL is returned */
-__api __check_ret __pure const char * iio_device_get_buffer_attr(
-		const struct iio_device *dev, unsigned int index);
 
 /** @brief Try to find a channel structure by its name of ID
  * @param dev A pointer to an iio_device structure
@@ -798,141 +786,8 @@ __api __check_ret __pure struct iio_channel * iio_device_find_channel(
  * <b>NOTE:</b> This function is useful to detect the presence of an attribute.
  * It can also be used to retrieve the name of an attribute as a pointer to a
  * static string from a dynamically allocated string. */
-__api __check_ret __pure const char * iio_device_find_attr(
-		const struct iio_device *dev, const char *name);
-
-/** @brief Try to find a buffer-specific attribute by its name
- * @param dev A pointer to an iio_device structure
- * @param name A NULL-terminated string corresponding to the name of the
- * attribute
- * @return On success, a pointer to a static NULL-terminated string
- * @return If the name does not correspond to any known attribute of the given
- * device, NULL is returned
- *
- * <b>NOTE:</b> This function is useful to detect the presence of an attribute.
- * It can also be used to retrieve the name of an attribute as a pointer to a
- * static string from a dynamically allocated string. */
-__api __check_ret __pure const char * iio_device_find_buffer_attr(
-		const struct iio_device *dev, const char *name);
-
-/** @brief Read the content of the given device-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param dst A pointer to the memory area where the NULL-terminated string
- * corresponding to the value read will be stored
- * @param len The available length of the memory area, in bytes
- * @return On success, the number of bytes written to the buffer
- * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t
-iio_device_attr_read_raw(const struct iio_device *dev,
-			 const char *attr, char *dst, size_t len);
-
-
-/** @brief Read the content of the given device-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param ptr A pointer to a variable where the value should be stored
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-#define iio_device_attr_read(dev, attr, ptr)			\
-	_Generic((ptr),						\
-		 bool *: iio_device_attr_read_bool,		\
-		 long long *: iio_device_attr_read_longlong,	\
-		 double *: iio_device_attr_read_double)(dev, attr, ptr)
-
-
-/** @brief Set the value of the given device-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param src A pointer to the data to be written
- * @param len The number of bytes that should be written
- * @return On success, the number of bytes written
- * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t
-iio_device_attr_write_raw(const struct iio_device *dev,
-			  const char *attr, const void *src, size_t len);
-
-
-/** @brief Set the value of the given device-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param val The value to set the attribute to
- * @return On success, the number of bytes written
- * @return On error, a negative errno code is returned. */
-#define iio_device_attr_write(dev, attr, val)			\
-	_Generic((val),						\
-		 const char *: iio_device_attr_write_string,	\
-		 char *: iio_device_attr_write_string,		\
-		 bool: iio_device_attr_write_bool,		\
-		 long long: iio_device_attr_write_longlong,	\
-		 double: iio_device_attr_write_double)(dev, attr, val)
-
-
-/** @brief Read the content of the given buffer-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param buf_id The index of the hardware buffer (generally 0)
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param dst A pointer to the memory area where the NULL-terminated string
- * corresponding to the value read will be stored
- * @param len The available length of the memory area, in bytes
- * @return On success, the number of bytes written to the buffer
- * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t
-iio_device_buffer_attr_read_raw(const struct iio_device *dev,
-				unsigned int buf_id,
-				const char *attr, char *dst, size_t len);
-
-
-/** @brief Read the content of the given buffer-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param buf_id The index of the hardware buffer (generally 0)
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param ptr A pointer to the variable where the value should be stored
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-#define iio_device_buffer_attr_read(dev, buf_id, attr, ptr)		\
-	_Generic((ptr),							\
-		 bool *: iio_device_buffer_attr_read_bool,		\
-		 long long *: iio_device_buffer_attr_read_longlong,	\
-		 double *: iio_device_buffer_attr_read_double)(dev, buf_id, attr, ptr)
-
-
-/** @brief Set the value of the given buffer-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param buf_id The index of the hardware buffer (generally 0)
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param src A pointer to the data to be written
- * @param len The number of bytes that should be written
- * @return On success, the number of bytes written
- * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t
-iio_device_buffer_attr_write_raw(const struct iio_device *dev,
-				 unsigned int buf_id, const char *attr,
-				 const void *src, size_t len);
-
-
-/** @brief Set the value of the given buffer-specific attribute
- * @param dev A pointer to an iio_device structure
- * @param buf_id The index of the hardware buffer (generally 0)
- * @param attr A NULL-terminated string corresponding to the name of the
- * attribute
- * @param val A long long value to set the attribute to
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-#define iio_device_buffer_attr_write(dev, buf_id, attr, val)		\
-	_Generic((val),							\
-		 const char *: iio_device_buffer_attr_write_string,	\
-		 char *: iio_device_buffer_attr_write_string,		\
-		 bool: iio_device_buffer_attr_write_bool,		\
-		 long long: iio_device_buffer_attr_write_longlong,	\
-		 double: iio_device_buffer_attr_write_double)(dev, buf_id, attr, val)
+__api __check_ret __pure const struct iio_attr *
+iio_device_find_attr(const struct iio_device *dev, const char *name);
 
 
 /** @brief Associate a pointer to an iio_device structure
@@ -1539,8 +1394,8 @@ __api void iio_channel_convert_inverse(const struct iio_channel *chn,
 /** @brief Enumerate the debug attributes of the given device
  * @param dev A pointer to an iio_device structure
  * @return The number of debug attributes found */
-__api __check_ret __pure unsigned int iio_device_get_debug_attrs_count(
-		const struct iio_device *dev);
+__api __check_ret __pure unsigned int
+iio_device_get_debug_attrs_count(const struct iio_device *dev);
 
 
 /** @brief Get the debug attribute present at the given index
@@ -1548,8 +1403,8 @@ __api __check_ret __pure unsigned int iio_device_get_debug_attrs_count(
  * @param index The index corresponding to the debug attribute
  * @return On success, a pointer to a static NULL-terminated string
  * @return If the index is invalid, NULL is returned */
-__api __check_ret __pure const char * iio_device_get_debug_attr(
-		const struct iio_device *dev, unsigned int index);
+__api __check_ret __pure const struct iio_attr *
+iio_device_get_debug_attr(const struct iio_device *dev, unsigned int index);
 
 
 /** @brief Try to find a debug attribute by its name
@@ -1558,71 +1413,9 @@ __api __check_ret __pure const char * iio_device_get_debug_attr(
  * debug attribute
  * @return On success, a pointer to a static NULL-terminated string
  * @return If the name does not correspond to any known debug attribute of the
- * given device, NULL is returned
- *
- * <b>NOTE:</b> This function is useful to detect the presence of a debug
- * attribute.
- * It can also be used to retrieve the name of a debug attribute as a pointer
- * to a static string from a dynamically allocated string. */
-__api __check_ret __pure const char * iio_device_find_debug_attr(
-		const struct iio_device *dev, const char *name);
-
-
-/** @brief Read the content of the given debug attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * debug attribute
- * @param dst A pointer to the memory area where the NULL-terminated string
- * corresponding to the value read will be stored
- * @param len The available length of the memory area, in bytes
- * @return On success, the number of bytes written to the buffer
- * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t
-iio_device_debug_attr_read_raw(const struct iio_device *dev,
-			       const char *attr, char *dst, size_t len);
-
-
-/** @brief Read the content of the given debug attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * debug attribute
- * @param ptr A pointer to a variable where the value should be stored
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-#define iio_device_debug_attr_read(dev, attr, ptr)			\
-	_Generic((ptr),							\
-		 bool *: iio_device_debug_attr_read_bool,		\
-		 long long *: iio_device_debug_attr_read_longlong,	\
-		 double *: iio_device_debug_attr_read_double)(dev, attr, ptr)
-
-
-/** @brief Set the value of the given debug attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * debug attribute
- * @param src A pointer to the data to be written
- * @param len The number of bytes that should be written
- * @return On success, the number of bytes written
- * @return On error, a negative errno code is returned */
-__api __check_ret ssize_t
-iio_device_debug_attr_write_raw(const struct iio_device *dev,
-				const char *attr, const void *src, size_t len);
-
-
-/** @brief Set the value of the given debug attribute
- * @param dev A pointer to an iio_device structure
- * @param attr A NULL-terminated string corresponding to the name of the
- * debug attribute
- * @param val A double value to set the debug attribute to
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-#define iio_device_debug_attr_write(dev, attr, val)			\
-	_Generic((val),							\
-		 const char *: iio_device_debug_attr_write_string,	\
-		 char *: iio_device_debug_attr_write_string,		\
-		 bool: iio_device_debug_attr_write_bool,		\
-		 long long: iio_device_debug_attr_write_longlong,	\
-		 double: iio_device_debug_attr_write_double)(dev, attr, val)
+ * given device, NULL is returned */
+__api __check_ret __pure const struct iio_attr *
+iio_device_find_debug_attr(const struct iio_device *dev, const char *name);
 
 
 /** @brief Set the value of a hardware register
@@ -1649,98 +1442,8 @@ __api __check_ret int iio_device_reg_read(struct iio_device *dev,
 
 #ifndef DOXYGEN
 /* These functions can be used directly, but should be used through the generic
- * macros iio_{device,channel,device_buffer,device_debug}_attr_{read,write}() */
-__api __check_ret int
-iio_device_attr_read_bool(const struct iio_device *dev,
-			  const char *attr, bool *val);
-__api __check_ret int
-iio_device_attr_read_longlong(const struct iio_device *dev,
-			      const char *attr, long long *val);
-__api __check_ret int
-iio_device_attr_read_double(const struct iio_device *dev,
-			    const char *attr, double *val);
-__api __check_ret ssize_t
-iio_device_attr_write_string(const struct iio_device *dev,
-			     const char *attr, const char *src);
-__api __check_ret int
-iio_device_attr_write_bool(const struct iio_device *dev,
-			   const char *attr, bool val);
-__api __check_ret int
-iio_device_attr_write_longlong(const struct iio_device *dev,
-			       const char *attr, long long val);
-__api __check_ret int
-iio_device_attr_write_double(const struct iio_device *dev,
-			     const char *attr, double val);
-__api __check_ret int
-iio_device_buffer_attr_read_bool(const struct iio_device *dev,
-				 unsigned int buf_id,
-				 const char *attr, bool *val);
-__api __check_ret int
-iio_device_buffer_attr_read_longlong(const struct iio_device *dev,
-				     unsigned int buf_id,
-				     const char *attr, long long *val);
-__api __check_ret int
-iio_device_buffer_attr_read_double(const struct iio_device *dev,
-				   unsigned int buf_id,
-				   const char *attr, double *val);
-__api __check_ret ssize_t
-iio_device_buffer_attr_write_string(const struct iio_device *dev,
-				    unsigned int buf_id,
-				    const char *attr, const char *src);
-__api __check_ret int
-iio_device_buffer_attr_write_bool(const struct iio_device *dev,
-				  unsigned int buf_id,
-				  const char *attr, bool val);
-__api __check_ret int
-iio_device_buffer_attr_write_longlong(const struct iio_device *dev,
-				      unsigned int buf_id,
-				      const char *attr, long long val);
-__api __check_ret int
-iio_device_buffer_attr_write_double(const struct iio_device *dev,
-				    unsigned int buf_id,
-				    const char *attr, double val);
-__api __check_ret int
-iio_channel_attr_read_bool(const struct iio_channel *chn,
-			   const char *attr, bool *val);
-__api __check_ret int
-iio_channel_attr_read_longlong(const struct iio_channel *chn,
-			       const char *attr, long long *val);
-__api __check_ret int
-iio_channel_attr_read_double(const struct iio_channel *chn,
-			     const char *attr, double *val);
-__api __check_ret ssize_t
-iio_channel_attr_write_string(const struct iio_channel *chn,
-			      const char *attr, const char *src);
-__api __check_ret
-int iio_channel_attr_write_bool(const struct iio_channel *chn,
-				const char *attr, bool val);
-__api __check_ret int
-iio_channel_attr_write_longlong(const struct iio_channel *chn,
-				const char *attr, long long val);
-__api __check_ret int
-iio_channel_attr_write_double(const struct iio_channel *chn,
-			      const char *attr, double val);
-__api __check_ret int
-iio_device_debug_attr_read_bool(const struct iio_device *dev,
-				const char *attr, bool *val);
-__api __check_ret int
-iio_device_debug_attr_read_longlong(const struct iio_device *dev,
-				    const char *attr, long long *val);
-__api __check_ret int
-iio_device_debug_attr_read_double(const struct iio_device *dev,
-				  const char *attr, double *val);
-__api __check_ret ssize_t
-iio_device_debug_attr_write_string(const struct iio_device *dev,
-				   const char *attr, const char *src);
-__api __check_ret int
-iio_device_debug_attr_write_bool(const struct iio_device *dev,
-				 const char *attr, bool val);
-__api __check_ret int
-iio_device_debug_attr_write_longlong(const struct iio_device *dev,
-				     const char *attr, long long val);
-__api __check_ret int
-iio_device_debug_attr_write_double(const struct iio_device *dev,
-				   const char *attr, double val);
+ * macros iio_attr_{read,write}() */
+
 __api __check_ret int
 iio_attr_read_bool(const struct iio_attr *attr, bool *val);
 

--- a/include/iio/iiod-client.h
+++ b/include/iio/iiod-client.h
@@ -68,6 +68,14 @@ __api ssize_t iiod_client_write_attr(struct iiod_client *client,
 				     size_t len, enum iio_attr_type type,
 				     unsigned int buf_id);
 
+__api ssize_t iiod_client_attr_read(struct iiod_client *client,
+				    const struct iio_attr *attr,
+				    char *dest, size_t len);
+
+__api ssize_t iiod_client_attr_write(struct iiod_client *client,
+				     const struct iio_attr *attr,
+				     const char *src, size_t len);
+
 __api struct iio_context *
 iiod_client_create_context(struct iiod_client *client,
 			   const struct iio_backend *backend,

--- a/include/iio/iiod-client.h
+++ b/include/iio/iiod-client.h
@@ -54,20 +54,6 @@ __api int iiod_client_set_kernel_buffers_count(struct iiod_client *client,
 __api int iiod_client_set_timeout(struct iiod_client *client,
 				  unsigned int timeout);
 
-__api ssize_t iiod_client_read_attr(struct iiod_client *client,
-				    const struct iio_device *dev,
-				    const struct iio_channel *chn,
-				    const char *attr, char *dest, size_t len,
-				    enum iio_attr_type type,
-				    unsigned int buf_id);
-
-__api ssize_t iiod_client_write_attr(struct iiod_client *client,
-				     const struct iio_device *dev,
-				     const struct iio_channel *chn,
-				     const char *attr, const char *src,
-				     size_t len, enum iio_attr_type type,
-				     unsigned int buf_id);
-
 __api ssize_t iiod_client_attr_read(struct iiod_client *client,
 				    const struct iio_attr *attr,
 				    char *dest, size_t len);

--- a/local.c
+++ b/local.c
@@ -717,7 +717,8 @@ static int read_device_name(struct iio_device *dev)
 	char buf[1024];
 	ssize_t ret;
 
-	ret = iio_device_attr_read_raw(dev, "name", buf, sizeof(buf));
+	ret = local_read_dev_attr(dev, 0, "name", buf, sizeof(buf),
+				  IIO_ATTR_TYPE_DEVICE);
 	if (ret < 0)
 		return ret;
 	else if (ret == 0)
@@ -735,7 +736,8 @@ static int read_device_label(struct iio_device *dev)
 	char buf[1024];
 	ssize_t ret;
 
-	ret = iio_device_attr_read_raw(dev, "label", buf, sizeof(buf));
+	ret = local_read_dev_attr(dev, 0, "label", buf, sizeof(buf),
+				  IIO_ATTR_TYPE_DEVICE);
 	if (ret < 0)
 		return ret;
 	else if (ret == 0)
@@ -1620,11 +1622,15 @@ const struct iio_backend iio_local_backend = {
 static void init_data_scale(struct iio_channel *chn)
 {
 	char *end, buf[1024];
+	const char *attr;
 	ssize_t ret;
 	float value;
 
 	chn->format.with_scale = false;
-	ret = iio_channel_attr_read_raw(chn, "scale", buf, sizeof(buf));
+	attr = get_filename(chn, "scale");
+
+	ret = local_read_dev_attr(chn->dev, 0, attr,
+				  buf, sizeof(buf), IIO_ATTR_TYPE_DEVICE);
 	if (ret < 0)
 		return;
 

--- a/local.c
+++ b/local.c
@@ -6,6 +6,7 @@
  * Author: Paul Cercueil <paul.cercueil@analog.com>
  */
 
+#include "attr.h"
 #include "iio-private.h"
 #include "local.h"
 #include "sort.h"

--- a/local.c
+++ b/local.c
@@ -1733,8 +1733,7 @@ local_create_context(const struct iio_context_params *params, const char *args)
 			goto err_context_destroy;
 	}
 
-	qsort(ctx->devices, ctx->nb_devices, sizeof(struct iio_device *),
-		iio_device_compare);
+	iio_sort_devices(ctx);
 
 	foreach_in_dir(ctx, ctx, "/sys/kernel/debug/iio", true, add_debug);
 

--- a/local.c
+++ b/local.c
@@ -446,8 +446,15 @@ static ssize_t local_read_dev_attr(const struct iio_device *dev,
 					dev->id, attr);
 			break;
 		case IIO_ATTR_TYPE_BUFFER:
-			iio_snprintf(buf, sizeof(buf), "/sys/bus/iio/devices/%s/buffer/%s",
-					dev->id, attr);
+			if (buf_id > 0) {
+				iio_snprintf(buf, sizeof(buf),
+					     "/sys/bus/iio/devices/%s/buffer%u/%s",
+					     dev->id, buf_id, attr);
+			} else {
+				iio_snprintf(buf, sizeof(buf),
+					     "/sys/bus/iio/devices/%s/buffer/%s",
+					     dev->id, attr);
+			}
 			break;
 		default:
 			return -EINVAL;

--- a/local.c
+++ b/local.c
@@ -38,14 +38,10 @@
 #define IIO_BUFFER_GET_FD_IOCTL		_IOWR('i', 0x91, int)
 
 /* Forward declarations */
-static ssize_t local_read_chn_attr(const struct iio_channel *chn,
-		const char *attr, char *dst, size_t len);
 static ssize_t local_write_dev_attr(const struct iio_device *dev,
 				    unsigned int buf_id, const char *attr,
 				    const char *src, size_t len,
 				    enum iio_attr_type type);
-static ssize_t local_write_chn_attr(const struct iio_channel *chn,
-		const char *attr, const char *src, size_t len);
 static struct iio_context *
 local_create_context(const struct iio_context_params *params, const char *args);
 static int local_context_scan(const struct iio_context_params *params,
@@ -544,22 +540,6 @@ static const char * get_filename(const struct iio_channel *chn,
 		if (!strcmp(attr, chn->attrlist.attrs[i].name))
 			return chn->attrlist.attrs[i].filename;
 	return attr;
-}
-
-static ssize_t local_read_chn_attr(const struct iio_channel *chn,
-		const char *attr, char *dst, size_t len)
-{
-	attr = get_filename(chn, attr);
-	return local_read_dev_attr(chn->dev, 0, attr,
-				   dst, len, IIO_ATTR_TYPE_DEVICE);
-}
-
-static ssize_t local_write_chn_attr(const struct iio_channel *chn,
-		const char *attr, const char *src, size_t len)
-{
-	attr = get_filename(chn, attr);
-	return local_write_dev_attr(chn->dev, 0, attr,
-				    src, len, IIO_ATTR_TYPE_DEVICE);
 }
 
 static int channel_write_state(const struct iio_channel *chn,
@@ -1564,10 +1544,6 @@ int local_dequeue_block(struct iio_block_pdata *pdata, bool nonblock)
 static const struct iio_backend_ops local_ops = {
 	.scan = local_context_scan,
 	.create = local_create_context,
-	.read_device_attr = local_read_dev_attr,
-	.write_device_attr = local_write_dev_attr,
-	.read_channel_attr = local_read_chn_attr,
-	.write_channel_attr = local_write_chn_attr,
 	.read_attr = local_read_attr,
 	.write_attr = local_write_attr,
 	.get_trigger = local_get_trigger,

--- a/network.c
+++ b/network.c
@@ -368,50 +368,24 @@ static void network_free_iiod_client(struct iiod_client *client,
 	io_ctx->fd = -1;
 }
 
-static ssize_t network_read_dev_attr(const struct iio_device *dev,
-				     unsigned int buf_id, const char *attr,
-				     char *dst, size_t len,
-				     enum iio_attr_type type)
+static ssize_t network_read_attr(const struct iio_attr *attr,
+				 char *dst, size_t len)
 {
+	const struct iio_device *dev = iio_attr_get_device(attr);
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
-	return iiod_client_read_attr(pdata->iiod_client, dev, NULL,
-				     attr, dst, len, type, buf_id);
+	return iiod_client_attr_read(pdata->iiod_client, attr, dst, len);
 }
 
-static ssize_t network_write_dev_attr(const struct iio_device *dev,
-				      unsigned int buf_id, const char *attr,
-				      const char *src, size_t len,
-				      enum iio_attr_type type)
+static ssize_t network_write_attr(const struct iio_attr *attr,
+				  const char *src, size_t len)
 {
+	const struct iio_device *dev = iio_attr_get_device(attr);
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
-	return iiod_client_write_attr(pdata->iiod_client, dev, NULL,
-				      attr, src, len, type, buf_id);
-}
-
-static ssize_t network_read_chn_attr(const struct iio_channel *chn,
-		const char *attr, char *dst, size_t len)
-{
-	const struct iio_device *dev = iio_channel_get_device(chn);
-	const struct iio_context *ctx = iio_device_get_context(dev);
-	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
-
-	return iiod_client_read_attr(pdata->iiod_client, dev, chn,
-				     attr, dst, len, false, 0);
-}
-
-static ssize_t network_write_chn_attr(const struct iio_channel *chn,
-		const char *attr, const char *src, size_t len)
-{
-	const struct iio_device *dev = iio_channel_get_device(chn);
-	const struct iio_context *ctx = iio_device_get_context(dev);
-	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
-
-	return iiod_client_write_attr(pdata->iiod_client, dev, chn,
-				      attr, src, len, false, 0);
+	return iiod_client_attr_write(pdata->iiod_client, attr, src, len);
 }
 
 static const struct iio_device *
@@ -525,10 +499,8 @@ struct iio_block_pdata * network_create_block(struct iio_buffer_pdata *pdata,
 static const struct iio_backend_ops network_ops = {
 	.scan = IF_ENABLED(HAVE_DNS_SD, dnssd_context_scan),
 	.create = network_create_context,
-	.read_device_attr = network_read_dev_attr,
-	.write_device_attr = network_write_dev_attr,
-	.read_channel_attr = network_read_chn_attr,
-	.write_channel_attr = network_write_chn_attr,
+	.read_attr = network_read_attr,
+	.write_attr = network_write_attr,
 	.get_trigger = network_get_trigger,
 	.set_trigger = network_set_trigger,
 	.shutdown = network_shutdown,

--- a/serial.c
+++ b/serial.c
@@ -100,50 +100,24 @@ static inline int libserialport_to_errno(enum sp_return ret)
 	}
 }
 
-static ssize_t serial_read_dev_attr(const struct iio_device *dev,
-				    unsigned int buf_id, const char *attr,
-				    char *dst, size_t len,
-				    enum iio_attr_type type)
+static ssize_t
+serial_read_attr(const struct iio_attr *attr, char *dst, size_t len)
 {
+	const struct iio_device *dev = iio_attr_get_device(attr);
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
-	return iiod_client_read_attr(pdata->iiod_client,
-				     dev, NULL, attr, dst, len, type, buf_id);
+	return iiod_client_attr_read(pdata->iiod_client, attr, dst, len);
 }
 
-static ssize_t serial_write_dev_attr(const struct iio_device *dev,
-				     unsigned int buf_id, const char *attr,
-				     const char *src, size_t len,
-				     enum iio_attr_type type)
+static ssize_t
+serial_write_attr(const struct iio_attr *attr, const char *src, size_t len)
 {
+	const struct iio_device *dev = iio_attr_get_device(attr);
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
-	return iiod_client_write_attr(pdata->iiod_client, dev, NULL, attr,
-				      src, len, type, buf_id);
-}
-
-static ssize_t serial_read_chn_attr(const struct iio_channel *chn,
-		const char *attr, char *dst, size_t len)
-{
-	const struct iio_device *dev = iio_channel_get_device(chn);
-	const struct iio_context *ctx = iio_device_get_context(dev);
-	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
-
-	return iiod_client_read_attr(pdata->iiod_client,
-				     dev, chn, attr, dst, len, false, 0);
-}
-
-static ssize_t serial_write_chn_attr(const struct iio_channel *chn,
-		const char *attr, const char *src, size_t len)
-{
-	const struct iio_device *dev = iio_channel_get_device(chn);
-	const struct iio_context *ctx = iio_device_get_context(dev);
-	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
-
-	return iiod_client_write_attr(pdata->iiod_client,
-				      dev, chn, attr, src, len, false, 0);
+	return iiod_client_attr_write(pdata->iiod_client, attr, src, len);
 }
 
 static ssize_t serial_write_data(struct iiod_client_pdata *io_data,
@@ -264,10 +238,8 @@ serial_create_block(struct iio_buffer_pdata *buf, size_t size, void **data)
 
 static const struct iio_backend_ops serial_ops = {
 	.create = serial_create_context_from_args,
-	.read_device_attr = serial_read_dev_attr,
-	.write_device_attr = serial_write_dev_attr,
-	.read_channel_attr = serial_read_chn_attr,
-	.write_channel_attr = serial_write_chn_attr,
+	.read_attr = serial_read_attr,
+	.write_attr = serial_write_attr,
 	.shutdown = serial_shutdown,
 	.get_trigger = serial_get_trigger,
 	.set_trigger = serial_set_trigger,

--- a/sort.c
+++ b/sort.c
@@ -44,54 +44,12 @@ static int iio_channel_compare(const void *p1, const void *p2)
 	return -1;
 }
 
-int iio_channel_attr_compare(const void *p1, const void *p2)
-{
-	const struct iio_channel_attr *tmp1 = (struct iio_channel_attr *)p1;
-	const struct iio_channel_attr *tmp2 = (struct iio_channel_attr *)p2;
-	/* qsort channel attributes by name */
-	return strcmp(tmp1->name, tmp2->name);
-}
-
 static int iio_device_compare(const void *p1, const void *p2)
 {
 	const struct iio_device *tmp1 = *(struct iio_device **)p1;
 	const struct iio_device *tmp2 = *(struct iio_device **)p2;
 	/* qsort devices by ID */
 	return strcmp(tmp1->id, tmp2->id);
-}
-
-int iio_device_attr_compare(const void *p1, const void *p2)
-{
-	const char *tmp1 = *(const char **)p1;
-	const char *tmp2 = *(const char **)p2;
-	/* qsort device attributes by name */
-	return strcmp(tmp1, tmp2);
-}
-
-int iio_buffer_attr_compare(const void *p1, const void *p2)
-{
-	const char *tmp1 = *(const char **)p1;
-	const char *tmp2 = *(const char **)p2;
-	/* qsort buffer attributes by name */
-	return strcmp(tmp1, tmp2);
-}
-
-int iio_context_info_compare(const void *p1, const void *p2)
-{
-	int ret;
-	const struct iio_context_info *tmp1 = *(struct iio_context_info **)p1;
-	const struct iio_context_info *tmp2 = *(struct iio_context_info **)p2;
-
-	if(!tmp1->uri)
-		return 1;
-	if (!tmp2->uri)
-		return 0;
-
-	ret = strcmp(tmp1->uri, tmp2->uri);
-	if (ret)
-		return ret;
-
-	return strcmp(tmp1->description, tmp2->description);
 }
 
 static int iio_attr_compare(const void *p1, const void *p2)

--- a/sort.c
+++ b/sort.c
@@ -26,7 +26,7 @@
  * to char", hence the cast plus dereference
  */
 
-int iio_channel_compare(const void *p1, const void *p2)
+static int iio_channel_compare(const void *p1, const void *p2)
 {
 	const struct iio_channel *tmp1 = *(struct iio_channel **)p1;
 	const struct iio_channel *tmp2 = *(struct iio_channel **)p2;
@@ -52,7 +52,7 @@ int iio_channel_attr_compare(const void *p1, const void *p2)
 	return strcmp(tmp1->name, tmp2->name);
 }
 
-int iio_device_compare(const void *p1, const void *p2)
+static int iio_device_compare(const void *p1, const void *p2)
 {
 	const struct iio_device *tmp1 = *(struct iio_device **)p1;
 	const struct iio_device *tmp2 = *(struct iio_device **)p2;

--- a/sort.c
+++ b/sort.c
@@ -29,24 +29,18 @@ int iio_channel_compare(const void *p1, const void *p2)
 {
 	const struct iio_channel *tmp1 = *(struct iio_channel **)p1;
 	const struct iio_channel *tmp2 = *(struct iio_channel **)p2;
+	long idx1 = iio_channel_get_index(tmp1);
+	long idx2 = iio_channel_get_index(tmp2);
 
-	/* make sure buffer enabled channels are first */
-	if (iio_channel_is_scan_element(tmp1) && !iio_channel_is_scan_element(tmp2))
-		return -1;
-	if (!iio_channel_is_scan_element(tmp1) && iio_channel_is_scan_element(tmp2))
-		return 1;
-	/* and sort them by index */
-	if (iio_channel_is_scan_element(tmp1) && iio_channel_is_scan_element(tmp2)){
-		if (iio_channel_get_index(tmp1) > iio_channel_get_index(tmp2))
-			return 1;
-		return -1;
+	if (idx1 == idx2 && idx1 >= 0) {
+		idx1 = iio_channel_get_data_format(tmp1)->shift;
+		idx2 = iio_channel_get_data_format(tmp2)->shift;
 	}
-	/* otherwise, if the ID is the same, input channels first */
-	if (strcmp(tmp1->id, tmp2->id) == 0)
-		return !iio_channel_is_output(tmp1);
 
-	/* finally by ID */
-	return strcmp(tmp1->id, tmp2->id);
+	if (idx2 >= 0 && (idx1 > idx2 || idx1 < 0))
+		return 1;
+
+	return -1;
 }
 
 int iio_channel_attr_compare(const void *p1, const void *p2)

--- a/sort.c
+++ b/sort.c
@@ -94,6 +94,22 @@ int iio_context_info_compare(const void *p1, const void *p2)
 	return strcmp(tmp1->description, tmp2->description);
 }
 
+static int iio_attr_compare(const void *p1, const void *p2)
+{
+	const struct iio_attr *attr1 = (const struct iio_attr *)p1;
+	const struct iio_attr *attr2 = (const struct iio_attr *)p2;
+
+	return strcmp(attr1->name, attr2->name);
+}
+
+void iio_sort_attrs(struct iio_attr_list *attrs)
+{
+	if (attrs->num > 0) {
+		qsort(attrs->attrs, attrs->num,
+		      sizeof(*attrs->attrs), iio_attr_compare);
+	}
+}
+
 void iio_sort_devices(struct iio_context *ctx)
 {
 	qsort(ctx->devices, ctx->nb_devices,

--- a/sort.c
+++ b/sort.c
@@ -8,6 +8,7 @@
 
 #include "iio-private.h"
 #include <string.h>
+#include <stdlib.h>
 
 /* These are a few functions to do sorting via qsort for various
  * iio structures. For more info, see the qsort(3) man page.
@@ -91,4 +92,16 @@ int iio_context_info_compare(const void *p1, const void *p2)
 		return ret;
 
 	return strcmp(tmp1->description, tmp2->description);
+}
+
+void iio_sort_devices(struct iio_context *ctx)
+{
+	qsort(ctx->devices, ctx->nb_devices,
+	      sizeof(*ctx->devices), iio_device_compare);
+}
+
+void iio_sort_channels(struct iio_device *dev)
+{
+	qsort(dev->channels, dev->nb_channels,
+	      sizeof(*dev->channels), iio_channel_compare);
 }

--- a/sort.h
+++ b/sort.h
@@ -12,9 +12,7 @@
 struct iio_context;
 struct iio_device;
 
-int iio_channel_compare(const void *p1, const void *p2);
 int iio_channel_attr_compare(const void *p1, const void *p2);
-int iio_device_compare(const void *p1, const void *p2);
 int iio_device_attr_compare(const void *p1, const void *p2);
 int iio_buffer_attr_compare(const void *p1, const void *p2);
 int iio_context_info_compare(const void *p1, const void *p2);

--- a/sort.h
+++ b/sort.h
@@ -9,6 +9,7 @@
 #ifndef __IIO_QSORT_H__
 #define __IIO_QSORT_H__
 
+struct iio_attr_list;
 struct iio_context;
 struct iio_device;
 
@@ -16,6 +17,7 @@ int iio_channel_attr_compare(const void *p1, const void *p2);
 int iio_device_attr_compare(const void *p1, const void *p2);
 int iio_buffer_attr_compare(const void *p1, const void *p2);
 int iio_context_info_compare(const void *p1, const void *p2);
+void iio_sort_attrs(struct iio_attr_list *attrs);
 void iio_sort_devices(struct iio_context *ctx);
 void iio_sort_channels(struct iio_device *dev);
 

--- a/sort.h
+++ b/sort.h
@@ -9,11 +9,16 @@
 #ifndef __IIO_QSORT_H__
 #define __IIO_QSORT_H__
 
+struct iio_context;
+struct iio_device;
+
 int iio_channel_compare(const void *p1, const void *p2);
 int iio_channel_attr_compare(const void *p1, const void *p2);
 int iio_device_compare(const void *p1, const void *p2);
 int iio_device_attr_compare(const void *p1, const void *p2);
 int iio_buffer_attr_compare(const void *p1, const void *p2);
 int iio_context_info_compare(const void *p1, const void *p2);
+void iio_sort_devices(struct iio_context *ctx);
+void iio_sort_channels(struct iio_device *dev);
 
 #endif /* __IIO_QSORT_H__ */

--- a/sort.h
+++ b/sort.h
@@ -13,10 +13,6 @@ struct iio_attr_list;
 struct iio_context;
 struct iio_device;
 
-int iio_channel_attr_compare(const void *p1, const void *p2);
-int iio_device_attr_compare(const void *p1, const void *p2);
-int iio_buffer_attr_compare(const void *p1, const void *p2);
-int iio_context_info_compare(const void *p1, const void *p2);
 void iio_sort_attrs(struct iio_attr_list *attrs);
 void iio_sort_devices(struct iio_context *ctx);
 void iio_sort_channels(struct iio_device *dev);

--- a/usb.c
+++ b/usb.c
@@ -246,52 +246,26 @@ static const struct iiod_client_ops usb_iiod_client_ops = {
 	.cancel = usb_cancel,
 };
 
-static ssize_t usb_read_dev_attr(const struct iio_device *dev,
-				 unsigned int buf_id, const char *attr,
-				 char *dst, size_t len, enum iio_attr_type type)
+static ssize_t
+usb_read_attr(const struct iio_attr *attr, char *dst, size_t len)
 {
+	const struct iio_device *dev = iio_attr_get_device(attr);
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 	struct iiod_client *client = pdata->io_ctx.iiod_client;
 
-	return iiod_client_read_attr(client, dev, NULL, attr,
-				     dst, len, type, buf_id);
+	return iiod_client_attr_read(client, attr, dst, len);
 }
 
-static ssize_t usb_write_dev_attr(const struct iio_device *dev,
-				  unsigned int buf_id, const char *attr,
-				  const char *src, size_t len,
-				  enum iio_attr_type type)
+static ssize_t
+usb_write_attr(const struct iio_attr *attr, const char *src, size_t len)
 {
+	const struct iio_device *dev = iio_attr_get_device(attr);
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 	struct iiod_client *client = pdata->io_ctx.iiod_client;
 
-	return iiod_client_write_attr(client, dev, NULL, attr, src,
-				      len, type, buf_id);
-}
-
-static ssize_t usb_read_chn_attr(const struct iio_channel *chn,
-		const char *attr, char *dst, size_t len)
-{
-	const struct iio_device *dev = iio_channel_get_device(chn);
-	const struct iio_context *ctx = iio_device_get_context(dev);
-	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
-	struct iiod_client *client = pdata->io_ctx.iiod_client;
-
-	return iiod_client_read_attr(client, dev, chn, attr,
-				     dst, len, false, 0);
-}
-
-static ssize_t usb_write_chn_attr(const struct iio_channel *chn,
-		const char *attr, const char *src, size_t len)
-{
-	const struct iio_device *dev = iio_channel_get_device(chn);
-	const struct iio_context *ctx = iio_device_get_context(dev);
-	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
-	struct iiod_client *client = pdata->io_ctx.iiod_client;
-
-	return iiod_client_write_attr(client, dev, chn, attr, src, len, false, 0);
+	return iiod_client_attr_write(client, attr, src, len);
 }
 
 static int usb_set_timeout(struct iio_context *ctx, unsigned int timeout)
@@ -530,10 +504,8 @@ usb_create_block(struct iio_buffer_pdata *pdata, size_t size, void **data)
 static const struct iio_backend_ops usb_ops = {
 	.scan = usb_context_scan,
 	.create = usb_create_context_from_args,
-	.read_device_attr = usb_read_dev_attr,
-	.read_channel_attr = usb_read_chn_attr,
-	.write_device_attr = usb_write_dev_attr,
-	.write_channel_attr = usb_write_chn_attr,
+	.read_attr = usb_read_attr,
+	.write_attr = usb_write_attr,
 	.get_trigger = usb_get_trigger,
 	.set_trigger = usb_set_trigger,
 	.set_timeout = usb_set_timeout,

--- a/utils/gen_code.h
+++ b/utils/gen_code.h
@@ -10,6 +10,8 @@
 #ifndef GEN_CODE_H
 #define GEN_CODE_H
 
+struct iio_attr;
+
 void gen_start(const char *gen_file);
 bool gen_test_path(const char *gen_file);
 void gen_context (const char *uri);
@@ -18,6 +20,6 @@ void gen_context_attr(const char *key);
 void gen_dev(const struct iio_device *dev);
 void gen_ch(const struct iio_channel *ch);
 void gen_function(const char* prefix, const char* target,
-                const char* attr, const char* wbuf);
+		  const struct iio_attr *attr, const char *wbuf);
 void gen_context_timeout(unsigned int timeout_ms);
 #endif

--- a/utils/iio_stresstest.c
+++ b/utils/iio_stresstest.c
@@ -478,9 +478,6 @@ int main(int argc, char **argv)
 					dev = iio_context_get_device(ctx, i);
 					name = iio_device_get_name(dev);
 
-					if (!iio_device_get_buffer_attrs_count(dev))
-						continue;
-
 					nb_channels = iio_device_get_channels_count(dev);
 					mask = iio_create_channels_mask(nb_channels);
 					if (!mask) {

--- a/xml.c
+++ b/xml.c
@@ -6,6 +6,7 @@
  * Author: Paul Cercueil <paul.cercueil@analog.com>
  */
 
+#include "attr.h"
 #include "iio-private.h"
 
 #include <errno.h>


### PR DESCRIPTION
This set of patches change how attributes work in Libiio.

Before, each one of `iio_context`, `iio_device`, `iio_channel` had its own set of API functions to read / write their attributes, for a total of 50+ different API functions.

This was maybe slightly easier to use, but had some drawbacks; notably the high number of API functions, but also a lack of standardization of the accesses:
- context attributes did not have any read_bool / read_longlong / read_double functions;
- buffer attributes required the hardware buffer index to be specified.
This lack of standardization also meant that it was impossible for language bindings to wrap attributes into a common "attribute" object.

For these reasons, a new API is proposed.

Accessors are still present, but will now return an opaque pointer to an `iio_attr`:
```c
unsigned int iio_context_get_attrs_count(const struct iio_context *ctx);
const struct iio_attr * iio_context_get_attr(const struct iio_context *ctx, unsigned int idx);
const struct iio_attr * iio_context_find_attr(const struct iio_context *ctx, const char *name);

unsigned int iio_device_get_attrs_count(const struct iio_device *dev);
const struct iio_attr * iio_device_get_attr(const struct iio_device *dev, unsigned int idx);
const struct iio_attr * iio_device_find_attr(const struct iio_device *dev, const char *name);

unsigned int iio_device_get_debug_attrs_count(const struct iio_device *dev);
const struct iio_attr * iio_device_get_debug_attr(const struct iio_device *dev, unsigned int idx);
const struct iio_attr * iio_device_find_debug_attr(const struct iio_device *dev, const char *name);

unsigned int iio_channel_get_attrs_count(const struct iio_channel *chn);
const struct iio_attr * iio_channel_get_attr(const struct iio_channel *chn, unsigned int idx);
const struct iio_attr * iio_channel_find_attr(const struct iio_channel *chn, const char *name);
```

Note that the accessors for buffer attributes changed. They are now specific to an `iio_buffer` object, and not to an `iio_device` object as it used to be. The reason behind that, is that in a multi-buffer situation, different buffers will have different attributes.
```c
unsigned int iio_buffer_get_attrs_count(const struct iio_buffer *buf);
const struct iio_attr * iio_buffer_get_attr(const struct iio_buffer *buf, unsigned int idx);
const struct iio_attr * iio_buffer_find_attr(const struct iio_buffer *buf, const char *name);
```

Once you obtain the `iio_attr` object, you can get its name, filename and static value (only for context attributes) with these functions:
```c
const char * iio_attr_get_name(const struct iio_attr *attr);
const char * iio_attr_get_filename(const struct iio_attr *attr);
const char * iio_attr_get_static_value(const struct iio_attr *attr);
```

The functions to read / write attributes are now:
```c
ssize_t iio_attr_read_raw(const struct iio_attr *attr, char *dst, size_t len);
ssize_t iio_attr_write_raw(const struct iio_attr *attr, const void *src, size_t len);

int iio_attr_read_bool(const struct iio_attr *attr, bool *val);
int iio_attr_read_longlong(const struct iio_attr *attr, long long *val);
int iio_attr_read_double(const struct iio_attr *attr, double *val);

int iio_attr_write_string(const struct iio_attr *attr, const char *str);
int iio_attr_write_bool(const struct iio_attr *attr, bool val);
int iio_attr_write_longlong(const struct iio_attr *attr, long long val);
int iio_attr_write_double(const struct iio_attr *attr, double val);
```
You also have the `iio_attr_read` and `iio_attr_write` C11 generic macros which will automatically pick the right API function according to the type.

Emulating the old behaviour is very easy (except for buffer attributes - more on that below), and client applications who wish to keep using the old behaviour can create themselves wrappers like this:
```c
ssize_t channel_write_raw(const struct iio_channel *chn, const char *name, const void *src, size_t len)
{
   const struct iio_attr *attr = iio_channel_find_attr(ch, name);
   if (!attr)
       return -ENOENT;
   return iio_attr_write_raw(attr, src, len);
}
```

The most intrusive change is maybe the one with the buffer attributes, because now they can only be accessed when a `iio_buffer` has been created. Granted, in v1.0 API creating a `iio_buffer` does not automatically start the stream process like it did in v0.x, but it will still try to open the /dev node. If that fails, then the buffer attributes cannot be accessed, but that should be okay - you probably don't need to change buffer attributes if the buffer can't be created in the first place.

The problem is more with the v0.x compatibility layer; as emulating `iio_device_buffer_attr_read_raw` for instance would mean creating a "fake" `iio_buffer` just to be able to read its attributes. The compatibility layer (and IIOD) will now return an error code when an old application tries to read a buffer attribute before an iio_buffer has been created. This definitely affects the old "iio_info" for instance, but it *should* be fine as very few applications in v0.x used buffer attributes in the first place.

Feedback welcome.