### PR TITLE
serial.c: force DTR serial connection flag to ON for Windows clients

### DIFF
--- a/serial.c
+++ b/serial.c
@@ -335,6 +335,11 @@ static int apply_settings(struct sp_port *port, unsigned int baud_rate,
 {
 	int ret;
 
+#ifdef _WIN32
+	ret = libserialport_to_errno(sp_set_dtr(port, SP_DTR_ON));
+	if (ret)
+		return ret;
+#endif
 	ret = libserialport_to_errno(sp_set_baudrate(port, (int) baud_rate));
 	if (ret)
 		return ret;


### PR DESCRIPTION
## PR Description

On Linux and MacOS the serial connection handler has the DTR flag configured as ON by default. 
The Windows handler has it OFF by default, which prevents a successful serial connection because the driver expects it to be ON.
This issue can be reproduced using UART over USB. The first serial connection through libiio will block while initializing due to this flag. Using a different terminal emulator for the first connection will set the DTR flag to ON. Any subsequent libiio connection (prior to a reset) will be functional.

Serial connection opening is handled separately for Windows (can be checked in libserialport: https://github.com/sigrokproject/libserialport/blob/master/serialport.c#L488 and  https://github.com/sigrokproject/libserialport/blob/master/serialport.c#L549 ). 

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
