### PR TITLE
device.c: Avoid reordering channels for XML based iio contexts

### DIFF
--- a/device.c
+++ b/device.c
@@ -407,8 +407,10 @@ struct iio_channel * iio_device_add_channel(struct iio_device *dev, long index,
 
 	iio_channel_init_finalize(chn);
 
-	/* Reorder channels by index */
-	iio_sort_channels(dev);
+	/* Reorder channels by index unless context is created from xml which
+	 * should provide already sorted channels. */
+	if (strcmp(dev->ctx->name, "xml"))
+		iio_sort_channels(dev);
 
 	for (i = 0; i < dev->nb_channels; i++)
 		dev->channels[i]->number = i;


### PR DESCRIPTION
## PR Description
The XML already contains channels in a sorted order.

These changes reduce context creation time, but the primary reason for implementing them is to address differences in channel sorting behavior between Windows and Linux. These differences cause communication issues between libiio running on Windows and the remote IIOD.

More specifically, when all channels lack an index (marked with a value of -2), qsort() on Linux preserves the original order since there is nothing to sort. However, on Windows, the channel list is modified each time qsort() is called.

The channel's position in the list is critical because it is used by the binary interface with IIOD.

The first symptom of this issue was the failure to create an iio_context. Internally, this process reads all scale attributes from all channels of all devices. One of these read operations failed because the command contained the channel position, which was altered, making it unrecognizable by IIOD.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
