### PR TITLE
iio.py: fix Trigger instantiation

### DIFF
--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -1346,7 +1346,7 @@ class Device(_DeviceOrTrigger):
     def _get_trigger(self):
         value = _DevicePtr()
         _d_get_trigger(self._device, _byref(value))
-        trig = Trigger(value.contents)
+        trig = Trigger(self.ctx, value.contents)
 
         for dev in self.ctx.devices:
             if trig.id == dev.id:


### PR DESCRIPTION
Trigger() is being passed device contents, but no context, and therefore fails like so:

|>>> adc._ctrl.trigger
|Traceback (most recent call last):
|  File "<stdin>", line 1, in <module>
|  File "/home/baylibre/git/pyadi-iio/venv/lib/python3.10/site-packages/iio.py", line 1281, in _get_trigger
|    trig = Trigger(value.contents)
|TypeError: Trigger.__init__() missing 1 required positional argument: '_device'

Pass self.ctx as the first argument so that the trigger is properly instantiated.

Fixes #1107.