### PR TITLE
Serial backend fixes

### DIFF
--- a/compat.c
+++ b/compat.c
@@ -410,6 +410,14 @@ struct iio_context * iio_context_clone(const struct iio_context *old_ctx)
 	uri = IIO_CALL(iio_attr_get_static_value)(attr);
 	params = IIO_CALL(iio_context_get_params)(old_ctx);
 
+	if (strncmp(uri, "local:", sizeof("local:") - 1)
+	    && strncmp(uri, "ip:", sizeof("ip:") - 1)) {
+		/* The .clone callback was only implemented by the local
+		 * and network backends in Libiio <= v0.25. */
+		err = -ENOSYS;
+		goto err_set_errno;
+	}
+
 	ctx = IIO_CALL(iio_create_context)(params, uri);
 	err = iio_err(ctx);
 	if (err)

--- a/serial.c
+++ b/serial.c
@@ -262,6 +262,18 @@ static int serial_enable_buffer(struct iio_buffer_pdata *buf,
 	return iiod_client_enable_buffer(buf->pdata, nb_samples, enable);
 }
 
+static ssize_t
+serial_readbuf(struct iio_buffer_pdata *buf, void *dst, size_t len)
+{
+	return iiod_client_readbuf(buf->pdata, dst, len);
+}
+
+static ssize_t
+serial_writebuf(struct iio_buffer_pdata *buf, const void *src, size_t len)
+{
+	return iiod_client_writebuf(buf->pdata, src, len);
+}
+
 static struct iio_block_pdata *
 serial_create_block(struct iio_buffer_pdata *buf, size_t size, void **data)
 {
@@ -288,6 +300,9 @@ static const struct iio_backend_ops serial_ops = {
 	.create_buffer = serial_create_buffer,
 	.free_buffer = serial_free_buffer,
 	.enable_buffer = serial_enable_buffer,
+
+	.readbuf = serial_readbuf,
+	.writebuf = serial_writebuf,
 
 	.create_block = serial_create_block,
 	.free_block = iiod_client_free_block,

--- a/serial.c
+++ b/serial.c
@@ -187,9 +187,6 @@ static ssize_t serial_read_data(struct iiod_client_pdata *io_data,
 		time_left_ms--;
 	}
 
-	prm_dbg(&pdata->params, "Read returned %li: %.*s\n",
-		(long) ret, (int) ret, buf);
-
 	if (ret == 0) {
 		if (!pdata->shutdown)
 			prm_err(&pdata->params, "serial_read_data has timed out\n");

--- a/task.c
+++ b/task.c
@@ -50,6 +50,9 @@ static int iio_task_run(void *d)
 	iio_mutex_lock(task->lock);
 
 	for (;;) {
+		/* Signal that we're idle */
+		iio_cond_signal(task->cond);
+
 		while (!task->stop && !(task->list && task->running)) {
 			iio_cond_wait(task->cond, task->lock, 0);
 
@@ -77,9 +80,7 @@ static int iio_task_run(void *d)
 		if (autoclear)
 			iio_task_token_destroy(entry);
 
-		/* Signal that we're done with the previous entry */
 		iio_mutex_lock(task->lock);
-		iio_cond_signal(task->cond);
 	}
 
 	iio_mutex_unlock(task->lock);


### PR DESCRIPTION
- Make sure the serial backend will properly exit and not lock up when iio_context_destroy is called;
- Handle clients sending the BINARY command in ASCII when IIOD is already in binary mode (which happens when a new client connects)
- Fix iio_context_clone() in the compat layer, which should return -ENOSYS with the serial backend, as only one context can be created at the same time. This fixes iio-osc running on top of the compat layer when using the serial backend.