### PR TITLE
Check the encoded error in the iio structures for utils and examples

### DIFF
--- a/examples/ad9361-iiostream.c
+++ b/examples/ad9361-iiostream.c
@@ -225,10 +225,14 @@ int main (int argc, char **argv)
 
 	printf("* Acquiring IIO context\n");
 	if (argc == 1) {
-		IIO_ENSURE((ctx = iio_create_context(NULL, NULL)) && "No context");
+		ctx = iio_create_context(NULL, NULL);
+		err = iio_err(ctx);
+		IIO_ENSURE(!err && "No context");
 	}
 	else if (argc == 2) {
-		IIO_ENSURE((ctx = iio_create_context(NULL, argv[1])) && "No context");
+		ctx = iio_create_context(NULL, argv[1]);
+		err = iio_err(ctx);
+		IIO_ENSURE(!err && "No context");
 	}
 	IIO_ENSURE(iio_context_get_devices_count(ctx) > 0 && "No devices");
 

--- a/examples/ad9371-iiostream.c
+++ b/examples/ad9371-iiostream.c
@@ -225,7 +225,10 @@ int main (__notused int argc, __notused char **argv)
 	txcfg.lo_hz = GHZ(2.5); // 2.5 GHz rf frequency
 
 	printf("* Acquiring IIO context\n");
-	IIO_ENSURE((ctx = iio_create_context(NULL, NULL)) && "No context");
+
+	ctx = iio_create_context(NULL, NULL);
+	err = iio_err(ctx);
+	IIO_ENSURE(!err && "No context");
 	IIO_ENSURE(iio_context_get_devices_count(ctx) > 0 && "No devices");
 
 	printf("* Acquiring AD9371 streaming devices\n");

--- a/examples/adrv9002-iiostream.c
+++ b/examples/adrv9002-iiostream.c
@@ -226,12 +226,14 @@ int main(void)
 	struct iio_device *rx;
 	size_t tx_sample_sz, rx_sample_sz;
 	int ret = EXIT_FAILURE;
+	int err;
 
 	if (register_signals() < 0)
 		return EXIT_FAILURE;
 
 	ctx = iio_create_context(NULL, NULL);
-	if (!ctx) {
+	err = iio_err(ctx);
+	if (ret) {
 		error("Could not create IIO context\n");
 		return EXIT_FAILURE;
 	}

--- a/examples/adrv9009-iiostream.c
+++ b/examples/adrv9009-iiostream.c
@@ -218,7 +218,9 @@ int main (__notused int argc, __notused char **argv)
 	trxcfg.lo_hz = GHZ(2.5);
 
 	printf("* Acquiring IIO context\n");
-	IIO_ENSURE((ctx = iio_create_context(NULL, NULL)) && "No context");
+	ctx = iio_create_context(NULL, NULL);
+	err = iio_err(ctx);
+	IIO_ENSURE(!err && "No context");
 	IIO_ENSURE(iio_context_get_devices_count(ctx) > 0 && "No devices");
 
 	printf("* Acquiring ADRV9009 streaming devices\n");

--- a/examples/dummy-iiostream.c
+++ b/examples/dummy-iiostream.c
@@ -239,7 +239,9 @@ int main (int argc, char **argv)
 	has_repeat = ((major * 10000) + minor) >= 8 ? true : false;
 
 	printf("* Acquiring IIO context\n");
-	IIO_ENSURE((ctx = iio_create_context(NULL, NULL)) && "No context");
+	ctx = iio_create_context(NULL, NULL);
+	err = iio_err(ctx);
+	IIO_ENSURE(!err && "No context");
 	IIO_ENSURE(iio_context_get_devices_count(ctx) > 0 && "No devices");
 
 	printf("* Acquiring device %s\n", name);

--- a/examples/iio-monitor.c
+++ b/examples/iio-monitor.c
@@ -251,7 +251,7 @@ static struct iio_context *show_contexts_screen(void)
 	int i;
 	bool free_uri;
 	char **items;
-	int ret;
+	int ret, err;
 
 	screen = initCDKScreen(win);
 	if (!screen) {
@@ -261,7 +261,8 @@ static struct iio_context *show_contexts_screen(void)
 
 	do {
 		scan_ctx = iio_scan(NULL, NULL);
-		if (!scan_ctx)
+		err = iio_err(scan_ctx);
+		if (err)
 			break;
 
 		num_contexts = iio_scan_get_results_count(scan_ctx);
@@ -311,7 +312,8 @@ static struct iio_context *show_contexts_screen(void)
 
 		if (uri) {
 			ctx = iio_create_context(NULL, uri);
-			if (ctx == NULL) {
+			err = iio_err(ctx);
+			if (err) {
 				char *msg[] = { "</16>Failed to create IIO context.<!16>" };
 				popupLabel(screen, (CDK_CSTRING2)msg, 1);
 			}
@@ -326,7 +328,7 @@ static struct iio_context *show_contexts_screen(void)
 			free(items[i]);
 		free(items);
 
-	} while (!ctx && ret >= 0);
+	} while (err && ret >= 0);
 
 	destroyCDKScreen(screen);
 

--- a/utils/gen_code.c
+++ b/utils/gen_code.c
@@ -161,7 +161,8 @@ void gen_context (const char *uri_in)
 
 	if (lang == C_LANG) {
 		fprintf(fd, "\t/* Create IIO Context */\n"
-		    "\tIIO_ASSERT(ctx = iio_create_context(NULL, \"%s\"));\n\n", uri);
+			"\tctx = iio_create_context(NULL, \"%s\");"
+		    "\tIIO_ASSERT(!iio_err(ctx));\n\n", uri);
 	} else if (lang == PYTHON_LANG) {
 		fprintf(fd, "    # Create IIO Context\n"
 			    "    try:\n"

--- a/utils/iio_genxml.c
+++ b/utils/iio_genxml.c
@@ -36,6 +36,7 @@ int main(int argc, char **argv)
 	struct option *opts;
 	size_t buf_len;
 	int c, ret = EXIT_FAILURE;
+	int err;
 
 	argw = dup_argv(MY_NAME, argc, argv);
 	ctx = handle_common_opts(MY_NAME, argc, argw, "",
@@ -77,6 +78,12 @@ int main(int argc, char **argv)
 		return ret;
 
 	xml = iio_context_get_xml(ctx);
+	err = iio_err(xml);
+	if (err) {
+		fprintf(stderr, "Unable to retrieve context xml representation!\n");
+		iio_context_destroy(ctx);
+		return EXIT_FAILURE;
+	}
 	printf("XML generated:\n\n%s\n\n", xml);
 
 	buf_len = strlen(xml) + 5;
@@ -93,7 +100,8 @@ int main(int argc, char **argv)
 	free(xml);
 
 	ctx = iio_create_context(NULL, uri);
-	if (!ctx) {
+	err = iio_err(ctx);
+	if (err) {
 		fprintf(stderr, "Unable to re-generate context\n");
 	} else {
 		printf("Context re-creation from generated XML succeeded!\n");


### PR DESCRIPTION
## PR Description

Replace old way of checking pointers returned by iio_create_context().
The pointers returned by iio_create_context() need to be checked with iio_err().

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [x] I have checked that I did not intoduced new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
