### PR TITLE
iio.h: Add IIO_MOD_LIGHT_UVA/UVB modifiers

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -119,6 +119,8 @@ static const char * const modifier_names[] = {
 	[IIO_MOD_PITCH] = "pitch",
 	[IIO_MOD_YAW] = "yaw",
 	[IIO_MOD_ROLL] = "roll",
+	[IIO_MOD_LIGHT_UVA] = "uva",
+	[IIO_MOD_LIGHT_UVB] = "uvb",
 };
 
 /*

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -272,6 +272,8 @@ enum iio_modifier {
 	IIO_MOD_PITCH,
 	IIO_MOD_YAW,
 	IIO_MOD_ROLL,
+	IIO_MOD_LIGHT_UVA,
+	IIO_MOD_LIGHT_UVB,
 };
 
 /**


### PR DESCRIPTION
Add the IIO_MOD_LIGHT_UVA and IIO_MOD_LIGHT_UVB modifiers that will be introduced in Linux v6.8.

Note that Linux v6.8-rc1 added those entries in the middle of the iio_modifier enum (which is wrong as it breaks ABI), but it will be fixed for the regular v6.8 release.

Fixes #1130.