### PR TITLE
Misc improvements

### DIFF
--- a/stream.c
+++ b/stream.c
@@ -74,8 +74,17 @@ void iio_stream_destroy(struct iio_stream *stream)
 	size_t i;
 
 	for (i = 0; i < stream->nb_blocks; i++)
-		if (stream->blocks[i])
+		if (stream->blocks[i]) {
+			/* Make sure to dequeue any possible in flight block
+			 * before destroying it. Note that if the block is not
+			 * enqueued, this returns an error but we really don't
+			 * care about it. Making sure the block is dequeued makes
+			 * for a much cleaner exit specially in cases where freeing
+			 * the blocks is deferred to the default client.
+			 */
+			iio_block_dequeue(stream->blocks[i], false);
 			iio_block_destroy(stream->blocks[i]);
+		}
 	free(stream->blocks);
 	free(stream);
 }


### PR DESCRIPTION
## PR Description

This improves iio_rwdev exit and is a combination of two things:

1. When destroying the stream, make sure to dequeue any possible in flight block before destroying it. This makes for a much cleaner exit specially in cases where freeing the blocks is deferred to the default client which for some reason will make iiod choke for sometime on a io_submit() call related to in flight block dequeue;
2. With 1), we don't really want to cancel the buffer as soon as we hit ctrl-c since then we would timeout in dequeing the block. And if we don't do 1), then we would still have the delay caused by iiod (since with #1243, iiod now makes sure it's safe to free a block before freeing it).

So this is really a combination of the above two points which improves things a lot when cancelling a buffer session with iio_rwdev.

Note this is only tested on linux so it would be great if someone could do a quick test on windows.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
