### PR TITLE
Restore support for reading/writing all attributes and improve compat layer

### DIFF
--- a/compat.c
+++ b/compat.c
@@ -972,7 +972,10 @@ ssize_t iio_device_attr_read(const struct iio_device *dev,
 	const struct iio_attr *attr;
 
 	attr = IIO_CALL(iio_device_find_attr)(dev, name);
-	return IIO_CALL(iio_attr_read_raw)(attr, dst, len);
+	if (attr)
+		return IIO_CALL(iio_attr_read_raw)(attr, dst, len);
+
+	return -ENOENT;
 }
 
 int iio_device_attr_read_bool(const struct iio_device *dev,
@@ -981,7 +984,10 @@ int iio_device_attr_read_bool(const struct iio_device *dev,
 	const struct iio_attr *attr;
 
 	attr = IIO_CALL(iio_device_find_attr)(dev, name);
-	return IIO_CALL(iio_attr_read_bool)(attr, val);
+	if (attr)
+		return IIO_CALL(iio_attr_read_bool)(attr, val);
+
+	return -ENOENT;
 }
 
 int iio_device_attr_read_longlong(const struct iio_device *dev,
@@ -990,7 +996,10 @@ int iio_device_attr_read_longlong(const struct iio_device *dev,
 	const struct iio_attr *attr;
 
 	attr = IIO_CALL(iio_device_find_attr)(dev, name);
-	return IIO_CALL(iio_attr_read_longlong)(attr, val);
+	if (attr)
+		return IIO_CALL(iio_attr_read_longlong)(attr, val);
+
+	return -ENOENT;
 }
 
 int iio_device_attr_read_double(const struct iio_device *dev,
@@ -999,7 +1008,10 @@ int iio_device_attr_read_double(const struct iio_device *dev,
 	const struct iio_attr *attr;
 
 	attr = IIO_CALL(iio_device_find_attr)(dev, name);
-	return IIO_CALL(iio_attr_read_double)(attr, val);
+	if (attr)
+		return IIO_CALL(iio_attr_read_double)(attr, val);
+
+	return -ENOENT;
 }
 
 int iio_device_attr_read_all(struct iio_device *dev,
@@ -1159,7 +1171,10 @@ ssize_t iio_device_debug_attr_read(const struct iio_device *dev,
 	const struct iio_attr *attr;
 
 	attr = IIO_CALL(iio_device_find_debug_attr)(dev, name);
-	return IIO_CALL(iio_attr_read_raw)(attr, dst, len);
+	if (attr)
+		return IIO_CALL(iio_attr_read_raw)(attr, dst, len);
+
+	return -ENOENT;
 }
 
 int iio_device_debug_attr_read_bool(const struct iio_device *dev,
@@ -1168,7 +1183,10 @@ int iio_device_debug_attr_read_bool(const struct iio_device *dev,
 	const struct iio_attr *attr;
 
 	attr = IIO_CALL(iio_device_find_debug_attr)(dev, name);
-	return IIO_CALL(iio_attr_read_bool)(attr, val);
+	if (attr)
+		return IIO_CALL(iio_attr_read_bool)(attr, val);
+
+	return -ENOENT;
 }
 
 int iio_device_debug_attr_read_longlong(const struct iio_device *dev,
@@ -1177,7 +1195,10 @@ int iio_device_debug_attr_read_longlong(const struct iio_device *dev,
 	const struct iio_attr *attr;
 
 	attr = IIO_CALL(iio_device_find_debug_attr)(dev, name);
-	return IIO_CALL(iio_attr_read_longlong)(attr, val);
+	if (attr)
+		return IIO_CALL(iio_attr_read_longlong)(attr, val);
+
+	return -ENOENT;
 }
 
 int iio_device_debug_attr_read_double(const struct iio_device *dev,
@@ -1186,7 +1207,10 @@ int iio_device_debug_attr_read_double(const struct iio_device *dev,
 	const struct iio_attr *attr;
 
 	attr = IIO_CALL(iio_device_find_debug_attr)(dev, name);
-	return IIO_CALL(iio_attr_read_double)(attr, val);
+	if (attr)
+		return IIO_CALL(iio_attr_read_double)(attr, val);
+
+	return -ENOENT;
 }
 
 int iio_device_debug_attr_read_all(struct iio_device *dev,
@@ -1667,7 +1691,10 @@ ssize_t iio_channel_attr_read(const struct iio_channel *chn,
 	const struct iio_attr *attr;
 
 	attr = IIO_CALL(iio_channel_find_attr)(chn, name);
-	return IIO_CALL(iio_attr_read_raw)(attr, dst, len);
+	if (attr)
+		return IIO_CALL(iio_attr_read_raw)(attr, dst, len);
+
+	return -ENOENT;
 }
 
 int iio_channel_attr_read_bool(const struct iio_channel *chn,
@@ -1676,7 +1703,10 @@ int iio_channel_attr_read_bool(const struct iio_channel *chn,
 	const struct iio_attr *attr;
 
 	attr = IIO_CALL(iio_channel_find_attr)(chn, name);
-	return IIO_CALL(iio_attr_read_bool)(attr, val);
+	if (attr)
+		return IIO_CALL(iio_attr_read_bool)(attr, val);
+
+	return -ENOENT;
 }
 
 int iio_channel_attr_read_longlong(const struct iio_channel *chn,
@@ -1685,7 +1715,10 @@ int iio_channel_attr_read_longlong(const struct iio_channel *chn,
 	const struct iio_attr *attr;
 
 	attr = IIO_CALL(iio_channel_find_attr)(chn, name);
-	return IIO_CALL(iio_attr_read_longlong)(attr, val);
+	if (attr)
+		return IIO_CALL(iio_attr_read_longlong)(attr, val);
+
+	return -ENOENT;
 }
 
 int iio_channel_attr_read_double(const struct iio_channel *chn,
@@ -1694,7 +1727,10 @@ int iio_channel_attr_read_double(const struct iio_channel *chn,
 	const struct iio_attr *attr;
 
 	attr = IIO_CALL(iio_channel_find_attr)(chn, name);
-	return IIO_CALL(iio_attr_read_double)(attr, val);
+	if (attr)
+		return IIO_CALL(iio_attr_read_double)(attr, val);
+
+	return -ENOENT;
 }
 
 int iio_channel_attr_read_all(struct iio_channel *chn,

--- a/compat.c
+++ b/compat.c
@@ -1685,6 +1685,19 @@ const char * iio_channel_find_attr(const struct iio_channel *chn,
 	return IIO_CALL(iio_attr_get_name)(attr);
 }
 
+const char * iio_channel_attr_get_filename(const struct iio_channel *chn,
+					   const char *name)
+{
+	const struct iio_attr *attr;
+
+	attr = IIO_CALL(iio_channel_find_attr)(chn, name);
+	if (!attr)
+		return NULL;
+
+	return IIO_CALL(iio_attr_get_filename)(attr);
+}
+
+
 ssize_t iio_channel_attr_read(const struct iio_channel *chn,
 			      const char *name, char *dst, size_t len)
 {


### PR DESCRIPTION
A set of three commits that IIOD to work again with the iio-oscilloscope, and also allow iio-oscilloscope to run on top of the compatibility layer.