### PR TITLE
Fix compatibility layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -646,6 +646,7 @@ string(REPLACE ";" "," LIBIIO_SCAN_BACKENDS "${LIBIIO_SCAN_BACKENDS}")
 
 configure_file(iio-config.h.cmakein ${CMAKE_CURRENT_BINARY_DIR}/iio-config.h @ONLY)
 
+toggle_iio_feature("${LIBIIO_COMPAT}" compat)
 toggle_iio_feature("${WITH_XML_BACKEND}" xml)
 toggle_iio_feature("${WITH_ZSTD}" zstd)
 toggle_iio_feature("${WITH_NETWORK_BACKEND}" network)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,16 @@ add_library(iio attr.c backend.c block.c channel.c device.c context.c buffer.c m
 	${CMAKE_CURRENT_BINARY_DIR}/iio-config.h
 )
 
+if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang" AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+	# Specify that the symbols referenced by Libiio should be searched from
+	# within Libiio itself first. This makes sure that the library won't
+	# call the symbols from the compat layer if the compat layer is used.
+
+	# TODO: Use cmake_link_options() in CMake 3.13+
+	SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Bsymbolic")
+	SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic")
+endif()
+
 if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|MSVC")
 	option(LIBIIO_COMPAT "Add compatibility layer for libiio 0.x" ON)
 	if (LIBIIO_COMPAT)

--- a/compat.c
+++ b/compat.c
@@ -306,6 +306,7 @@ static int iio_init_context_compat(struct iio_context *ctx)
 	struct iio_channel *chn;
 	size_t size = sizeof(*compat);
 	unsigned int i, j, nb_devices, nb_channels;
+	unsigned int chn_counter = 0;
 	int err;
 
 	nb_devices = IIO_CALL(iio_context_get_devices_count)(ctx);
@@ -351,7 +352,7 @@ static int iio_init_context_compat(struct iio_context *ctx)
 			chn_compat = (void *)((uintptr_t)compat
 					      + sizeof(*compat)
 					      + nb_devices * sizeof(*dev_compat)
-					      + j * sizeof(*chn_compat));
+					      + chn_counter++ * sizeof(*chn_compat));
 			IIO_CALL(iio_channel_set_data)(chn, chn_compat);
 		}
 	}


### PR DESCRIPTION
After the new attributes API was introduced, the compatibility layer started to fail, but only on non-local backends.

This was caused by local Libiio symbols being incorrectly linked to the compatibility layer. The call to `iio_channel_get_attr` in `iiod_client_read_attr_new` would resolve to the compatibility layer's `iio_channel_get_attr`, which returns a string instead of a `struct iio_attr *`, and caused all kinds of weird problems further down.

This happened because by default the linker will search for any symbol in the global symbol table, instead of searching in priority in the shared library that contains the code. Since the v0.25 "iio_info" (used in this test) would call `iio_channel_get_attr` before calling `iio_channel_attr_read`, the compat layer's `iio_channel_get_attr` ended up in the global symbol table, and was being chosen as the symbol to be called from the v1.0 Libiio.

Fix this by telling the linker to bind Libiio's references to the definitions within Libiio, if present, so that those have priority over the symbols found in the global symbol table.