### PR TITLE
local: Avoid keeping buffer FD opened at all times

### DIFF
--- a/local.h
+++ b/local.h
@@ -22,7 +22,6 @@ struct iio_buffer_pdata {
 	struct iio_buffer_impl_pdata *pdata;
 	int fd, cancel_fd;
 	unsigned int idx;
-	bool multi_buffer;
 	bool dmabuf_supported;
 	bool mmap_supported;
 	size_t size;


### PR DESCRIPTION
The problem of leaving it opened at all times is that other instances of Libiio cannot be ran in parallel.

Fixes #1111.