### PR TITLE
Revert removing iiod interpreter calls

### DIFF
--- a/iiod/interpreter.c
+++ b/iiod/interpreter.c
@@ -114,7 +114,8 @@ static ssize_t writefd_aio(struct parser_pdata *pdata, const void *dest,
 		len = MAX_AIO_REQ_SIZE;
 	return async_io(pdata, (void *)dest, len, false);
 }
-#endif /* WITH_AIO */
+
+#else
 
 static ssize_t readfd_io(struct parser_pdata *pdata, void *dest, size_t len)
 {
@@ -195,6 +196,8 @@ static ssize_t writefd_io(struct parser_pdata *pdata, const void *src, size_t le
 
 	return ret;
 }
+
+#endif /* WITH_AIO */
 
 void interpreter(struct iio_context *ctx, int fd_in, int fd_out,
 		 bool is_socket, bool is_usb,

--- a/iiod/interpreter.c
+++ b/iiod/interpreter.c
@@ -116,6 +116,86 @@ static ssize_t writefd_aio(struct parser_pdata *pdata, const void *dest,
 }
 #endif /* WITH_AIO */
 
+static ssize_t readfd_io(struct parser_pdata *pdata, void *dest, size_t len)
+{
+	ssize_t ret;
+	struct pollfd pfd[2];
+
+	pfd[0].fd = pdata->fd_in;
+	pfd[0].events = POLLIN | POLLRDHUP;
+	pfd[0].revents = 0;
+	pfd[1].fd = thread_pool_get_poll_fd(pdata->pool);
+	pfd[1].events = POLLIN;
+	pfd[1].revents = 0;
+
+	do {
+		poll_nointr(pfd, 2);
+
+		/* Got STOP event, or client closed the socket: treat it as EOF */
+		if (pfd[1].revents & POLLIN || pfd[0].revents & POLLRDHUP)
+			return 0;
+		if (pfd[0].revents & POLLERR)
+			return -EIO;
+		if (!(pfd[0].revents & POLLIN))
+			continue;
+
+		do {
+			if (pdata->fd_in_is_socket)
+				ret = recv(pdata->fd_in, dest, len, MSG_NOSIGNAL);
+			else
+				ret = read(pdata->fd_in, dest, len);
+		} while (ret == -1 && errno == EINTR);
+
+		if (ret != -1 || errno != EAGAIN)
+			break;
+	} while (true);
+
+	if (ret == -1)
+		return -errno;
+
+	return ret;
+}
+
+static ssize_t writefd_io(struct parser_pdata *pdata, const void *src, size_t len)
+{
+	ssize_t ret;
+	struct pollfd pfd[2];
+
+	pfd[0].fd = pdata->fd_out;
+	pfd[0].events = POLLOUT;
+	pfd[0].revents = 0;
+	pfd[1].fd = thread_pool_get_poll_fd(pdata->pool);
+	pfd[1].events = POLLIN;
+	pfd[1].revents = 0;
+
+	do {
+		poll_nointr(pfd, 2);
+
+		/* Got STOP event, or client closed the socket: treat it as EOF */
+		if (pfd[1].revents & POLLIN || pfd[0].revents & POLLHUP)
+			return 0;
+		if (pfd[0].revents & POLLERR)
+			return -EIO;
+		if (!(pfd[0].revents & POLLOUT))
+			continue;
+
+		do {
+			if (pdata->fd_out_is_socket)
+				ret = send(pdata->fd_out, src, len, MSG_NOSIGNAL);
+			else
+				ret = write(pdata->fd_out, src, len);
+		} while (ret == -1 && errno == EINTR);
+
+		if (ret != -1 || errno != EAGAIN)
+			break;
+	} while (true);
+
+	if (ret == -1)
+		return -errno;
+
+	return ret;
+}
+
 void interpreter(struct iio_context *ctx, int fd_in, int fd_out,
 		 bool is_socket, bool is_usb,
 		 struct thread_pool *pool, const void *xml_zstd,


### PR DESCRIPTION
'readfd_io' and 'writefd_io' are used when building with cmake flag WITH_AIO=OFF. They are used here: https://github.com/analogdevicesinc/libiio/blob/73bba2572c0710190b46e00242ca1e99095838e8/iiod/interpreter.c#L165-L166

This reverts commit a80a31274e0c01b64dabb81c3bb4e41c09355ce8.

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
