### PR TITLE
channel: don't look for attributes for iio_channel_attr_write_all

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -403,9 +403,11 @@ ssize_t iio_channel_attr_read(const struct iio_channel *chn,
 ssize_t iio_channel_attr_write_raw(const struct iio_channel *chn,
 		const char *attr, const void *src, size_t len)
 {
-	attr = iio_channel_find_attr(chn, attr);
-	if (!attr)
-		return -ENOENT;
+	if (attr) {
+		attr = iio_channel_find_attr(chn, attr);
+		if (!attr)
+			return -ENOENT;
+	}
 
 	if (chn->dev->ctx->ops->write_channel_attr)
 		return chn->dev->ctx->ops->write_channel_attr(chn,


### PR DESCRIPTION
iio_channel_attr_write_all calls iio_channel_attr_write with attr set to NULL, causing a segmentation fault
when attr is NULL, the iio_channel_find_attr step in iio_channel_attr_write is skipped