### PR TITLE
Add C++ compiler support for generic attr

### DIFF
--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -362,11 +362,13 @@ iio_attr_read_raw(const struct iio_attr *attr, char *dst, size_t len);
  * @param ptr A pointer to a variable where the value should be stored
  * @return On success, 0 is returned
  * @return On error, a negative errno code is returned */
+#ifndef __cplusplus
 #define iio_attr_read(attr, ptr)				\
 	_Generic((ptr),						\
 		 bool *: iio_attr_read_bool,			\
 		 long long *: iio_attr_read_longlong,		\
 		 double *: iio_attr_read_double)(attr, ptr)
+#endif /* __cplusplus */
 
 /** @brief Set the value of the given attribute
  * @param attr A pointer to an iio_attr structure
@@ -382,6 +384,7 @@ iio_attr_write_raw(const struct iio_attr *attr, const void *src, size_t len);
  * @param val The value to set the attribute to
  * @return On success, the number of bytes written
  * @return On error, a negative errno code is returned. */
+#ifndef __cplusplus
 #define iio_attr_write(attr, val)			\
 	_Generic((val),						\
 		 const char *: iio_attr_write_string,		\
@@ -389,6 +392,7 @@ iio_attr_write_raw(const struct iio_attr *attr, const void *src, size_t len);
 		 bool: iio_attr_write_bool,			\
 		 long long: iio_attr_write_longlong,		\
 		 double: iio_attr_write_double)(attr, val)
+#endif /* __cplusplus */
 
 /** @brief Retrieve the name of an attribute
  * @param attr A pointer to an iio_attr structure
@@ -1595,6 +1599,52 @@ iio_attr_write_longlong(const struct iio_attr *attr, long long val);
 
 __api __check_ret int
 iio_attr_write_double(const struct iio_attr *attr, double val);
+
+#ifdef __cplusplus 
+/* These functions are meant to simulate the generic macros
+ * iio_attr_{read,write}() in C++ compiled programs. */
+extern "C++" {
+static inline __check_ret int
+iio_attr_read(const struct iio_attr *attr, bool *val) {
+	return iio_attr_read_bool(attr, val);
+}
+
+static inline __check_ret int
+iio_attr_read(const struct iio_attr *attr, long long *val) {
+	return iio_attr_read_longlong(attr, val);
+}
+
+static inline __check_ret int
+iio_attr_read(const struct iio_attr *attr, double *val) {
+	return iio_attr_read_double(attr, val);
+}
+
+static inline __check_ret ssize_t
+iio_attr_write(const struct iio_attr *attr, const char *val) {
+	return iio_attr_write_string(attr, val);
+}
+
+static inline __check_ret ssize_t
+iio_attr_write(const struct iio_attr *attr, char *val) {
+	return iio_attr_write_string(attr, val);
+}
+
+static inline __check_ret int
+iio_attr_write(const struct iio_attr *attr, bool val) {
+	return iio_attr_write_bool(attr, val);
+}
+
+static inline __check_ret int
+iio_attr_write(const struct iio_attr *attr, long long val) {
+	return iio_attr_write_longlong(attr, val);
+}
+
+static inline __check_ret int
+iio_attr_write(const struct iio_attr *attr, double val) {
+	return iio_attr_write_double(attr, val);
+}
+}
+#endif /* __cplusplus */
 
 #endif /* DOXYGEN */
 


### PR DESCRIPTION
The C11 generic macros iio_attr_{read,write} cannot be accesed from a program built with C++. Instead C++ makes use of function overload to achieve the same behaviour.

This change does not influence the behaviour of libiio in C environments, but it allows the use of generic attr functions in C++ programs linked to libiio.

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
