### PR TITLE
iiod: support compiling without v0.x compatibility

### DIFF
--- a/README_BUILD.md
+++ b/README_BUILD.md
@@ -107,6 +107,7 @@ Cmake Options       | Default | Description                                    |
 `WITH_IIOD`         |  ON | Build the IIO Daemon                                 |
 `WITH_IIOD_SERIAL`  |  ON | Add serial (UART) support                            |
 `WITH_IIOD_USBD`    |  ON | Add support for USB through FunctionFS within IIOD   |
+`WITH_IIOD_V0_COMPAT` |  ON | Add support for Libiio v0.x protocol and clients |
 `WITH_AIO`          |  ON | Build IIOD with async. I/O support                   |
 `WITH_SYSTEMD`      | OFF | Enable installation of systemd service file for iiod |
 `SYSTEMD_UNIT_INSTALL_DIR`  | /lib/systemd/system | default install path for systemd unit files |

--- a/iio-config.h.cmakein
+++ b/iio-config.h.cmakein
@@ -30,6 +30,7 @@
 #cmakedefine01 WITH_NETWORK_EVENTFD
 #cmakedefine01 WITH_IIOD_USBD
 #cmakedefine01 WITH_IIOD_SERIAL
+#cmakedefine01 WITH_IIOD_V0_COMPAT
 #cmakedefine01 WITH_LOCAL_CONFIG
 #cmakedefine01 WITH_LOCAL_DMABUF_API
 #cmakedefine01 WITH_LOCAL_MMAP_API

--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -1,15 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(iiod C)
 
-include(FindBISON)
-include(FindFLEX)
-
-flex_target(lexer
-	${CMAKE_CURRENT_SOURCE_DIR}/lexer.l ${CMAKE_CURRENT_BINARY_DIR}/lexer.c)
-bison_target(parser
-	${CMAKE_CURRENT_SOURCE_DIR}/parser.y ${CMAKE_CURRENT_BINARY_DIR}/parser.c)
-add_flex_bison_dependency(lexer parser)
-
 include(CheckSymbolExists)
 set(CMAKE_REQUIRED_LIBRARIES ${PTHREAD_LIBRARIES})
 set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
@@ -21,8 +12,7 @@ set(CMAKE_REQUIRED_LIBRARIES)
 set(CMAKE_REQUIRED_DEFINITIONS)
 
 add_executable(iiod
-	iiod.c interpreter.c ops.c responder.c thread-pool.c
-	${BISON_parser_OUTPUTS} ${FLEX_lexer_OUTPUTS}
+	iiod.c interpreter.c responder.c thread-pool.c
 )
 set_target_properties(iiod PROPERTIES
 	C_STANDARD 99
@@ -40,6 +30,20 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
 	set_source_files_properties(${FLEX_lexer_OUTPUTS} PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
 	set_source_files_properties(${BISON_parser_OUTPUTS} PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
 endif ()
+
+option(WITH_IIOD_V0_COMPAT "Build support for Libiio v0.x protocol" ON)
+if (WITH_IIOD_V0_COMPAT)
+	include(FindBISON)
+	include(FindFLEX)
+
+	flex_target(lexer
+		${CMAKE_CURRENT_SOURCE_DIR}/lexer.l ${CMAKE_CURRENT_BINARY_DIR}/lexer.c)
+	bison_target(parser
+		${CMAKE_CURRENT_SOURCE_DIR}/parser.y ${CMAKE_CURRENT_BINARY_DIR}/parser.c)
+	add_flex_bison_dependency(lexer parser)
+
+	target_sources(iiod PRIVATE ops.c ${BISON_parser_OUTPUTS} ${FLEX_lexer_OUTPUTS})
+endif (WITH_IIOD_V0_COMPAT)
 
 option(WITH_AIO "Build IIOD with async. I/O support" ON)
 if (WITH_AIO)
@@ -130,6 +134,7 @@ if (WITH_UPSTART)
 endif()
 
 toggle_iio_feature("${WITH_IIOD_SERIAL}" iiod-serial)
+toggle_iio_feature("${WITH_IIOD_V0_COMPAT}" iiod-v0-compat)
 toggle_iio_feature("${WITH_AIO}" iiod-aio)
 toggle_iio_feature("${WITH_IIOD_USBD}" iiod-usb)
 toggle_iio_feature("${WITH_SYSTEMD}" iiod-systemd)

--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_REQUIRED_LIBRARIES)
 set(CMAKE_REQUIRED_DEFINITIONS)
 
 add_executable(iiod
-	iiod.c ops.c responder.c thread-pool.c
+	iiod.c interpreter.c ops.c responder.c thread-pool.c
 	${BISON_parser_OUTPUTS} ${FLEX_lexer_OUTPUTS}
 )
 set_target_properties(iiod PROPERTIES

--- a/iiod/interpreter.c
+++ b/iiod/interpreter.c
@@ -243,6 +243,7 @@ void interpreter(struct iio_context *ctx, int fd_in, int fd_out, bool verbose,
 	pdata.fd_out = fd_out;
 	pdata.verbose = verbose;
 	pdata.pool = pool;
+	pdata.binary = !WITH_IIOD_V0_COMPAT;
 
 	pdata.xml_zstd = xml_zstd;
 	pdata.xml_zstd_len = xml_zstd_len;
@@ -287,7 +288,8 @@ void interpreter(struct iio_context *ctx, int fd_in, int fd_out, bool verbose,
 		pdata.writefd = writefd_io;
 	}
 
-	ascii_interpreter(&pdata, verbose);
+	if (WITH_IIOD_V0_COMPAT)
+		ascii_interpreter(&pdata, verbose);
 
 	if (pdata.binary)
 		binary_parse(&pdata);

--- a/iiod/interpreter.c
+++ b/iiod/interpreter.c
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+/*
+ * libiio - Library for interfacing industrial I/O (IIO) devices
+ *
+ * Copyright (C) 2023 Analog Devices, Inc.
+ * Author: Paul Cercueil <paul.cercueil@analog.com>
+ */
+
+#include "../iio-config.h"
+#include "debug.h"
+#include "ops.h"
+#include "thread-pool.h"
+
+#include <poll.h>
+#if WITH_AIO
+#include <pthread.h>
+#include <sys/eventfd.h>
+#endif
+
+#if WITH_AIO
+static ssize_t async_io(struct parser_pdata *pdata, void *buf, size_t len,
+	bool do_read)
+{
+	ssize_t ret;
+	struct pollfd pfd[2];
+	unsigned int num_pfds;
+	struct iocb iocb;
+	struct iocb *ios[1];
+	struct io_event e[1];
+
+	ios[0] = &iocb;
+
+	if (do_read)
+		io_prep_pread(&iocb, pdata->fd_in, buf, len, 0);
+	else
+		io_prep_pwrite(&iocb, pdata->fd_out, buf, len, 0);
+
+	io_set_eventfd(&iocb, pdata->aio_eventfd[do_read]);
+
+	pthread_mutex_lock(&pdata->aio_mutex[do_read]);
+
+	ret = io_submit(pdata->aio_ctx[do_read], 1, ios);
+	if (ret != 1) {
+		pthread_mutex_unlock(&pdata->aio_mutex[do_read]);
+		IIO_ERROR("Failed to submit IO operation: %zd\n", ret);
+		return -EIO;
+	}
+
+	pfd[0].fd = pdata->aio_eventfd[do_read];
+	pfd[0].events = POLLIN;
+	pfd[0].revents = 0;
+	pfd[1].fd = thread_pool_get_poll_fd(pdata->pool);
+	pfd[1].events = POLLIN;
+	pfd[1].revents = 0;
+	num_pfds = 2;
+
+	do {
+		poll_nointr(pfd, num_pfds);
+
+		if (pfd[0].revents & POLLIN) {
+			uint64_t event;
+			ret = read(pdata->aio_eventfd[do_read],
+						&event, sizeof(event));
+			if (ret != sizeof(event)) {
+				IIO_ERROR("Failed to read from eventfd: %d\n", -errno);
+				ret = -EIO;
+				break;
+			}
+
+			ret = io_getevents(pdata->aio_ctx[do_read], 0, 1, e, NULL);
+			if (ret != 1) {
+				IIO_ERROR("Failed to read IO events: %zd\n", ret);
+				ret = -EIO;
+				break;
+			} else {
+				ret = (long)e[0].res;
+			}
+		} else if ((num_pfds > 1 && pfd[1].revents & POLLIN)) {
+			/* Got a STOP event to abort this whole session */
+			ret = io_cancel(pdata->aio_ctx[do_read], &iocb, e);
+			if (ret != -EINPROGRESS && ret != -EINVAL) {
+				IIO_ERROR("Failed to cancel IO transfer: %zd\n", ret);
+				ret = -EIO;
+				break;
+			}
+			/* It should not be long now until we get the cancellation event */
+			num_pfds = 1;
+		}
+	} while (!(pfd[0].revents & POLLIN));
+
+	pthread_mutex_unlock(&pdata->aio_mutex[do_read]);
+
+	/* Got STOP event, treat it as EOF */
+	if (num_pfds == 1)
+		return 0;
+
+	return ret;
+}
+
+#define MAX_AIO_REQ_SIZE (1024 * 1024)
+
+static ssize_t readfd_aio(struct parser_pdata *pdata, void *dest, size_t len)
+{
+	if (len > MAX_AIO_REQ_SIZE)
+		len = MAX_AIO_REQ_SIZE;
+	return async_io(pdata, dest, len, true);
+}
+
+static ssize_t writefd_aio(struct parser_pdata *pdata, const void *dest,
+		size_t len)
+{
+	if (len > MAX_AIO_REQ_SIZE)
+		len = MAX_AIO_REQ_SIZE;
+	return async_io(pdata, (void *)dest, len, false);
+}
+#endif /* WITH_AIO */
+
+static ssize_t readfd_io(struct parser_pdata *pdata, void *dest, size_t len)
+{
+	ssize_t ret;
+	struct pollfd pfd[2];
+
+	pfd[0].fd = pdata->fd_in;
+	pfd[0].events = POLLIN | POLLRDHUP;
+	pfd[0].revents = 0;
+	pfd[1].fd = thread_pool_get_poll_fd(pdata->pool);
+	pfd[1].events = POLLIN;
+	pfd[1].revents = 0;
+
+	do {
+		poll_nointr(pfd, 2);
+
+		/* Got STOP event, or client closed the socket: treat it as EOF */
+		if (pfd[1].revents & POLLIN || pfd[0].revents & POLLRDHUP)
+			return 0;
+		if (pfd[0].revents & POLLERR)
+			return -EIO;
+		if (!(pfd[0].revents & POLLIN))
+			continue;
+
+		do {
+			if (pdata->fd_in_is_socket)
+				ret = recv(pdata->fd_in, dest, len, MSG_NOSIGNAL);
+			else
+				ret = read(pdata->fd_in, dest, len);
+		} while (ret == -1 && errno == EINTR);
+
+		if (ret != -1 || errno != EAGAIN)
+			break;
+	} while (true);
+
+	if (ret == -1)
+		return -errno;
+
+	return ret;
+}
+
+static ssize_t writefd_io(struct parser_pdata *pdata, const void *src, size_t len)
+{
+	ssize_t ret;
+	struct pollfd pfd[2];
+
+	pfd[0].fd = pdata->fd_out;
+	pfd[0].events = POLLOUT;
+	pfd[0].revents = 0;
+	pfd[1].fd = thread_pool_get_poll_fd(pdata->pool);
+	pfd[1].events = POLLIN;
+	pfd[1].revents = 0;
+
+	do {
+		poll_nointr(pfd, 2);
+
+		/* Got STOP event, or client closed the socket: treat it as EOF */
+		if (pfd[1].revents & POLLIN || pfd[0].revents & POLLHUP)
+			return 0;
+		if (pfd[0].revents & POLLERR)
+			return -EIO;
+		if (!(pfd[0].revents & POLLOUT))
+			continue;
+
+		do {
+			if (pdata->fd_out_is_socket)
+				ret = send(pdata->fd_out, src, len, MSG_NOSIGNAL);
+			else
+				ret = write(pdata->fd_out, src, len);
+		} while (ret == -1 && errno == EINTR);
+
+		if (ret != -1 || errno != EAGAIN)
+			break;
+	} while (true);
+
+	if (ret == -1)
+		return -errno;
+
+	return ret;
+}
+
+ssize_t write_all(struct parser_pdata *pdata, const void *src, size_t len)
+{
+	uintptr_t ptr = (uintptr_t) src;
+
+	while (len) {
+		ssize_t ret = pdata->writefd(pdata, (void *) ptr, len);
+		if (ret < 0)
+			return ret;
+		if (!ret)
+			return -EPIPE;
+		ptr += ret;
+		len -= ret;
+	}
+
+	return ptr - (uintptr_t) src;
+}
+
+ssize_t read_all(struct parser_pdata *pdata, void *dst, size_t len)
+{
+	uintptr_t ptr = (uintptr_t) dst;
+
+	while (len) {
+		ssize_t ret = pdata->readfd(pdata, (void *) ptr, len);
+		if (ret < 0)
+			return ret;
+		if (!ret)
+			return -EPIPE;
+		ptr += ret;
+		len -= ret;
+	}
+
+	return ptr - (uintptr_t) dst;
+}
+
+void interpreter(struct iio_context *ctx, int fd_in, int fd_out, bool verbose,
+		 bool is_socket, bool is_usb, bool use_aio,
+		 struct thread_pool *pool, const void *xml_zstd,
+		 size_t xml_zstd_len)
+{
+	struct parser_pdata pdata = { 0 };
+	unsigned int i;
+	int ret;
+
+	pdata.ctx = ctx;
+	pdata.fd_in = fd_in;
+	pdata.fd_out = fd_out;
+	pdata.verbose = verbose;
+	pdata.pool = pool;
+
+	pdata.xml_zstd = xml_zstd;
+	pdata.xml_zstd_len = xml_zstd_len;
+
+	pdata.fd_in_is_socket = is_socket;
+	pdata.fd_out_is_socket = is_socket;
+	pdata.is_usb = is_usb;
+
+	SLIST_INIT(&pdata.thdlist_head);
+
+	if (use_aio) {
+		/* Note: if WITH_AIO is not defined, use_aio is always false.
+		 * We ensure that in iiod.c. */
+#if WITH_AIO
+		char err_str[1024];
+
+		for (i = 0; i < 2; i++) {
+			pdata.aio_eventfd[i] = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+			if (pdata.aio_eventfd[i] < 0) {
+				iio_strerror(errno, err_str, sizeof(err_str));
+				IIO_ERROR("Failed to create AIO eventfd: %s\n", err_str);
+				goto err_free_aio;
+			}
+
+			pdata.aio_ctx[i] = 0;
+			ret = io_setup(1, &pdata.aio_ctx[i]);
+			if (ret < 0) {
+				iio_strerror(-ret, err_str, sizeof(err_str));
+				IIO_ERROR("Failed to create AIO context: %s\n", err_str);
+				close(pdata.aio_eventfd[i]);
+				goto err_free_aio;
+			}
+
+			pthread_mutex_init(&pdata.aio_mutex[i], NULL);
+		}
+
+		pdata.readfd = readfd_aio;
+		pdata.writefd = writefd_aio;
+#endif
+	} else {
+		pdata.readfd = readfd_io;
+		pdata.writefd = writefd_io;
+	}
+
+	ascii_interpreter(&pdata, verbose);
+
+	if (pdata.binary)
+		binary_parse(&pdata);
+
+#if WITH_AIO
+	i = use_aio ? 2 : 0;
+
+err_free_aio:
+	for (; i > 0; i--) {
+		io_destroy(pdata.aio_ctx[i - 1]);
+		close(pdata.aio_eventfd[i - 1]);
+		pthread_mutex_destroy(&pdata.aio_mutex[i - 1]);
+	}
+#endif
+}

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -152,218 +152,6 @@ static inline const char *dev_label_or_name_or_id(const struct iio_device *dev)
 	return iio_device_get_id(dev);
 }
 
-#if WITH_AIO
-static ssize_t async_io(struct parser_pdata *pdata, void *buf, size_t len,
-	bool do_read)
-{
-	ssize_t ret;
-	struct pollfd pfd[2];
-	unsigned int num_pfds;
-	struct iocb iocb;
-	struct iocb *ios[1];
-	struct io_event e[1];
-
-	ios[0] = &iocb;
-
-	if (do_read)
-		io_prep_pread(&iocb, pdata->fd_in, buf, len, 0);
-	else
-		io_prep_pwrite(&iocb, pdata->fd_out, buf, len, 0);
-
-	io_set_eventfd(&iocb, pdata->aio_eventfd[do_read]);
-
-	pthread_mutex_lock(&pdata->aio_mutex[do_read]);
-
-	ret = io_submit(pdata->aio_ctx[do_read], 1, ios);
-	if (ret != 1) {
-		pthread_mutex_unlock(&pdata->aio_mutex[do_read]);
-		IIO_ERROR("Failed to submit IO operation: %zd\n", ret);
-		return -EIO;
-	}
-
-	pfd[0].fd = pdata->aio_eventfd[do_read];
-	pfd[0].events = POLLIN;
-	pfd[0].revents = 0;
-	pfd[1].fd = thread_pool_get_poll_fd(pdata->pool);
-	pfd[1].events = POLLIN;
-	pfd[1].revents = 0;
-	num_pfds = 2;
-
-	do {
-		poll_nointr(pfd, num_pfds);
-
-		if (pfd[0].revents & POLLIN) {
-			uint64_t event;
-			ret = read(pdata->aio_eventfd[do_read],
-						&event, sizeof(event));
-			if (ret != sizeof(event)) {
-				IIO_ERROR("Failed to read from eventfd: %d\n", -errno);
-				ret = -EIO;
-				break;
-			}
-
-			ret = io_getevents(pdata->aio_ctx[do_read], 0, 1, e, NULL);
-			if (ret != 1) {
-				IIO_ERROR("Failed to read IO events: %zd\n", ret);
-				ret = -EIO;
-				break;
-			} else {
-				ret = (long)e[0].res;
-			}
-		} else if ((num_pfds > 1 && pfd[1].revents & POLLIN)) {
-			/* Got a STOP event to abort this whole session */
-			ret = io_cancel(pdata->aio_ctx[do_read], &iocb, e);
-			if (ret != -EINPROGRESS && ret != -EINVAL) {
-				IIO_ERROR("Failed to cancel IO transfer: %zd\n", ret);
-				ret = -EIO;
-				break;
-			}
-			/* It should not be long now until we get the cancellation event */
-			num_pfds = 1;
-		}
-	} while (!(pfd[0].revents & POLLIN));
-
-	pthread_mutex_unlock(&pdata->aio_mutex[do_read]);
-
-	/* Got STOP event, treat it as EOF */
-	if (num_pfds == 1)
-		return 0;
-
-	return ret;
-}
-
-#define MAX_AIO_REQ_SIZE (1024 * 1024)
-
-static ssize_t readfd_aio(struct parser_pdata *pdata, void *dest, size_t len)
-{
-	if (len > MAX_AIO_REQ_SIZE)
-		len = MAX_AIO_REQ_SIZE;
-	return async_io(pdata, dest, len, true);
-}
-
-static ssize_t writefd_aio(struct parser_pdata *pdata, const void *dest,
-		size_t len)
-{
-	if (len > MAX_AIO_REQ_SIZE)
-		len = MAX_AIO_REQ_SIZE;
-	return async_io(pdata, (void *)dest, len, false);
-}
-#endif /* WITH_AIO */
-
-static ssize_t readfd_io(struct parser_pdata *pdata, void *dest, size_t len)
-{
-	ssize_t ret;
-	struct pollfd pfd[2];
-
-	pfd[0].fd = pdata->fd_in;
-	pfd[0].events = POLLIN | POLLRDHUP;
-	pfd[0].revents = 0;
-	pfd[1].fd = thread_pool_get_poll_fd(pdata->pool);
-	pfd[1].events = POLLIN;
-	pfd[1].revents = 0;
-
-	do {
-		poll_nointr(pfd, 2);
-
-		/* Got STOP event, or client closed the socket: treat it as EOF */
-		if (pfd[1].revents & POLLIN || pfd[0].revents & POLLRDHUP)
-			return 0;
-		if (pfd[0].revents & POLLERR)
-			return -EIO;
-		if (!(pfd[0].revents & POLLIN))
-			continue;
-
-		do {
-			if (pdata->fd_in_is_socket)
-				ret = recv(pdata->fd_in, dest, len, MSG_NOSIGNAL);
-			else
-				ret = read(pdata->fd_in, dest, len);
-		} while (ret == -1 && errno == EINTR);
-
-		if (ret != -1 || errno != EAGAIN)
-			break;
-	} while (true);
-
-	if (ret == -1)
-		return -errno;
-
-	return ret;
-}
-
-static ssize_t writefd_io(struct parser_pdata *pdata, const void *src, size_t len)
-{
-	ssize_t ret;
-	struct pollfd pfd[2];
-
-	pfd[0].fd = pdata->fd_out;
-	pfd[0].events = POLLOUT;
-	pfd[0].revents = 0;
-	pfd[1].fd = thread_pool_get_poll_fd(pdata->pool);
-	pfd[1].events = POLLIN;
-	pfd[1].revents = 0;
-
-	do {
-		poll_nointr(pfd, 2);
-
-		/* Got STOP event, or client closed the socket: treat it as EOF */
-		if (pfd[1].revents & POLLIN || pfd[0].revents & POLLHUP)
-			return 0;
-		if (pfd[0].revents & POLLERR)
-			return -EIO;
-		if (!(pfd[0].revents & POLLOUT))
-			continue;
-
-		do {
-			if (pdata->fd_out_is_socket)
-				ret = send(pdata->fd_out, src, len, MSG_NOSIGNAL);
-			else
-				ret = write(pdata->fd_out, src, len);
-		} while (ret == -1 && errno == EINTR);
-
-		if (ret != -1 || errno != EAGAIN)
-			break;
-	} while (true);
-
-	if (ret == -1)
-		return -errno;
-
-	return ret;
-}
-
-ssize_t write_all(struct parser_pdata *pdata, const void *src, size_t len)
-{
-	uintptr_t ptr = (uintptr_t) src;
-
-	while (len) {
-		ssize_t ret = pdata->writefd(pdata, (void *) ptr, len);
-		if (ret < 0)
-			return ret;
-		if (!ret)
-			return -EPIPE;
-		ptr += ret;
-		len -= ret;
-	}
-
-	return ptr - (uintptr_t) src;
-}
-
-ssize_t read_all(struct parser_pdata *pdata, void *dst, size_t len)
-{
-	uintptr_t ptr = (uintptr_t) dst;
-
-	while (len) {
-		ssize_t ret = pdata->readfd(pdata, (void *) ptr, len);
-		if (ret < 0)
-			return ret;
-		if (!ret)
-			return -EPIPE;
-		ptr += ret;
-		len -= ret;
-	}
-
-	return ptr - (uintptr_t) dst;
-}
-
 static void print_value(struct parser_pdata *pdata, long value)
 {
 	if (pdata->verbose && value < 0) {
@@ -1806,92 +1594,25 @@ ssize_t read_line(struct parser_pdata *pdata, char *buf, size_t len)
 	return found ? (ssize_t) bytes_read : -EIO;
 }
 
-void interpreter(struct iio_context *ctx, int fd_in, int fd_out, bool verbose,
-		 bool is_socket, bool is_usb, bool use_aio,
-		 struct thread_pool *pool, const void *xml_zstd,
-		 size_t xml_zstd_len)
+void ascii_interpreter(struct parser_pdata *pdata, bool verbose)
 {
-	struct parser_pdata pdata = { 0 };
 	yyscan_t scanner;
 	unsigned int i;
 	int ret;
 
-	pdata.ctx = ctx;
-	pdata.fd_in = fd_in;
-	pdata.fd_out = fd_out;
-	pdata.verbose = verbose;
-	pdata.pool = pool;
-
-	pdata.xml_zstd = xml_zstd;
-	pdata.xml_zstd_len = xml_zstd_len;
-
-	pdata.fd_in_is_socket = is_socket;
-	pdata.fd_out_is_socket = is_socket;
-	pdata.is_usb = is_usb;
-
-	SLIST_INIT(&pdata.thdlist_head);
-
-	if (use_aio) {
-		/* Note: if WITH_AIO is not defined, use_aio is always false.
-		 * We ensure that in iiod.c. */
-#if WITH_AIO
-		char err_str[1024];
-
-		for (i = 0; i < 2; i++) {
-			pdata.aio_eventfd[i] = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
-			if (pdata.aio_eventfd[i] < 0) {
-				iio_strerror(errno, err_str, sizeof(err_str));
-				IIO_ERROR("Failed to create AIO eventfd: %s\n", err_str);
-				goto err_free_aio;
-			}
-
-			pdata.aio_ctx[i] = 0;
-			ret = io_setup(1, &pdata.aio_ctx[i]);
-			if (ret < 0) {
-				iio_strerror(-ret, err_str, sizeof(err_str));
-				IIO_ERROR("Failed to create AIO context: %s\n", err_str);
-				close(pdata.aio_eventfd[i]);
-				goto err_free_aio;
-			}
-
-			pthread_mutex_init(&pdata.aio_mutex[i], NULL);
-		}
-
-		pdata.readfd = readfd_aio;
-		pdata.writefd = writefd_aio;
-#endif
-	} else {
-		pdata.readfd = readfd_io;
-		pdata.writefd = writefd_io;
-	}
-
-	yylex_init_extra(&pdata, &scanner);
+	yylex_init_extra(pdata, &scanner);
 
 	do {
 		if (verbose)
-			output(&pdata, "iio-daemon > ");
+			output(pdata, "iio-daemon > ");
 		ret = yyparse(scanner);
-	} while (!pdata.stop && !pdata.binary && ret >= 0);
+	} while (!pdata->stop && !pdata->binary && ret >= 0);
 
 	yylex_destroy(scanner);
 
-	if (pdata.binary)
-		binary_parse(&pdata);
-
 	/* Close all opened devices */
-	for (i = 0; i < iio_context_get_devices_count(ctx); i++)
-		close_dev_helper(&pdata, iio_context_get_device(ctx, i));
-
-#if WITH_AIO
-	i = use_aio ? 2 : 0;
-
-err_free_aio:
-	for (; i > 0; i--) {
-		io_destroy(pdata.aio_ctx[i - 1]);
-		close(pdata.aio_eventfd[i - 1]);
-		pthread_mutex_destroy(&pdata.aio_mutex[i - 1]);
-	}
-#endif
+	for (i = 0; i < iio_context_get_devices_count(pdata->ctx); i++)
+		close_dev_helper(pdata, iio_context_get_device(pdata->ctx, i));
 }
 
 void enable_binary(struct parser_pdata *pdata)

--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -133,6 +133,7 @@ static inline void *zalloc(size_t size)
 void interpreter(struct iio_context *ctx, int fd_in, int fd_out, bool verbose,
 		 bool is_socket, bool is_usb, bool use_aio, struct thread_pool *pool,
 		 const void *xml_zstd, size_t xml_zstd_len);
+void ascii_interpreter(struct parser_pdata *pdata, bool verbose);
 
 int init_usb_daemon(const char *ffs, unsigned int nb_pipes);
 int start_usb_daemon(struct iio_context *ctx, const char *ffs,


### PR DESCRIPTION
Add support for compiling only with the binary interface, stripping away the ASCII protocol implemented in ops.c, and the flex/bison interpreter.