### PR TITLE
CI/azure/prepare_assets: remove macOS 11

### DIFF
--- a/CI/azure/prepare_assets.sh
+++ b/CI/azure/prepare_assets.sh
@@ -14,7 +14,7 @@ release_artifacts() {
                 rm -r "Linux-${i}"
         done
 
-	local pkg_assets='macOS-11 macOS-12 macOS-13-x64 macOS-13-arm64'
+	local pkg_assets='macOS-12 macOS-13-x64 macOS-13-arm64'
         cd "${BUILD_ARTIFACTSTAGINGDIRECTORY}"
         for i in $pkg_assets; do
                 cd "${i}"


### PR DESCRIPTION
## PR Description
We dropped support for macOS 11, but it was not removed from the script that prepares the artifacts for the release. This causes the script to fail. 

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
