### PR TITLE
local: Fix reading of empty attributes

### DIFF
--- a/local.c
+++ b/local.c
@@ -471,7 +471,7 @@ static ssize_t local_read_dev_attr(const struct iio_device *dev,
 	if (ferror(f))
 		ret = -errno;
 	fclose(f);
-	return ret ? ret : -EIO;
+	return ret;
 }
 
 static ssize_t local_write_dev_attr(const struct iio_device *dev,


### PR DESCRIPTION
This partially reverts 3fa8e97b. This commit is from 2014, I have no idea why we wanted -EIO for empty attributes. Maybe I thought that this would never happen.

Fixes #1061.