### PR TITLE
Rework iio_context_get_xml()

### DIFF
--- a/bindings/cpp/iiopp.h
+++ b/bindings/cpp/iiopp.h
@@ -81,6 +81,7 @@ class cstr
 public:
     cstr(std::string const & s) : s(s.c_str()){}
     cstr(char const * s) : s(s){assert(s);}
+    cstr(void const * s) : s(static_cast<char const *>(s)){assert(s);}
 
     char const * c_str() const {return s;}
     operator char const * () const {return s;}
@@ -580,6 +581,8 @@ public:
     uint32_t reg_read(uint32_t address) {uint32_t value; impl::check(iio_device_reg_read(p, address, &value), "iio_device_reg_read"); return value;}
 };
 
+typedef Ptr<cstr, void, free> CstrPtr;
+
 /** @brief C++ wrapper for the @ref Context C-API
  */
 class Context : public impl::IndexedSequence<Context, Device>
@@ -617,7 +620,7 @@ public:
     unsigned int version_major() const { return iio_context_get_version_major(p); }
     unsigned int version_minor() const { return iio_context_get_version_minor(p); }
     cstr version_tag() const { return iio_context_get_version_tag(p); }
-    cstr xml() const { return iio_context_get_xml(p); }
+    CstrPtr xml() const { return CstrPtr{impl::check(iio_context_get_xml(p), "iio_context_get_xml")};}
     cstr name() const { return iio_context_get_name(p); }
     cstr description() const { return iio_context_get_description(p); }
     unsigned int attrs_count() const {return iio_context_get_attrs_count(p);}

--- a/context.c
+++ b/context.c
@@ -181,7 +181,7 @@ static ssize_t iio_snprintf_context_xml(char *ptr, ssize_t len,
 }
 
 /* Returns a string containing the XML representation of this context */
-static char * iio_context_create_xml(const struct iio_context *ctx)
+char * iio_context_get_xml(const struct iio_context *ctx)
 {
 	ssize_t len;
 	char *str;
@@ -251,11 +251,6 @@ void iio_context_set_pdata(struct iio_context *ctx, struct iio_context_pdata *d)
 	ctx->pdata = d;
 }
 
-const char * iio_context_get_xml(const struct iio_context *ctx)
-{
-	return ctx->xml;
-}
-
 const char * iio_context_get_name(const struct iio_context *ctx)
 {
 	return ctx->name;
@@ -284,7 +279,6 @@ void iio_context_destroy(struct iio_context *ctx)
 	for (i = 0; i < ctx->nb_devices; i++)
 		free_device(ctx->devices[i]);
 	free(ctx->devices);
-	free(ctx->xml);
 	free(ctx->description);
 	free(ctx->git_tag);
 	free(ctx->pdata);
@@ -340,12 +334,7 @@ int iio_context_init(struct iio_context *ctx)
 	for (i = 0; i < ctx->nb_devices; i++)
 		reorder_channels(ctx->devices[i]);
 
-	if (ctx->xml)
-		return 0;
-
-	ctx->xml = iio_context_create_xml(ctx);
-
-	return iio_err(ctx->xml);
+	return 0;
 }
 
 unsigned int iio_context_get_version_major(const struct iio_context *ctx)

--- a/iio-private.h
+++ b/iio-private.h
@@ -92,8 +92,6 @@ struct iio_context {
 	struct iio_device **devices;
 	unsigned int nb_devices;
 
-	char *xml;
-
 	char **values;
 	struct iio_attr_list attrlist;
 

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -601,8 +601,9 @@ __api __pure const char * iio_context_get_version_tag(const struct iio_context *
 
 /** @brief Obtain a XML representation of the given context
  * @param ctx A pointer to an iio_context structure
- * @return A pointer to a static NULL-terminated string */
-__api __check_ret __pure const char * iio_context_get_xml(const struct iio_context *ctx);
+ * @return On success, an allocated string. Must be deallocated with free().
+ * @return On failure, a pointer-encoded error is returned */
+__api __check_ret char * iio_context_get_xml(const struct iio_context *ctx);
 
 
 /** @brief Get the name of the given context

--- a/utils/iio_genxml.c
+++ b/utils/iio_genxml.c
@@ -31,8 +31,7 @@ static const char *options_descriptions[] = {
 
 int main(int argc, char **argv)
 {
-	char **argw, *uri;
-	const char *xml;
+	char **argw, *uri, *xml;
 	struct iio_context *ctx;
 	struct option *opts;
 	size_t buf_len;
@@ -84,12 +83,14 @@ int main(int argc, char **argv)
 	uri = malloc(buf_len);
 	if (!uri) {
 		iio_context_destroy(ctx);
+		free(xml);
 		return EXIT_FAILURE;
 	}
 
 	snprintf(uri, buf_len, "xml:%s", xml);
 
 	iio_context_destroy(ctx);
+	free(xml);
 
 	ctx = iio_create_context(NULL, uri);
 	if (!ctx) {


### PR DESCRIPTION
Instead of returning a string allocated alongside the IIO context, it
will now return a string allocated on the heap, that has to be freed
with free() afterwards. The function can now also return errors.

The advantage of this change is multiple:
- IIO contexts now don't have a huge XML string allocated during their
  whole lifetime;
- If the application does not call iio_context_get_xml(), then all the
  internal functions used to generate the XML string in the first place
  are dead code, and when building statically, can be garbage-collected.

C# bindings will be updated by @AlexandraTrifan  in #1122.