### PR TITLE
Fix cyclic mode to IIOD v0.x

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -51,6 +51,7 @@ static int iio_buffer_set_enabled(const struct iio_buffer *buf, bool enabled)
 	if (buf->block_size) {
 		sample_size = iio_device_get_sample_size(buf->dev, buf->mask);
 		nb_samples = buf->block_size / sample_size;
+		cyclic = buf->cyclic;
 	}
 
 	if (ops->enable_buffer)

--- a/buffer.c
+++ b/buffer.c
@@ -46,6 +46,7 @@ static int iio_buffer_set_enabled(const struct iio_buffer *buf, bool enabled)
 {
 	const struct iio_backend_ops *ops = buf->dev->ctx->ops;
 	size_t sample_size, nb_samples = 0;
+	bool cyclic = false;
 
 	if (buf->block_size) {
 		sample_size = iio_device_get_sample_size(buf->dev, buf->mask);
@@ -53,7 +54,7 @@ static int iio_buffer_set_enabled(const struct iio_buffer *buf, bool enabled)
 	}
 
 	if (ops->enable_buffer)
-		return ops->enable_buffer(buf->pdata, nb_samples, enabled);
+		return ops->enable_buffer(buf->pdata, nb_samples, enabled, cyclic);
 
 	return -ENOSYS;
 }

--- a/iio-private.h
+++ b/iio-private.h
@@ -146,7 +146,10 @@ struct iio_buffer {
 
 	struct iio_task *worker;
 
+	/* These two fields are set by the last block created. They are only
+	 * used when communicating with v0.x IIOD. */
 	size_t block_size;
+	bool cyclic;
 
 	struct iio_attr_list attrlist;
 

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -1490,7 +1490,7 @@ void iiod_client_free_buffer(struct iiod_client_buffer_pdata *pdata)
 }
 
 int iiod_client_enable_buffer(struct iiod_client_buffer_pdata *pdata,
-			      size_t nb_samples, bool enable)
+			      size_t nb_samples, bool enable, bool cyclic)
 {
 	struct iiod_client *client = pdata->client;
 	struct iiod_client_io *client_io;
@@ -1511,7 +1511,7 @@ int iiod_client_enable_buffer(struct iiod_client_buffer_pdata *pdata,
 		if (enable) {
 			client_io = iiod_client_open_with_mask(client, pdata->dev,
 							       pdata->mask,
-							       nb_samples, false);
+							       nb_samples, cyclic);
 			err = iio_err(client_io);
 			pdata->io = err ? NULL : client_io;
 		} else {

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -398,8 +398,8 @@ err_free_blocks:
 	for (; i; i--)
 	      iio_block_destroy(entry->blocks[i - 1]);
 	iio_buffer_destroy(entry->buf);
-	entry->buf = NULL;
 err_free_blocks_array:
+	entry->buf = NULL;
 	free(entry->blocks);
 	entry->blocks = NULL;
 	return err;

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -108,7 +108,7 @@ struct iio_backend_ops {
 						  struct iio_channels_mask *mask);
 	void (*free_buffer)(struct iio_buffer_pdata *pdata);
 	int (*enable_buffer)(struct iio_buffer_pdata *pdata,
-			     size_t nb_samples, bool enable);
+			     size_t nb_samples, bool enable, bool cyclic);
 	void (*cancel_buffer)(struct iio_buffer_pdata *pdata);
 
 	ssize_t (*readbuf)(struct iio_buffer_pdata *pdata,

--- a/include/iio/iiod-client.h
+++ b/include/iio/iiod-client.h
@@ -77,7 +77,7 @@ iiod_client_create_buffer(struct iiod_client *client,
 			  struct iio_channels_mask *mask);
 __api void iiod_client_free_buffer(struct iiod_client_buffer_pdata *pdata);
 __api int iiod_client_enable_buffer(struct iiod_client_buffer_pdata *pdata,
-				    size_t nb_samples, bool enable);
+				    size_t nb_samples, bool enable, bool cyclic);
 
 __api struct iio_block_pdata *
 iiod_client_create_block(struct iiod_client_buffer_pdata *pdata,

--- a/local.c
+++ b/local.c
@@ -313,7 +313,7 @@ static int local_do_enable_buffer(struct iio_buffer_pdata *pdata, bool enable)
 }
 
 static int local_enable_buffer(struct iio_buffer_pdata *pdata,
-			       size_t nb_samples, bool enable)
+			       size_t nb_samples, bool enable, bool cyclic)
 {
 	int ret;
 

--- a/network.c
+++ b/network.c
@@ -485,9 +485,9 @@ void network_free_buffer(struct iio_buffer_pdata *pdata)
 }
 
 int network_enable_buffer(struct iio_buffer_pdata *pdata,
-			  size_t block_size, bool enable)
+			  size_t block_size, bool enable, bool cyclic)
 {
-	return iiod_client_enable_buffer(pdata->pdata, block_size, enable);
+	return iiod_client_enable_buffer(pdata->pdata, block_size, enable, cyclic);
 }
 
 struct iio_block_pdata * network_create_block(struct iio_buffer_pdata *pdata,

--- a/serial.c
+++ b/serial.c
@@ -257,9 +257,9 @@ static void serial_free_buffer(struct iio_buffer_pdata *buf)
 }
 
 static int serial_enable_buffer(struct iio_buffer_pdata *buf,
-				size_t nb_samples, bool enable)
+				size_t nb_samples, bool enable, bool cyclic)
 {
-	return iiod_client_enable_buffer(buf->pdata, nb_samples, enable);
+	return iiod_client_enable_buffer(buf->pdata, nb_samples, enable, cyclic);
 }
 
 static ssize_t

--- a/usb.c
+++ b/usb.c
@@ -490,9 +490,9 @@ static void usb_free_buffer(struct iio_buffer_pdata *buf)
 }
 
 static int usb_enable_buffer(struct iio_buffer_pdata *pdata,
-			     size_t nb_samples, bool enable)
+			     size_t nb_samples, bool enable, bool cyclic)
 {
-	return iiod_client_enable_buffer(pdata->pdata, nb_samples, enable);
+	return iiod_client_enable_buffer(pdata->pdata, nb_samples, enable, cyclic);
 }
 
 static struct iio_block_pdata *

--- a/utils/iio_common.c
+++ b/utils/iio_common.c
@@ -444,7 +444,7 @@ uint64_t get_time_us(void)
 #ifdef _MSC_BUILD
 	timespec_get(&tp, TIME_UTC);
 #else
-	clock_gettime(CLOCK_REALTIME, &tp);
+	clock_gettime(CLOCK_MONOTONIC, &tp);
 #endif
 
 	return tp.tv_sec * 1000000ull + tp.tv_nsec / 1000;


### PR DESCRIPTION
Some misc. fixes, alongside a rework of the interface to v0.x IIOD, which did not support cyclic buffers properly.

Fixes #1097.