### PR TITLE
Cherry pick to 2022 r2

### DIFF
--- a/CI/publish_deps.ps1
+++ b/CI/publish_deps.ps1
@@ -19,11 +19,11 @@ if ($COMPILER -eq "MinGW Makefiles") {
 	cp $src_dir\dependencies\libs\64\libserialport-0.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 	cp $src_dir\dependencies\libs\64\libusb-1.0.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 	cp C:\ghcup\ghc\9.2.8\mingw\bin\libgcc_s_seh-1.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
-	cp C:\ghcup\ghc\9.6.4\mingw\bin\libiconv-2.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
-	cp C:\ghcup\ghc\9.6.4\mingw\bin\zlib1.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
-	cp C:\ghcup\ghc\9.6.4\mingw\bin\liblzma-5.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
-	cp C:\ghcup\ghc\9.6.4\mingw\bin\libwinpthread-1.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
-	cp C:\ghcup\ghc\9.6.4\mingw\bin\libxml2-2.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+	cp C:\ghcup\ghc\9.6.5\mingw\bin\libiconv-2.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+	cp C:\ghcup\ghc\9.6.5\mingw\bin\zlib1.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+	cp C:\ghcup\ghc\9.6.5\mingw\bin\liblzma-5.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+	cp C:\ghcup\ghc\9.6.5\mingw\bin\libwinpthread-1.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+	cp C:\ghcup\ghc\9.6.5\mingw\bin\libxml2-2.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 	cp C:\ghcup\ghc\9.2.8\mingw\bin\libstdc++-6.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 } else {
 	cp $src_dir\dependencies\libs\64\libxml2.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY

--- a/serial.c
+++ b/serial.c
@@ -375,6 +375,11 @@ static int apply_settings(struct sp_port *port, unsigned int baud_rate,
 {
 	int ret;
 
+#ifdef _WIN32
+	ret = libserialport_to_errno(sp_set_dtr(port, SP_DTR_ON));
+	if (ret)
+		return ret;
+#endif
 	ret = libserialport_to_errno(sp_set_baudrate(port, (int) baud_rate));
 	if (ret)
 		return ret;


### PR DESCRIPTION
## PR Description

Cherry-pick commits from libiio-v0 to 2022_r2 in order for CIs to pass.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
