### PR TITLE
Update iio_device_get _trigger

### DIFF
--- a/device.c
+++ b/device.c
@@ -336,15 +336,13 @@ bool iio_device_is_trigger(const struct iio_device *dev)
 		!strncmp(id, "trigger", sizeof("trigger") - 1));
 }
 
-int iio_device_get_trigger(const struct iio_device *dev,
-		const struct iio_device **trigger)
+const struct iio_device *
+iio_device_get_trigger(const struct iio_device *dev)
 {
-	if (!trigger)
-		return -EINVAL;
-	else if (dev->ctx->ops->get_trigger)
-		return dev->ctx->ops->get_trigger(dev, trigger);
+	if (dev->ctx->ops->get_trigger)
+		return dev->ctx->ops->get_trigger(dev);
 	else
-		return -ENOSYS;
+		return iio_ptr(-ENOSYS);
 }
 
 int iio_device_set_trigger(const struct iio_device *dev,

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -1457,8 +1457,9 @@ ssize_t get_trigger(struct parser_pdata *pdata, struct iio_device *dev)
 		return -ENODEV;
 	}
 
-	ret = iio_device_get_trigger(dev, &trigger);
-	if (!ret && trigger) {
+	trigger = iio_device_get_trigger(dev);
+	ret = iio_err(trigger);
+	if (!ret) {
 		const char *name = iio_device_get_name(trigger);
 		char buf[256];
 

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -244,9 +244,8 @@ static void handle_gettrig(struct parser_pdata *pdata,
 	if (!dev)
 		goto out_send_response;
 
-	ret = iio_device_get_trigger(dev, &trigger);
-	if (!ret && !trigger)
-		ret = -ENODEV;
+	trigger = iio_device_get_trigger(dev);
+	ret = iio_err(trigger);
 	if (ret)
 		goto out_send_response;
 

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -81,8 +81,7 @@ struct iio_backend_ops {
 	ssize_t (*write_channel_attr)(const struct iio_channel *chn,
 			const char *attr, const char *src, size_t len);
 
-	int (*get_trigger)(const struct iio_device *dev,
-			const struct iio_device **trigger);
+	const struct iio_device * (*get_trigger)(const struct iio_device *dev);
 	int (*set_trigger)(const struct iio_device *dev,
 			const struct iio_device *trigger);
 

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -886,13 +886,13 @@ __api void * iio_device_get_data(const struct iio_device *dev);
 
 /** @brief Retrieve the trigger of a given device
  * @param dev A pointer to an iio_device structure
- * @param trigger a pointer to a pointer of an iio_device structure. The pointed
- * pointer will be set to the address of the iio_device structure corresponding
- * to the associated trigger device.
- * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
-__api __check_ret int iio_device_get_trigger(const struct iio_device *dev,
-		const struct iio_device **trigger);
+ * @return On success, a pointer to the trigger's iio_device structure is
+ * returned.
+ * @return On failure, a pointer-encoded error is returned. If no trigger
+ * has been associated with the given device, the error code will be
+ * -ENODEV. */
+__api __check_ret const struct iio_device *
+iio_device_get_trigger(const struct iio_device *dev);
 
 
 /** @brief Associate a trigger to a given device

--- a/include/iio/iiod-client.h
+++ b/include/iio/iiod-client.h
@@ -39,9 +39,9 @@ __api void iiod_client_destroy(struct iiod_client *client);
 
 __api bool iiod_client_uses_binary_interface(const struct iiod_client *client);
 
-__api int iiod_client_get_trigger(struct iiod_client *client,
-				  const struct iio_device *dev,
-				  const struct iio_device **trigger);
+__api const struct iio_device *
+iiod_client_get_trigger(struct iiod_client *client,
+			const struct iio_device *dev);
 
 __api int iiod_client_set_trigger(struct iiod_client *client,
 				  const struct iio_device *dev,

--- a/network.c
+++ b/network.c
@@ -414,13 +414,13 @@ static ssize_t network_write_chn_attr(const struct iio_channel *chn,
 				      attr, src, len, false, 0);
 }
 
-static int network_get_trigger(const struct iio_device *dev,
-		const struct iio_device **trigger)
+static const struct iio_device *
+network_get_trigger(const struct iio_device *dev)
 {
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
-	return iiod_client_get_trigger(pdata->iiod_client, dev, trigger);
+	return iiod_client_get_trigger(pdata->iiod_client, dev);
 }
 
 static int network_set_trigger(const struct iio_device *dev,

--- a/serial.c
+++ b/serial.c
@@ -201,13 +201,13 @@ static void serial_shutdown(struct iio_context *ctx)
 	sp_free_port(ctx_pdata->port);
 }
 
-static int serial_get_trigger(const struct iio_device *dev,
-			      const struct iio_device **trigger)
+static const struct iio_device *
+serial_get_trigger(const struct iio_device *dev)
 {
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
-	return iiod_client_get_trigger(pdata->iiod_client, dev, trigger);
+	return iiod_client_get_trigger(pdata->iiod_client, dev);
 }
 
 static int serial_set_trigger(const struct iio_device *dev,

--- a/usb.c
+++ b/usb.c
@@ -301,14 +301,13 @@ static int usb_set_timeout(struct iio_context *ctx, unsigned int timeout)
 	return iiod_client_set_timeout(pdata->io_ctx.iiod_client, timeout);
 }
 
-static int usb_get_trigger(const struct iio_device *dev,
-                const struct iio_device **trigger)
+static const struct iio_device * usb_get_trigger(const struct iio_device *dev)
 {
 	const struct iio_context *ctx = iio_device_get_context(dev);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 	struct iiod_client *client = pdata->io_ctx.iiod_client;
 
-	return iiod_client_get_trigger(client, dev, trigger);
+	return iiod_client_get_trigger(client, dev);
 }
 
 static int usb_set_trigger(const struct iio_device *dev,

--- a/utils/iio_info.c
+++ b/utils/iio_info.c
@@ -261,16 +261,15 @@ int main(int argc, char **argv)
 			}
 		}
 
-		ret = iio_device_get_trigger(dev, &trig);
+		trig = iio_device_get_trigger(dev);
+		ret = iio_err(trig);
 		if (ret == 0) {
-			if (trig == NULL) {
-				printf("\t\tNo trigger assigned to device\n");
-			} else {
-				name = iio_device_get_name(trig);
-				printf("\t\tCurrent trigger: %s(%s)\n",
-						iio_device_get_id(trig),
-						name ? name : "");
-			}
+			name = iio_device_get_name(trig);
+			printf("\t\tCurrent trigger: %s(%s)\n",
+					iio_device_get_id(trig),
+					name ? name : "");
+		} else if (ret == -ENODEV) {
+			printf("\t\tNo trigger assigned to device\n");
 		} else if (ret == -ENOENT) {
 			printf("\t\tNo trigger on this device\n");
 		} else if (ret < 0) {


### PR DESCRIPTION
Change the prototype from:
```c
int iio_device_get_trigger(const struct iio_device *dev, const struct iio_device **trigger);
```
to:
```c
const struct iio_device * iio_device_get_trigger(const struct iio_device *dev);
```
And return errors as pointer-encoded codes.