### PR TITLE
iio_info.py example: pick uri automatically when there's only one

### DIFF
--- a/bindings/python/examples/iio_info.py
+++ b/bindings/python/examples/iio_info.py
@@ -31,7 +31,11 @@ def _create_context():
             print("Multiple contexts found. Please select one using --uri:")
             for uri, description in contexts.items():
                 print("\t%s: %s" % (uri, description))
-        sys.exit(0)
+            sys.exit(0)
+        if len(contexts) == 0:
+            print("No contexts found.")
+            sys.exit(0)
+        uri = list(contexts.keys())[0]
 
     return iio.Context(uri)
 
@@ -55,7 +59,7 @@ class Information:
 
     def _context_info(self):
         print("IIO context created: " + self.context.name)
-        print("Backend version: %u.%u (git tag: %s" % self.context.version)
+        print("Backend version: %u.%u (git tag: %s)" % self.context.version)
         print("Backend description string: " + self.context.description)
 
         if len(self.context.attrs) > 0:


### PR DESCRIPTION
## PR Description

I was testing v0.25's iio_info.py and saw it didn't do anything when no command-line arguments were given. If there are more than one available uri a message is shown before exiting the program (with `sys.exit(0)`). However, this line is also executed when there's only one or zero of them, and without printing any message previously. This causes confusion, at least in my opinion. I've seen that v1 didn't had any changes in that file, meaning that this issue still persists.

For reference, the "oficial" C-programmed iio_info (the one that comes built in the releases) selects the first uri if only one exists by default.

What I've done in this PR is to mimic what it's being done in the iio_info executable. I'm not sure if the examples should change in v1, but at least it should be useful for v0.25 (this PR is on the main branch, but I can move it to the v0.25 branch if you prefer). I've also fixed a typo some lines below.

It's my first PR ever to an open-source project, so don't hesitate on giving me constructive feedback, it's all a little new to me!

Tested on v0.25, with Python3.6 and Python2.7 on a Ubuntu 18.04.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
(due to the simplicity of the fix, and given the fact that it is one of the example codes I consider that some of the checks don't apply, I left them unchecked)
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
