### PR TITLE
iiod: Drop unnecesary include

### DIFF
--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -8,7 +8,6 @@
 
 #include "debug.h"
 #include "ops.h"
-#include "thread-pool.h"
 
 #include "../iiod-responder.h"
 


### PR DESCRIPTION
responder.c will switch to MIT, while thread-pool.h apparently stays LGPL; drop the unnecesary header include to avoid problems.

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
