### PR TITLE
azure-pipelines: add trigger for libiio-v0 branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ trigger:
     - main
     - next_stable
     - dev
+    - libiio-v0
     - staging/*
     - 20*
   tags:


### PR DESCRIPTION
libiio-v0 is the branch for old libiio API. There is also v0.25 release that has associated all archives. But we found bugs on release and the fixes got pushed into libiio-v0 branch. So we need to keep the CI for old API active. The CI uses azure-pipelines.yml from libiio-v0 branch, meaning that the single impact on master is just on triggering.