### PR TITLE
lock: Fix passing the wrong parameter when creating threads on Windows

### DIFF
--- a/lock-windows.c
+++ b/lock-windows.c
@@ -117,7 +117,7 @@ struct iio_thrd * iio_thrd_create(int (*thrd)(void *),
 
 	iio_thrd->thid = CreateThread(NULL, 0,
 				      (LPTHREAD_START_ROUTINE) iio_thrd_wrapper,
-				      d, 0, NULL);
+				      iio_thrd, 0, NULL);
 	if (!iio_thrd->thid) {
 		free(iio_thrd);
 		return iio_ptr(-(int) GetLastError());


### PR DESCRIPTION
Send the same parameters as the Unix implementation: https://github.com/analogdevicesinc/libiio/blob/e54973a39f6f35fda3cf170d8585d48d65450e7b/lock.c#L131

This was causing random crashes when running iio_info on Windows. Error was: "0xC0000005: Access violation executing location".

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [x] I have checked that I did not intoduced new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
