### PR TITLE
Fix Windows Builds

### DIFF
--- a/CI/build_win.ps1
+++ b/CI/build_win.ps1
@@ -10,8 +10,11 @@ echo "Running cmake for $COMPILER on 64 bit..."
 mkdir build-x64
 cp .\libiio.iss.cmakein .\build-x64
 cd build-x64
-
-cmake -G "$COMPILER" -DPYTHON_EXECUTABLE:FILEPATH=$(python -c "import os, sys; print(os.path.dirname(sys.executable) + '\python.exe')") -DCMAKE_SYSTEM_PREFIX_PATH="C:" -Werror=dev -DCOMPILE_WARNING_AS_ERROR=ON -DENABLE_IPV6=ON -DWITH_USB_BACKEND=ON -DWITH_SERIAL_BACKEND=ON -DPYTHON_BINDINGS=ON -DCPP_BINDINGS=ON -DCSHARP_BINDINGS:BOOL=$USE_CSHARP -DLIBXML2_LIBRARIES="C:\\libs\\64\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\64\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\64\\libserialport.dll.a" -DLIBUSB_INCLUDE_DIR="C:\\include\\libusb-1.0" -DLIBXML2_INCLUDE_DIR="C:\\include\\libxml2" -DLIBZSTD_INCLUDE_DIR="C:\\include" -DLIBZSTD_LIBRARIES="C:\\libs\\64\\libzstd.dll.a" ..
+if ($COMPILER -eq "MinGW Makefiles") {
+	cmake -G "$COMPILER" -DPYTHON_EXECUTABLE:FILEPATH=$(python -c "import os, sys; print(os.path.dirname(sys.executable) + '\python.exe')") -DCMAKE_SYSTEM_PREFIX_PATH="C:" -Werror=dev -DCOMPILE_WARNING_AS_ERROR=ON -DENABLE_IPV6=ON -DWITH_USB_BACKEND=ON -DWITH_SERIAL_BACKEND=ON -DPYTHON_BINDINGS=ON -DCPP_BINDINGS=ON -DCSHARP_BINDINGS:BOOL=$USE_CSHARP -DLIBXML2_LIBRARIES="C:\\libs\\64\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libs\\64\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libs\\64\\libserialport.dll.a" -DLIBUSB_INCLUDE_DIR="C:\\include\\libusb-1.0" -DLIBXML2_INCLUDE_DIR="C:\\include\\libxml2" -DLIBZSTD_INCLUDE_DIR="C:\\include" -DLIBZSTD_LIBRARIES="C:\\libs\\64\\libzstd.dll.a" ..
+} else {
+	cmake -G "$COMPILER" -DPYTHON_EXECUTABLE:FILEPATH=$(python -c "import os, sys; print(os.path.dirname(sys.executable) + '\python.exe')") -DCMAKE_SYSTEM_PREFIX_PATH="C:" -Werror=dev -DCOMPILE_WARNING_AS_ERROR=ON -DENABLE_IPV6=ON -DWITH_USB_BACKEND=ON -DWITH_SERIAL_BACKEND=ON -DPYTHON_BINDINGS=ON -DCPP_BINDINGS=ON -DCSHARP_BINDINGS:BOOL=$USE_CSHARP -DLIBXML2_LIBRARIES="C:\\libiio-deps-240627\\msvc\\libs\\64\\libxml2.lib" -DLIBUSB_LIBRARIES="C:\\libiio-deps-240627\\msvc\\libs\\64\\libusb-1.0.lib" -DLIBSERIALPORT_LIBRARIES="C:\\libiio-deps-240627\\msvc\\libs\\64\\libserialport.lib" -DLIBUSB_INCLUDE_DIR="C:\\libiio-deps-240627\\msvc\\include\\libusb-1.0" -DLIBXML2_INCLUDE_DIR="C:\\libiio-deps-240627\\msvc\\include\\libxml2" -DLIBSERIALPORT_INCLUDE_DIR="C:\\libiio-deps-240627\\msvc\\include" -DLIBZSTD_INCLUDE_DIR="C:\\libiio-deps-240627\\msvc\\include" -DLIBZSTD_LIBRARIES="C:\\libiio-deps-240627\\msvc\\libs\\64\\libzstd.lib" ..
+}
 
 cmake --build . --config Release
 if ( $LASTEXITCODE -ne 0 ) {

--- a/CI/publish_deps.ps1
+++ b/CI/publish_deps.ps1
@@ -9,7 +9,10 @@ cd $src_dir
 mkdir dependencies
 cd dependencies
 wget http://swdownloads.analog.com/cse/build/libiio-deps-20220517.zip -OutFile "libiio-win-deps.zip"
+wget https://swdownloads.analog.com/cse/build/libiio-deps-20240627.zip -OutFile "libiio-msvc-deps.zip"
+
 7z x -y "libiio-win-deps.zip"
+7z x -y "libiio-msvc-deps.zip"
 
 # Version numbers inside this directory change all the time; print what's
 # currently in the folder to make it easier to debug CI breakages on MinGW.
@@ -27,10 +30,10 @@ if ($COMPILER -eq "MinGW Makefiles") {
 	cp C:\ghcup\ghc\9.6.5\mingw\bin\libxml2-2.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 	cp C:\ghcup\ghc\9.2.8\mingw\bin\libstdc++-6.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 } else {
-	cp $src_dir\dependencies\libs\64\libxml2.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
-	cp $src_dir\dependencies\libs\64\libserialport-0.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
-	cp $src_dir\dependencies\libs\64\libusb-1.0.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
-	cp $src_dir\dependencies\libs\64\libzstd.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+	cp $src_dir\dependencies\libiio-deps-240627\msvc\libs\64\libxml2.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+	cp $src_dir\dependencies\libiio-deps-240627\msvc\libs\64\libserialport.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+	cp $src_dir\dependencies\libiio-deps-240627\msvc\libs\64\libusb-1.0.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+	cp $src_dir\dependencies\libiio-deps-240627\msvc\libs\64\libzstd.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 
 	if ($COMPILER -eq "Visual Studio 16 2019") {
 		cd 'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Redist\MSVC\14.29.30133\x64\Microsoft.VC142.CRT'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -220,8 +220,8 @@ stages:
           7z x -y libxml.7z
           rm libxml.7z
           cd C:\
-          wget http://swdownloads.analog.com/cse/build/libiio-deps-20220517.zip -OutFile "libiio-win-deps.zip"
-          7z x -y "C:\libiio-win-deps.zip"
+          wget https://swdownloads.analog.com/cse/build/libiio-deps-20240627.zip -OutFile "libiio-win-msvc-deps.zip"
+          7z x -y "C:\libiio-win-msvc-deps.zip"
     - task: PowerShell@2
       inputs:
         targetType: 'filePath'

--- a/libiio.iss.cmakein
+++ b/libiio.iss.cmakein
@@ -45,7 +45,7 @@ Source: "D:\a\1\a\Windows-VS-2019-x64\libiio1.lib"; DestDir: "{commonpf32}\Micro
 Source: "D:\a\1\a\Windows-VS-2019-x64\iio\*.h"; DestDir: "{commonpf32}\Microsoft Visual Studio 12.0\VC\include\iio"
 Source: "D:\a\1\a\Windows-VS-2019-x64\libxml2.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Flags: onlyifdoesntexist
 Source: "D:\a\1\a\Windows-VS-2019-x64\libusb-1.0.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Flags: onlyifdoesntexist
-Source: "D:\a\1\a\Windows-VS-2019-x64\libserialport-0.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Flags: onlyifdoesntexist
+Source: "D:\a\1\a\Windows-VS-2019-x64\libserialport.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Flags: onlyifdoesntexist
 Source: "D:\a\1\a\Windows-VS-2019-x64\libzstd.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Flags: onlyifdoesntexist
 Source: "D:\a\1\a\Windows-VS-2019-x64\libiio-sharp.dll"; DestDir: "{commoncf}\libiio"; Flags: replacesameversion
 Source: "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Redist\MSVC\14.29.30133\x64\Microsoft.VC142.CRT\msvcp140.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Flags: onlyifdoesntexist


### PR DESCRIPTION
## PR Description

As things was before, for the windows deps an archive was downloaded from swdownloads. Said archive contains windows deps compiled with MinGW. The installer is created based on the MSVC builds. Both MSVC and MinGW builds were using deps from this archive compiled with MinGW. While the project seemed to be building okay, this caused problems which were visible in both installer and MSVC libiio zips at runtime. 
By adding a new archive with deps compiled with MSVC to be used when building libiio with MSVC, the issue is resolved. 
Moreover, a check for the compiler used was added in the windows build script. This ensures the correct paths to libiio's deps according to the compiler used. 
This fixes issue https://github.com/analogdevicesinc/libiio/issues/1174

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
