### PR TITLE
lock: fix build when HAS_PTHREAD_SETNAME_NP is not set

### DIFF
--- a/lock.c
+++ b/lock.c
@@ -16,17 +16,17 @@
 #include <stdlib.h>
 #include <time.h>
 
-#if defined(HAS_PTHREAD_SETNAME_NP)
 #ifndef PTHREAD_MAX_NAMELEN_NP
 #define PTHREAD_MAX_NAMELEN_NP	16
 #endif
+#if defined(HAS_PTHREAD_SETNAME_NP)
 #if defined(__APPLE__)
 #define iio_thrd_create_set_name(thid, name)	pthread_setname_np(name)
 #else
 #define iio_thrd_create_set_name(thid, name)	pthread_setname_np(thid, name)
 #endif
 #else
-#define iio_thrd_create_set_name(thid, name)	0
+#define iio_thrd_create_set_name(thid, name)
 #endif
 
 struct iio_mutex {


### PR DESCRIPTION
If HAS_PTHREAD_SETNAME_NP is not set, then PTHREAD_MAX_NAMELEN_NP will not be set and therefore the compilation fails. Instead of adding more '#idefs' let's just take PTHREAD_MAX_NAMELEN_NP of the HAS_PTHREAD_SETNAME_NP block.

On top of this, if HAS_PTHREAD_SETNAME_NP is not set, then iio_thrd_create_set_name() is defined to 0 which has no effect since we don't do any error handling when calling iio_thrd_create_set_name(). This was a leftover from the first versions of the patch series.

(this was found on a petalinux build where the toolchain does not include pthread_setname_np()) 

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
