### PR TITLE
[v0] xml: Fix compatibility with libxml 2.12

### DIFF
--- a/xml.c
+++ b/xml.c
@@ -10,6 +10,7 @@
 #include "iio-private.h"
 
 #include <errno.h>
+#include <libxml/parser.h>
 #include <libxml/tree.h>
 #include <string.h>
 


### PR DESCRIPTION
libxml 2.12.0 reorganized includes, resulting in the following no longer being in scope:

- XML_PARSE_DTDVALID
- xmlReadMemory
- xmlReadFile
- xmlCleanupParser

Signed-off-by: Jan Tojnar <jtojnar@gmail.com>
(cherry picked from commit bb688d04294dda45e68dfaf13e3bc1187841e52a)
