### PR TITLE
Staging/iiod segfault

### DIFF
--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -45,6 +45,7 @@
 
 struct iio_mutex;
 struct iio_task;
+struct iio_task_token;
 struct iiod_io;
 struct pollfd;
 struct parser_pdata;
@@ -59,6 +60,8 @@ struct block_entry {
 	SLIST_ENTRY(block_entry) entry;
 	struct iio_block *block;
 	struct iiod_io *io;
+	struct iio_task_token *enqueue_token;
+	struct iio_task_token *dequeue_token;
 	uint64_t bytes_used;
 	uint16_t idx;
 	bool cyclic;

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -39,6 +39,8 @@ static void free_block_entry(struct block_entry *entry)
 	iiod_io_cancel(entry->io);
 	iiod_io_unref(entry->io);
 	iio_block_destroy(entry->block);
+	iio_task_token_destroy(entry->enqueue_token);
+	iio_task_token_destroy(entry->dequeue_token);
 	free(entry);
 }
 
@@ -299,7 +301,7 @@ static int buffer_enqueue_block(void *priv, void *d)
 	if (entry->cyclic)
 		goto out_send_response;
 
-	ret = iio_task_enqueue_autoclear(buffer->dequeue_task, entry);
+	ret = iio_task_token_enqueue(entry->dequeue_token);
 	if (ret)
 		goto out_send_response;
 
@@ -685,13 +687,22 @@ static void handle_create_block(struct parser_pdata *pdata,
 	entry = zalloc(sizeof(*entry));
 	if (!entry) {
 		ret = -ENOMEM;
-		iio_block_destroy(block);
-		goto out_send_response;
+		goto out_block_destroy;
 	}
 
 	entry->block = block;
 	entry->io = io;
 	entry->idx = cmd->code >> 16;
+
+	entry->enqueue_token = iio_task_token_create(buf_entry->enqueue_task, entry);
+	ret = iio_err(entry->enqueue_token);
+	if (ret)
+		goto out_free_entry;
+
+	entry->dequeue_token = iio_task_token_create(buf_entry->dequeue_task, entry);
+	ret = iio_err(entry->dequeue_token);
+	if (ret)
+		goto out_destroy_token;
 
 	if (WITH_IIOD_USB_DMABUF && pdata->is_usb) {
 		entry->dmabuf_fd = iio_block_get_dmabuf_fd(block);
@@ -719,6 +730,14 @@ static void handle_create_block(struct parser_pdata *pdata,
 	SLIST_INSERT_HEAD(&buf_entry->blocklist, entry, entry);
 	iio_mutex_unlock(buf_entry->lock);
 
+	goto out_send_response;
+
+out_destroy_token:
+	iio_task_token_destroy(entry->enqueue_token);
+out_free_entry:
+	free(entry);
+out_block_destroy:
+	iio_block_destroy(block);
 out_send_response:
 	iiod_io_send_response_code(io, ret);
 	iiod_io_unref(io);
@@ -746,6 +765,10 @@ static void handle_free_block(struct parser_pdata *pdata,
 	ret = iio_err(block);
 	if (ret)
 		goto out_send_response;
+
+	/* make sure the block is not being used by the enqueue or dequeue tasks */
+	iio_task_cancel_sync(entry->enqueue_token, 0);
+	iio_task_cancel_sync(entry->dequeue_token, 0);
 
 	if (WITH_IIOD_USB_DMABUF && entry->dmabuf_fd > 0)
 		usb_detach_dmabuf(entry->ep_fd, entry->dmabuf_fd);
@@ -832,7 +855,7 @@ static void handle_transfer_block(struct parser_pdata *pdata,
 	block_entry->bytes_used = bytes_used;
 	block_entry->cyclic = cmd->op == IIOD_OP_ENQUEUE_BLOCK_CYCLIC;
 
-	ret = iio_task_enqueue_autoclear(entry->enqueue_task, block_entry);
+	ret = iio_task_token_enqueue(block_entry->enqueue_token);
 	if (ret)
 		goto out_send_response;
 
@@ -871,7 +894,7 @@ static void handle_retry_dequeue_block(struct parser_pdata *pdata,
 		goto out_unlock;
 	}
 
-	ret = iio_task_enqueue_autoclear(entry->dequeue_task, block_entry);
+	ret = iio_task_token_enqueue(block_entry->dequeue_token);
 	if (ret)
 		goto out_send_response;
 

--- a/include/iio/iio-lock.h
+++ b/include/iio/iio-lock.h
@@ -44,8 +44,11 @@ __api int iio_task_destroy(struct iio_task *task);
 __api void iio_task_start(struct iio_task *task);
 __api void iio_task_stop(struct iio_task *task);
 
+__api void iio_task_token_destroy(struct iio_task_token *token);
+__api struct iio_task_token * iio_task_token_create(struct iio_task *task, void *elm);
 __api struct iio_task_token * iio_task_enqueue(struct iio_task *task, void *elm);
 __api int iio_task_enqueue_autoclear(struct iio_task *task, void *elm);
+__api int iio_task_token_enqueue(struct iio_task_token *token);
 
 __api _Bool iio_task_is_done(struct iio_task_token *token);
 __api int iio_task_sync(struct iio_task_token *token, unsigned int timeout_ms);

--- a/include/iio/iio-lock.h
+++ b/include/iio/iio-lock.h
@@ -52,6 +52,7 @@ __api int iio_task_token_enqueue(struct iio_task_token *token);
 
 __api _Bool iio_task_is_done(struct iio_task_token *token);
 __api int iio_task_sync(struct iio_task_token *token, unsigned int timeout_ms);
+__api int iio_task_cancel_sync(struct iio_task_token *token, unsigned int timeout_ms);
 __api void iio_task_cancel(struct iio_task_token *token);
 
 #undef __api

--- a/task.c
+++ b/task.c
@@ -355,6 +355,12 @@ bool iio_task_is_done(struct iio_task_token *token)
 	return token->done;
 }
 
+int iio_task_cancel_sync(struct iio_task_token *token, unsigned int timeout_ms)
+{
+	iio_task_cancel(token);
+	return iio_task_sync_core(token, timeout_ms, false);
+}
+
 void iio_task_cancel(struct iio_task_token *token)
 {
 	struct iio_task *task = token->task;

--- a/task.c
+++ b/task.c
@@ -94,6 +94,29 @@ static int iio_task_run(void *d)
 
 	return 0;
 }
+static int iio_task_sync_core(struct iio_task_token *token, unsigned int timeout_ms, bool token_destroy)
+{
+	int ret;
+
+	iio_mutex_lock(token->done_lock);
+	while (!token->done) {
+		ret = iio_cond_wait(token->done_cond, token->done_lock,
+				    timeout_ms);
+		if (ret) {
+			iio_mutex_unlock(token->done_lock);
+			iio_task_cancel(token);
+			iio_mutex_lock(token->done_lock);
+		}
+	}
+	iio_mutex_unlock(token->done_lock);
+
+	ret = token->ret;
+
+	if (token_destroy)
+		iio_task_token_destroy(token);
+
+	return ret;
+}
 
 struct iio_task * iio_task_create(int (*fn)(void *, void *),
 				  void *firstarg, const char *name)
@@ -207,25 +230,7 @@ int iio_task_enqueue_autoclear(struct iio_task *task, void *elm)
 
 int iio_task_sync(struct iio_task_token *token, unsigned int timeout_ms)
 {
-	int ret;
-
-	iio_mutex_lock(token->done_lock);
-	while (!token->done) {
-		ret = iio_cond_wait(token->done_cond, token->done_lock,
-				    timeout_ms);
-		if (ret) {
-			iio_mutex_unlock(token->done_lock);
-			iio_task_cancel(token);
-			iio_mutex_lock(token->done_lock);
-		}
-	}
-	iio_mutex_unlock(token->done_lock);
-
-	ret = token->ret;
-
-	iio_task_token_destroy(token);
-
-	return ret;
+	return iio_task_sync_core(token, timeout_ms, true);
 }
 
 void iio_task_flush(struct iio_task *task)


### PR DESCRIPTION
## PR Description

This series fixes a bug where iiod crashes (very often actually). To reproduce the issue one just needs to start a buffering session (I tested with the network backend) with iio_rwdev and hit CTRL-C. IIOD crashed fairy easy and the reason is that blocks could be enqueued in the (d)enqueue tasks, then freed and only then the tasks would process the already freed block.

the first patch is a bit unrelated but it fixes some issues regarding locking of the iiod_io write_token. Then, it's all about preparing the path (re-working task.c) for the real fix in the last commit.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
