### PR TITLE
USB context fixes

### DIFF
--- a/iiod-client.c
+++ b/iiod-client.c
@@ -48,6 +48,7 @@ static int iiod_client_enable_binary(struct iiod_client *client);
 
 struct iiod_client_buffer_pdata {
 	struct iiod_client *client;
+	struct iiod_client *client_fb;
 	struct iiod_client_io *io;
 
 	struct iio_channels_mask *mask;
@@ -1419,6 +1420,7 @@ ssize_t iiod_client_writebuf(struct iiod_client_buffer_pdata *pdata,
 
 struct iiod_client_buffer_pdata *
 iiod_client_create_buffer(struct iiod_client *client,
+			  struct iiod_client *client_fb,
 			  const struct iio_device *dev, unsigned int idx,
 			  struct iio_channels_mask *mask)
 {
@@ -1435,6 +1437,7 @@ iiod_client_create_buffer(struct iiod_client *client,
 	pdata->dev = dev;
 	pdata->idx = (uint16_t) idx;
 	pdata->client = client;
+	pdata->client_fb = client_fb;
 	pdata->mask = mask;
 
 	if (iiod_client_uses_binary_interface(client)) {
@@ -1462,7 +1465,7 @@ err_free_pdata:
 
 void iiod_client_free_buffer(struct iiod_client_buffer_pdata *pdata)
 {
-	struct iiod_client *client = pdata->client;
+	struct iiod_client *client = pdata->client_fb;
 	struct iiod_io *io;
 	struct iiod_command cmd;
 
@@ -1586,7 +1589,7 @@ err_free_block:
 
 void iiod_client_free_block(struct iio_block_pdata *block)
 {
-	struct iiod_client *client = block->buffer->client;
+	struct iiod_client *client = block->buffer->client_fb;
 	struct iiod_io *io;
 	struct iiod_client_buffer_pdata *pdata = block->buffer;
 	struct iiod_command cmd;

--- a/iiod-responder.c
+++ b/iiod-responder.c
@@ -482,7 +482,10 @@ int32_t iiod_io_wait_for_response(struct iiod_io *io)
 	while (!io->r_done) {
 		ret = iiod_io_cond_wait(io);
 		if (ret) {
+			iio_mutex_lock(priv->lock);
 			__iiod_io_cancel_unlocked(io);
+			iio_mutex_unlock(priv->lock);
+
 			io->r_io.cmd.code = ret;
 			io->r_done = true;
 			break;

--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -59,7 +59,7 @@ struct block_entry {
 	struct iio_block *block;
 	struct iiod_io *io;
 	uint64_t bytes_used;
-	uint16_t client_id;
+	uint16_t idx;
 	bool cyclic;
 };
 

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -47,6 +47,8 @@ static void free_buffer_entry(struct buffer_entry *entry)
 {
 	struct block_entry *block_entry, *block_next;
 
+	iio_buffer_cancel(entry->buf);
+
 	if (!NO_THREADS) {
 		iio_task_stop(entry->dequeue_task);
 		iio_task_stop(entry->enqueue_task);

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -510,7 +510,7 @@ static struct iio_block * get_iio_block(struct parser_pdata *pdata,
 	iio_mutex_lock(entry_buf->lock);
 
 	SLIST_FOREACH(entry, &entry_buf->blocklist, entry) {
-		if (entry->client_id == cmd->client_id) {
+		if (entry->idx == cmd->code >> 16) {
 			block = entry->block;
 			break;
 		}
@@ -670,7 +670,7 @@ static void handle_create_block(struct parser_pdata *pdata,
 
 	entry->block = block;
 	entry->io = io;
-	entry->client_id = cmd->client_id;
+	entry->idx = cmd->code >> 16;
 
 	/* Keep a reference to the iiod_io until the block is freed. */
 	iiod_io_ref(io);

--- a/include/iio/iiod-client.h
+++ b/include/iio/iiod-client.h
@@ -69,6 +69,7 @@ iiod_client_create_context(struct iiod_client *client,
 
 __api struct iiod_client_buffer_pdata *
 iiod_client_create_buffer(struct iiod_client *client,
+			  struct iiod_client *client_fb,
 			  const struct iio_device *dev, unsigned int idx,
 			  struct iio_channels_mask *mask);
 __api void iiod_client_free_buffer(struct iiod_client_buffer_pdata *pdata);

--- a/network.c
+++ b/network.c
@@ -459,8 +459,9 @@ network_create_buffer(const struct iio_device *dev, unsigned int idx,
 		goto err_free_buf;
 	}
 
-	buf->pdata = iiod_client_create_buffer(buf->iiod_client, dev,
-					       idx, mask);
+	buf->pdata = iiod_client_create_buffer(buf->iiod_client,
+					       pdata->iiod_client,
+					       dev, idx, mask);
 	ret = iio_err(buf->pdata);
 	if (ret) {
 		dev_perror(dev, ret, "Unable to create buffer");

--- a/serial.c
+++ b/serial.c
@@ -239,6 +239,7 @@ serial_create_buffer(const struct iio_device *dev, unsigned int idx,
 		return iio_ptr(-ENOMEM);
 
 	buf->pdata = iiod_client_create_buffer(pdata->iiod_client,
+					       pdata->iiod_client,
 					       dev, idx, mask);
 	ret = iio_err(buf->pdata);
 	if (ret) {

--- a/usb.c
+++ b/usb.c
@@ -445,6 +445,7 @@ usb_create_buffer(const struct iio_device *dev, unsigned int idx,
 	}
 
 	buf->pdata = iiod_client_create_buffer(buf->io_ctx.iiod_client,
+					       ctx_pdata->io_ctx.iiod_client,
 					       dev, idx, mask);
 	ret = iio_err(buf->pdata);
 	if (ret) {


### PR DESCRIPTION
Rework how the blocks and buffers are identified and destroyed when using the USB backend; previously, nothing would be freed.