### PR TITLE
CI: Remove support for macos-12 as it's no longer hosted on azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -278,11 +278,6 @@ stages:
       clean: all
     strategy:
       matrix:
-        macOS_12:
-          poolName: 'Azure Pipelines'
-          vmImage: 'macOS-12'
-          agentName: 'Azure Pipelines 3'
-          artifactName: 'macOS-12'
         macOS_13_x64:
           poolName: 'Azure Pipelines'
           vmImage: 'macOS-13'


### PR DESCRIPTION
Remove CI jobs for macos-12 since the image has been deprecated by Azure DevOps.

Deprecation announcement at:
https://devblogs.microsoft.com/devops/upcoming-deprecation-of-macos-12-hosted-pipeline-image

"Azure DevOps is starting the deprecation process for the macOS-12.."
"..the image will be fully unsupported by January 8, 2025"

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
