### PR TITLE
dox: Fix minor spell error reported by CI

### DIFF
--- a/mainpage.dox
+++ b/mainpage.dox
@@ -228,7 +228,7 @@ The exception is when iio_channel_read() or iio_channel_write() are used, as the
 
 @subsection push Submitting the Buffer (output devices only)
 When all the samples have been written to the iio_buffer object, you can submit the buffer to the hardware with a call to iio_buffer_push().
-As soon as the buffer has been submitted, it can be re-used to store new samples.
+As soon as the buffer has been submitted, it can be reused to store new samples.
 
 If the iio_buffer object has been created with the "cyclic" parameter set, and the kernel driver supports cyclic buffers,
 the submitted buffer will be repeated until the iio_buffer is destroyed, and no subsequent call to iio_buffer_push() will be allowed.


### PR DESCRIPTION
Error message: "Error: ./mainpage.dox:231: re-used ==> reused"

## PR Description
Fix minor spelling error found by CI.


## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [x] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
