### PR TITLE
Increase attribute read buffer space

### DIFF
--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -759,7 +759,7 @@ class Attr(_IIO_Object):
         return self._name
 
     def _read(self):
-        buf = create_string_buffer(1024)
+        buf = create_string_buffer(4096)
         _a_read(self._attr, buf, len(buf))
         return buf.value.decode("ascii")
 


### PR DESCRIPTION


## PR Description

When reading an attribute a buffer of size 1024 bytes is used by the python bindings of libiio (iio.py:762). This is not enough space for large attributes, such as `gain_table_config` of an AD9361 ('ad9361-phy'), which is 1688 bytes. This PR increases the buffer size to 4096 bytes.

This is a bit of a brute-force solution. Ideally, iiod would be able to inform the caller of the required buffer space, or the caller could use an incrementally growing buffer. I think the simple solution of using a larger buffer is ok though.

## PR Type
- [x] Bug fix (a change that fixes an issue) - Fixes #1156
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
