### PR TITLE
iiod: Add default env var to service file

### DIFF
--- a/iiod/init/iiod.service.cmakein
+++ b/iiod/init/iiod.service.cmakein
@@ -2,7 +2,7 @@
 #
 # iiod - Systemd init script
 #
-# Copyright (C) 2016-2021 Analog Devices Inc.
+# Copyright (C) 2016-2024 Analog Devices Inc.
 
 [Unit]
 Description=IIO Daemon
@@ -12,6 +12,7 @@ ConditionPathExists=/sys/bus/iio
 Documentation=man:iiod(8)
 
 [Service]
+Environment=$IIOD_EXTRA_OPTS=''
 EnvironmentFile=-/etc/default/iiod
 ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/iiod $IIOD_EXTRA_OPTS
 KillMode=process


### PR DESCRIPTION
Systemd now gives a warning when IIOD_EXTRA_OPTS is unset.

This change sets it to an empty string by default while still allowing it be overridden by /etc/default/iiod.

Fixes #1142.