### PR TITLE
xml: Fix compatibility with libxml 2.12

### DIFF
--- a/xml.c
+++ b/xml.c
@@ -11,6 +11,7 @@
 
 #include <errno.h>
 #include <iio/iio-debug.h>
+#include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <string.h>
 


### PR DESCRIPTION
libxml 2.12.0 reorganized includes, resulting in the following no longer being in scope:

- XML_PARSE_DTDVALID
- xmlReadMemory
- xmlReadFile
- xmlCleanupParser
