### PR TITLE
iio.h: Remove c++ access to c only functions

### DIFF
--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -362,11 +362,13 @@ iio_attr_read_raw(const struct iio_attr *attr, char *dst, size_t len);
  * @param ptr A pointer to a variable where the value should be stored
  * @return On success, 0 is returned
  * @return On error, a negative errno code is returned */
+#ifndef __cplusplus
 #define iio_attr_read(attr, ptr)				\
 	_Generic((ptr),						\
 		 bool *: iio_attr_read_bool,			\
 		 long long *: iio_attr_read_longlong,		\
 		 double *: iio_attr_read_double)(attr, ptr)
+#endif /* __cplusplus */
 
 /** @brief Set the value of the given attribute
  * @param attr A pointer to an iio_attr structure
@@ -382,6 +384,7 @@ iio_attr_write_raw(const struct iio_attr *attr, const void *src, size_t len);
  * @param val The value to set the attribute to
  * @return On success, the number of bytes written
  * @return On error, a negative errno code is returned. */
+#ifndef __cplusplus
 #define iio_attr_write(attr, val)			\
 	_Generic((val),						\
 		 const char *: iio_attr_write_string,		\
@@ -389,6 +392,7 @@ iio_attr_write_raw(const struct iio_attr *attr, const void *src, size_t len);
 		 bool: iio_attr_write_bool,			\
 		 long long: iio_attr_write_longlong,		\
 		 double: iio_attr_write_double)(attr, val)
+#endif /* __cplusplus */
 
 /** @brief Retrieve the name of an attribute
  * @param attr A pointer to an iio_attr structure


### PR DESCRIPTION
The C11 generic macros iio_attr_{read,write} cannot be accesed from a program built with C++. Adding the __cplusplus guard for these functions will ensure that C++ users do not accidentally use these (resulting in an error). The reason for these changes were also discussed here: #1240 

## PR Description

- Add ifndef __cplusplus to iio_attr_{read,write}  functions.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
