### PR TITLE
Better backend API

### DIFF
--- a/attr.c
+++ b/attr.c
@@ -7,6 +7,7 @@
  */
 
 #include "iio-private.h"
+#include "sort.h"
 
 #include <inttypes.h>
 #include <errno.h>
@@ -213,6 +214,8 @@ int iio_add_attr(union iio_pointer p, struct iio_attr_list *attrs,
 	}
 
 	attrs->num++;
+
+	iio_sort_attrs(attrs);
 
 	return 0;
 }

--- a/attr.h
+++ b/attr.h
@@ -27,11 +27,4 @@ int iio_add_attr(union iio_pointer p, struct iio_attr_list *attrs,
 		 const char *name, const char *filename,
 		 enum iio_attr_type type);
 
-int iio_context_add_attr(struct iio_context *ctx,
-			 const char *key, const char *value);
-int iio_device_add_attr(struct iio_device *dev,
-			const char *name, enum iio_attr_type type);
-int iio_channel_add_attr(struct iio_channel *chn,
-			 const char *name, const char *filename);
-
 #endif /* __IIO_ATTR_H__ */

--- a/context.c
+++ b/context.c
@@ -511,7 +511,7 @@ iio_context_find_attr(const struct iio_context *ctx, const char *name)
 	return iio_attr_find(&ctx->attrlist, name);
 }
 
-int iio_context_add_device(struct iio_context *ctx, struct iio_device *dev)
+int _iio_context_add_device(struct iio_context *ctx, struct iio_device *dev)
 {
 	struct iio_device **devices = realloc(ctx->devices,
 			(ctx->nb_devices + 1) * sizeof(struct iio_device *));

--- a/context.c
+++ b/context.c
@@ -582,24 +582,6 @@ err_free_dev:
 	return NULL;
 }
 
-int _iio_context_add_device(struct iio_context *ctx, struct iio_device *dev)
-{
-	struct iio_device **devices = realloc(ctx->devices,
-			(ctx->nb_devices + 1) * sizeof(struct iio_device *));
-
-	if (!devices) {
-		ctx_err(ctx, "Unable to allocate memory\n");
-		return -ENOMEM;
-	}
-
-	devices[ctx->nb_devices++] = dev;
-	ctx->devices = devices;
-
-	ctx_dbg(ctx, "Added device \'%s\' to context \'%s\'\n",
-		dev->id, ctx->name);
-	return 0;
-}
-
 struct iio_context *
 iio_create_context_from_xml(const struct iio_context_params *params,
 			    const char *uri, const struct iio_backend *backend,

--- a/iio-private.h
+++ b/iio-private.h
@@ -225,8 +225,6 @@ char *iio_strtok_r(char *str, const char *delim, char **saveptr);
 char * iio_getenv (char * envvar);
 uint64_t iio_read_counter_us(void);
 
-int _iio_context_add_device(struct iio_context *ctx, struct iio_device *dev);
-
 __cnst const struct iio_context_params *get_default_params(void);
 
 extern const struct iio_backend iio_ip_backend;

--- a/iio-private.h
+++ b/iio-private.h
@@ -225,7 +225,7 @@ char *iio_strtok_r(char *str, const char *delim, char **saveptr);
 char * iio_getenv (char * envvar);
 uint64_t iio_read_counter_us(void);
 
-int iio_context_add_device(struct iio_context *ctx, struct iio_device *dev);
+int _iio_context_add_device(struct iio_context *ctx, struct iio_device *dev);
 
 __cnst const struct iio_context_params *get_default_params(void);
 

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -155,9 +155,11 @@ struct iio_backend {
  */
 extern const struct iio_backend iio_external_backend;
 
-struct iio_context * iio_context_create_from_backend(
-		const struct iio_backend *backend,
-		const char *description);
+__api struct iio_context *
+iio_context_create_from_backend(const struct iio_context_params *params,
+				const struct iio_backend *backend,
+				const char *description, unsigned int minor,
+				unsigned int major, const char *git_tag);
 
 __api struct iio_device *
 iio_context_add_device(struct iio_context *ctx,

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -168,6 +168,16 @@ iio_device_add_channel(struct iio_device *dev, long index,
 		       const char *id, const char *name, bool output,
 		       bool scan_element, const struct iio_data_format *fmt);
 
+__api int
+iio_context_add_attr(struct iio_context *ctx,
+		     const char *key, const char *value);
+__api int
+iio_device_add_attr(struct iio_device *dev,
+		    const char *name, enum iio_attr_type type);
+__api int
+iio_channel_add_attr(struct iio_channel *chn,
+		     const char *name, const char *filename);
+
 __api struct iio_context_pdata *
 iio_context_get_pdata(const struct iio_context *ctx);
 

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -159,6 +159,10 @@ struct iio_context * iio_context_create_from_backend(
 		const struct iio_backend *backend,
 		const char *description);
 
+__api struct iio_device *
+iio_context_add_device(struct iio_context *ctx,
+		       const char *id, const char *name, const char *label);
+
 __api struct iio_context_pdata *
 iio_context_get_pdata(const struct iio_context *ctx);
 

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -163,6 +163,11 @@ __api struct iio_device *
 iio_context_add_device(struct iio_context *ctx,
 		       const char *id, const char *name, const char *label);
 
+__api struct iio_channel *
+iio_device_add_channel(struct iio_device *dev, long index,
+		       const char *id, const char *name, bool output,
+		       bool scan_element, const struct iio_data_format *fmt);
+
 __api struct iio_context_pdata *
 iio_context_get_pdata(const struct iio_context *ctx);
 

--- a/local.c
+++ b/local.c
@@ -1838,7 +1838,8 @@ local_create_context(const struct iio_context_params *params, const char *args)
 	if (!description)
 		return iio_ptr(-ENOMEM);
 
-	ctx = iio_context_create_from_backend(&iio_local_backend, description);
+	ctx = iio_context_create_from_backend(params, &iio_local_backend,
+					      description, 0, 0, NULL);
 	free(description);
 	ret = iio_err(ctx);
 	if (ret)
@@ -1854,8 +1855,6 @@ local_create_context(const struct iio_context_params *params, const char *args)
 	ret = iio_err(ctx->pdata->lock);
 	if (ret < 0)
 		goto err_context_destroy;
-
-	ctx->params = *params;
 
 	ret = foreach_in_dir(ctx, ctx, "/sys/bus/iio/devices",
 			     true, create_device);

--- a/local.c
+++ b/local.c
@@ -1318,7 +1318,7 @@ static int create_device(void *d, const char *path)
 
 	iio_sort_attrs(&dev->attrlist[IIO_ATTR_TYPE_DEVICE]);
 
-	ret = iio_context_add_device(ctx, dev);
+	ret = _iio_context_add_device(ctx, dev);
 	if (!ret)
 		return 0;
 

--- a/serial.c
+++ b/serial.c
@@ -243,7 +243,7 @@ serial_create_buffer(const struct iio_device *dev, unsigned int idx,
 					       dev, idx, mask);
 	ret = iio_err(buf->pdata);
 	if (ret) {
-		dev_perror(dev, ret, "Unable to create IIOD client");
+		dev_perror(dev, ret, "Unable to create buffer");
 		free(buf);
 		return iio_ptr(ret);
 	}

--- a/xml.c
+++ b/xml.c
@@ -405,24 +405,13 @@ iio_create_xml_context_helper(const struct iio_context_params *params,
 		}
 	}
 
-	ctx = iio_context_create_from_backend(&iio_xml_backend, description);
+	ctx = iio_context_create_from_backend(params, &iio_xml_backend,
+					      description,
+					      major, minor, git_tag);
 	err = iio_err(ctx);
 	if (err) {
 		prm_err(params, "Unable to allocate memory for context\n");
 		return iio_ptr(err);
-	}
-
-	ctx->params = *params;
-
-	if (git_tag) {
-		ctx->major = major;
-		ctx->minor = minor;
-
-		ctx->git_tag = iio_strdup(git_tag);
-		if (!ctx->git_tag) {
-			iio_context_destroy(ctx);
-			return iio_ptr(-ENOMEM);
-		}
 	}
 
 	err = iio_populate_xml_context_helper(ctx, root);

--- a/xml.c
+++ b/xml.c
@@ -354,7 +354,7 @@ static int iio_populate_xml_context_helper(struct iio_context *ctx, xmlNode *roo
 			return err;
 		}
 
-		err = iio_context_add_device(ctx, dev);
+		err = _iio_context_add_device(ctx, dev);
 		if (err) {
 			free(dev);
 			return err;


### PR DESCRIPTION
Modify/add functions:
- `iio_context_add_device`, which will create a `iio_device` and add it to the context;
- `iio_device_add_channel`, which will create a `iio_channel` and add it to the device;
- The functions `iio_{context,device,channel}_add_attr` to add attributes to contexts/devices/channels are now backend API
- `iio_create_context_from_backend` now takes a few extra parameters that will be used to create the iio_context.

With these changes, the XML backend was updated to be fully implemented on top of the public API (be it iio.h or iio-backend.h) and does not use iio-private.h anymore.

In theory, the local backend could do that too but it's a lot more work (due to how it currently creates the context).

The code should be considered very experimental, it was not thoroughly tested.