### PR TITLE
channel: Fix iio_channel_read()

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -607,7 +607,7 @@ size_t iio_channel_read(const struct iio_channel *chn,
 	if (raw)
 		cb = chn_memcpy;
 	else
-		cb = iio_channel_convert_inverse;
+		cb = iio_channel_convert;
 
 	for (src_ptr = (uintptr_t) iio_block_first(block, chn);
 	     src_ptr < block_end && dst_ptr + length <= end;


### PR DESCRIPTION
It was using iio_channel_convert_inverse() instead of iio_channel_convert() to convert the raw samples into readable samples.