### PR TITLE
CI: Limit FreeBSD CI time to 30 minutes

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -6,6 +6,7 @@ on: [push]
 jobs:
   build:
     runs-on: macos-12
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
A FreeBSD 12.3 CI build takes less than 10 minutes. However, FreeBSD 13.2 will currently hang somewhere, causing the CI to fail after a timeout of 6 hours.

Since that's way too long, reduce the maximum CI time for FreeBSD to 30 minutes.