### PR TITLE
CI/build_win.ps1: Fix cmake using the wrong python version

### DIFF
--- a/CI/build_win.ps1
+++ b/CI/build_win.ps1
@@ -11,7 +11,8 @@ mkdir build-x64
 cp .\libiio.iss.cmakein .\build-x64
 cd build-x64
 
-cmake -G "$COMPILER" -DCMAKE_SYSTEM_PREFIX_PATH="C:" -Werror=dev -DCOMPILE_WARNING_AS_ERROR=ON -DENABLE_IPV6=ON -DWITH_USB_BACKEND=ON -DWITH_SERIAL_BACKEND=ON -DPYTHON_BINDINGS=ON -DCSHARP_BINDINGS:BOOL=$USE_CSHARP -DLIBXML2_LIBRARIES="C:\\libs\\64\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\64\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\64\\libserialport.dll.a" -DLIBUSB_INCLUDE_DIR="C:\\include\\libusb-1.0" -DLIBXML2_INCLUDE_DIR="C:\\include\\libxml2" -DLIBZSTD_INCLUDE_DIR="C:\\include" -DLIBZSTD_LIBRARIES="C:\\libs\\64\\libzstd.dll.a" ..
+cmake -G "$COMPILER" -DPYTHON_EXECUTABLE:FILEPATH=$(python -c "import os, sys; print(os.path.dirname(sys.executable) + '\python.exe')") -DCMAKE_SYSTEM_PREFIX_PATH="C:" -Werror=dev -DCOMPILE_WARNING_AS_ERROR=ON -DENABLE_IPV6=ON -DWITH_USB_BACKEND=ON -DWITH_SERIAL_BACKEND=ON -DPYTHON_BINDINGS=ON -DCSHARP_BINDINGS:BOOL=$USE_CSHARP -DLIBXML2_LIBRARIES="C:\\libs\\64\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\64\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\64\\libserialport.dll.a" -DLIBUSB_INCLUDE_DIR="C:\\include\\libusb-1.0" -DLIBXML2_INCLUDE_DIR="C:\\include\\libxml2" -DLIBZSTD_INCLUDE_DIR="C:\\include" -DLIBZSTD_LIBRARIES="C:\\libs\\64\\libzstd.dll.a" ..
+
 cmake --build . --config Release
 if ( $LASTEXITCODE -ne 0 ) {
 		throw "[*] cmake build failure"


### PR DESCRIPTION
Added a flag for cmake which sets the python version to the one used by the system (configured in azure-pipelines.yml).