### PR TITLE
iiod: ensure service starts with only hwmon devs

### DIFF
--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -103,6 +103,11 @@ endif()
 
 option(WITH_SYSTEMD "Enable installation of systemd service file for iiod" OFF)
 if (WITH_SYSTEMD)
+	if(${WITH_HWMON})
+		set(CMAKE_SERVICE_PATH "ConditionPathExists=|/sys/bus/iio\nConditionPathExists=|/sys/class/hwmon")
+	else()
+		set(CMAKE_SERVICE_PATH "ConditionPathExists=/sys/bus/iio")
+	endif()
 	set(SYSTEMD_UNIT_INSTALL_DIR /lib/systemd/system CACHE PATH
 		"default install path for systemd unit files"
 	)

--- a/iiod/init/iiod.service.cmakein
+++ b/iiod/init/iiod.service.cmakein
@@ -8,7 +8,7 @@
 Description=IIO Daemon
 Requires=systemd-udev-settle.service
 After=network.target systemd-udev-settle.service
-ConditionPathExists=/sys/bus/iio
+@CMAKE_SERVICE_PATH@
 Documentation=man:iiod(8)
 
 [Service]


### PR DESCRIPTION
## PR Description
Make sure iiod service looks in the path for hwmon devices too , fixes issue https://github.com/analogdevicesinc/libiio/issues/1194
## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
