### PR TITLE
examples/*-iiostream: Fix [rx|tx]_sample_sz initialization

### DIFF
--- a/examples/ad9361-iiostream.c
+++ b/examples/ad9361-iiostream.c
@@ -296,8 +296,8 @@ int main (int argc, char **argv)
 		shutdown();
 	}
 
-	tx_sample_sz = iio_device_get_sample_size(tx, rxmask);
-	rx_sample_sz = iio_device_get_sample_size(rx, txmask);
+	rx_sample_sz = iio_device_get_sample_size(rx, rxmask);
+	tx_sample_sz = iio_device_get_sample_size(tx, txmask);
 
 	printf("* Starting IO streaming (press CTRL+C to cancel)\n");
 	stream(rx_sample_sz, tx_sample_sz, BLOCK_SIZE,

--- a/examples/ad9371-iiostream.c
+++ b/examples/ad9371-iiostream.c
@@ -292,8 +292,8 @@ int main (__notused int argc, __notused char **argv)
 		shutdown();
 	}
 
-	tx_sample_sz = iio_device_get_sample_size(tx, rxmask);
-	rx_sample_sz = iio_device_get_sample_size(rx, txmask);
+	rx_sample_sz = iio_device_get_sample_size(rx, rxmask);
+	tx_sample_sz = iio_device_get_sample_size(tx, txmask);
 
 	printf("* Starting IO streaming (press CTRL+C to cancel)\n");
 	stream(rx_sample_sz, tx_sample_sz, BLOCK_SIZE,

--- a/examples/adrv9002-iiostream.c
+++ b/examples/adrv9002-iiostream.c
@@ -289,8 +289,8 @@ int main(void)
 		goto clean;
 	}
 
-	tx_sample_sz = iio_device_get_sample_size(tx, rxmask);
-	rx_sample_sz = iio_device_get_sample_size(rx, txmask);
+	rx_sample_sz = iio_device_get_sample_size(rx, rxmask);
+	tx_sample_sz = iio_device_get_sample_size(tx, txmask);
 
 	info("* Starting IO streaming (press CTRL+C to cancel)\n");
 	stream(rx_sample_sz, tx_sample_sz, BLOCK_SIZE, rxstream, txstream,

--- a/examples/adrv9009-iiostream.c
+++ b/examples/adrv9009-iiostream.c
@@ -278,8 +278,8 @@ int main (__notused int argc, __notused char **argv)
 		shutdown();
 	}
 
-	tx_sample_sz = iio_device_get_sample_size(tx, rxmask);
-	rx_sample_sz = iio_device_get_sample_size(rx, txmask);
+	rx_sample_sz = iio_device_get_sample_size(rx, rxmask);
+	tx_sample_sz = iio_device_get_sample_size(tx, txmask);
 
 	printf("* Starting IO streaming (press CTRL+C to cancel)\n");
 


### PR DESCRIPTION
This fixes a few typos introduced with the update to the new API

Fixes: 99688f2dcc19 ("examples: Update to the new API")