### PR TITLE
Crashes while reading .osc_profile.ini for gcc 13.2.0.

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -863,7 +863,7 @@ int iio_channel_attr_write_all(struct iio_channel *chn,
 		}
 	}
 
-	ret = (int) iio_channel_attr_write_raw(chn, NULL, buf, ptr - buf);
+	ret = -ENOENT;//(int) iio_channel_attr_write_raw(chn, NULL, buf, ptr - buf);
 
 err_free_buf:
 	free(buf);


### PR DESCRIPTION
Because, when program gets to channel.c line 354 and tries to run strcmp(attr, name) whith the second argument "name" equal to NULL, strcmp crashes.

## PR Description

I tried to build libiio and iio-oscilloscope from source on Ubuntu 24.04.1 LTS. It has the following version of gcc:
gcc (Ubuntu 13.2.0-23ubuntu4) 13.2.0

I used the following commits:
libiio - v0.25, commit b6028fdeef888ab45f7c1dd6e4ed9480ae4b55e3
Author: Paul Cercueil <paul@crapouillou.net> 2023-08-09 17:19:32

iio-oscilloscope - v0.17-master, commit b7e5b37c1a2956548270d49a59260bb102899757
Author: Andrei Popa <andrei.popa@analog.com> 2023-05-26 11:58:26

When I run "osc" program for PlutoSDR and it starts to read the ini file attached,
[osc_profile.txt](https://github.com/user-attachments/files/17451869/osc_profile.txt)
it crashes. I think, that is because strcmp() does not allow parameters with NULL values.
