### PR TITLE
Wrong IIO device attribute (and a iio_rwdev fix)

### DIFF
--- a/local.c
+++ b/local.c
@@ -134,6 +134,7 @@ static void local_shutdown(struct iio_context *ctx)
 static void strcut(char *str, int nb)
 {
 	char *ptr = str + nb;
+
 	while (*ptr)
 		*str++ = *ptr++;
 	*str = 0;
@@ -634,8 +635,8 @@ static int local_set_trigger(const struct iio_device *dev,
 				  strlen(value) + 1, IIO_ATTR_TYPE_DEVICE);
 	if (nb < 0)
 		return (int) nb;
-	else
-		return 0;
+
+	return 0;
 }
 
 static bool is_channel(const struct iio_device *dev, const char *attr, bool strict)
@@ -996,6 +997,7 @@ static unsigned int is_global_attr(struct iio_channel *chn, const char *attr)
 		unsigned int len1 = dashptr - attr;
 		unsigned int len2 = ptr - dashptr - 1;
 		const char*  iddashptr = strchr(chn->id, '-');
+
 		if (iddashptr && strlen(iddashptr + 1) > len2 &&
 			(unsigned int)(iddashptr - chn->id) > len1 &&
 			chn->id[len1] >= '0' && chn->id[len1] <= '9' &&
@@ -1017,9 +1019,10 @@ static unsigned int is_global_attr(struct iio_channel *chn, const char *attr)
 				return 2;
 		}
 		return 1;
-	} else if (chn->id[len] != '_') {
-		return 0;
 	}
+
+	if (chn->id[len] != '_')
+		return 0;
 
 	if (find_channel_modifier(chn->id + len + 1, NULL) != IIO_NO_MOD)
 		return 1;
@@ -1035,6 +1038,7 @@ static int detect_global_attr(struct iio_device *dev, const char *attr,
 	*match = false;
 	for (i = 0; i < dev->nb_channels; i++) {
 		struct iio_channel *chn = dev->channels[i];
+
 		if (is_global_attr(chn, attr) == level) {
 			int ret;
 			*match = true;
@@ -1930,7 +1934,6 @@ static char * cat_file(const char *path)
 {
 	char buf[BUF_SIZE];
 	ssize_t ret;
-
 	FILE *f;
 
 	f = fopen(path, "re");
@@ -1939,10 +1942,10 @@ static char * cat_file(const char *path)
 
 	ret = fread(buf, 1, sizeof(buf)-1, f);
 	fclose(f);
-	if (ret > 0)
-		buf[ret - 1] = '\0';
-	else
+	if (ret <= 0)
 		return NULL;
+
+	buf[ret - 1] = '\0';
 
 	return strndup(buf, sizeof(buf) - 1);
 }

--- a/local.c
+++ b/local.c
@@ -71,6 +71,7 @@ struct iio_channel_pdata {
 static const char * const device_attrs_denylist[] = {
 	"dev",
 	"uevent",
+	"waiting_for_supplier",
 };
 
 static const char * const buffer_attrs_reserved[] = {

--- a/utils/iio_rwdev.c
+++ b/utils/iio_rwdev.c
@@ -459,8 +459,9 @@ int main(int argc, char **argv)
 
 		block = iio_stream_get_next_block(stream);
 		ret = iio_err(block);
-		if (ret && app_running) {
-			dev_perror(dev, ret, "Unable to get next block");
+		if (ret) {
+			if (app_running)
+				dev_perror(dev, ret, "Unable to get next block");
 			break;
 		}
 


### PR DESCRIPTION
## PR Description

Fix a device attribute being wrongly displayed and make sure iio_rwdev does not crash if we hit ctrl-c while streaming with a command as `iio_rwdev -u ip:192.168.1.79 -b 1048576 axi-adrv9002-rx-lpc | pv > /dev/null`

There's also a stylistic patch on local.c

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
