### PR TITLE
[FIX] missed `inline`s in C++ binding

### DIFF
--- a/bindings/cpp/iiopp.h
+++ b/bindings/cpp/iiopp.h
@@ -346,7 +346,7 @@ public:
 
 typedef Ptr<ChannelsMask, iio_channels_mask, iio_channels_mask_destroy> ChannelsMaskPtr;
 
-ChannelsMaskPtr create_channels_mask(unsigned int nb_channels)
+inline ChannelsMaskPtr create_channels_mask(unsigned int nb_channels)
 {
     return ChannelsMaskPtr(iio_create_channels_mask(nb_channels));
 }
@@ -695,7 +695,7 @@ public:
 
 typedef Ptr<Scan, struct iio_scan, iio_scan_destroy> ScanPtr;
 
-ScanPtr scan(struct iio_context_params const * params, char const * backends)
+inline ScanPtr scan(struct iio_context_params const * params, char const * backends)
 {
     return ScanPtr(impl::check(iio_scan(params, backends), "iio_scan"));
 }


### PR DESCRIPTION
## PR Description

Missed `inline` keyword before a couple of functions in `bindings/cpp/iiopp.h` . Since I included it in two .cpp files and no more "multiple definitions", that should be all missed inlines.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
