### PR TITLE
Fix MinGW build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,6 +125,7 @@ stages:
       inputs:
         targetType: inline
         script: |
+          ghcup install ghc 9.2.8
           git submodule update --init
           if ( !( Test-Path deps ) ) {
             mkdir deps


### PR DESCRIPTION
Install 9.2.8 version of ghc because it's not supported anymore on windows-2022 image from azure.