### PR TITLE
Fixed invalid IIOD_EXTRA_OPTS assignment

### DIFF
--- a/iiod/init/iiod.service.cmakein
+++ b/iiod/init/iiod.service.cmakein
@@ -12,7 +12,7 @@ After=network.target systemd-udev-settle.service
 Documentation=man:iiod(8)
 
 [Service]
-Environment=$IIOD_EXTRA_OPTS=''
+Environment=IIOD_EXTRA_OPTS=''
 EnvironmentFile=-/etc/default/iiod
 ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/iiod $IIOD_EXTRA_OPTS
 KillMode=process


### PR DESCRIPTION
## PR Description

Removing extraneous $ in the assignment of IIOD_EXTRA_OPTS in the service file that was part of https://github.com/analogdevicesinc/libiio/commit/a436ad602835dddaa297a7040abbd8f24a879af5

Fixes #1142.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
