### PR TITLE
Forward libiio compiler flags to in house clients

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,8 +195,10 @@ if (DEFAULT_LOG_LEVEL GREATER MAX_LOG_LEVEL_VALUE)
 	message(SEND_ERROR "Default log level cannot be more than the maximum log level.")
 endif()
 
+add_library(iio_common_config INTERFACE)
+
 if (MSVC)
-	target_compile_options(iio PRIVATE /Zi /W4 /wd4200 /wd4127 /wd4100)
+	target_compile_options(iio_common_config INTERFACE /Zi /W4 /wd4200 /wd4127 /wd4100)
 	# Zi produces a separate PDB file that contains all the symbolic debugging information
 	# W4 displays level 1, 2, 3, and 4 (informational) warnings that aren't off by default
 	# C4200: nonstandard extension used : zero-sized array in struct (usb.h)
@@ -215,18 +217,20 @@ elseif (CMAKE_COMPILER_IS_GNUCC)
 	check_c_compiler_flag(-Wpedantic HAS_WPEDANTIC)
 	check_c_compiler_flag(-Wshadow HAS_WSHADOW)
 
-	target_compile_options(iio PRIVATE -Wall -Wextra -Wno-unused-parameter
+	target_compile_options(iio_common_config INTERFACE -Wall -Wextra -Wno-unused-parameter
 		$<$<BOOL:HAS_WPEDANTIC>:-Wpedantic>
 		$<$<BOOL:HAS_WSHADOW>:-Wshadow>
 	)
 
 elseif (CMAKE_C_COMPILER_ID STREQUAL "Clang")
-	target_compile_options(iio PRIVATE -Wall -Wextra -pedantic -Wno-unused-parameter)
+	target_compile_options(iio_common_config INTERFACE -Wall -Wextra -pedantic -Wno-unused-parameter)
 else()
 	message(STATUS "Unknown compiler, please report upstream")
 	message(STATUS "CMAKE_C_COMPILER_ID : " ${CMAKE_C_COMPILER_ID})
 	message(STATUS "CFLAGS set to " ${CMAKE_C_FLAGS})
 endif()
+
+target_link_libraries(iio PRIVATE iio_common_config)
 
 include(CheckSymbolExists)
 check_symbol_exists(strdup "string.h" HAS_STRDUP)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,7 +7,7 @@ project(dummy-iiostream C)
 project(adrv9002-iiostream C)
 
 add_library(iiostream_helper STATIC iiostream-common.c)
-target_link_libraries(iiostream_helper PUBLIC iio)
+target_link_libraries(iiostream_helper PUBLIC iio iio_common_config)
 
 if (APPLE)
     # Add relative rpath to iio library (which is in the same framework)

--- a/examples/adrv9002-iiostream.c
+++ b/examples/adrv9002-iiostream.c
@@ -224,13 +224,12 @@ int main(void)
 	struct iio_device *rx;
 	size_t tx_sample_sz, rx_sample_sz;
 	int ret = EXIT_FAILURE;
-	int err;
 
 	if (register_signals() < 0)
 		return EXIT_FAILURE;
 
 	ctx = iio_create_context(NULL, NULL);
-	err = iio_err(ctx);
+	ret = iio_err(ctx);
 	if (ret) {
 		error("Could not create IIO context\n");
 		return EXIT_FAILURE;

--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -18,12 +18,6 @@ target_link_libraries(iiod LINK_PRIVATE iio iio_common_config iiod-responder
 target_include_directories(iiod PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_definitions(iiod PRIVATE _GNU_SOURCE)
 
-if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
-	# flex sometimes generates code which generate sign comparison errors
-	set_source_files_properties(${FLEX_lexer_OUTPUTS} PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
-	set_source_files_properties(${BISON_parser_OUTPUTS} PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
-endif ()
-
 option(WITH_IIOD_V0_COMPAT "Build support for Libiio v0.x protocol" ON)
 if (WITH_IIOD_V0_COMPAT)
 	include(FindBISON)
@@ -37,6 +31,11 @@ if (WITH_IIOD_V0_COMPAT)
 
 	target_sources(iiod PRIVATE ops.c ${BISON_parser_OUTPUTS} ${FLEX_lexer_OUTPUTS})
 endif (WITH_IIOD_V0_COMPAT)
+if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
+	# flex sometimes generates code which generate sign comparison errors
+	set_source_files_properties(${FLEX_lexer_OUTPUTS} PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
+	set_source_files_properties(${BISON_parser_OUTPUTS} PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
+endif ()
 
 option(WITH_AIO "Build IIOD with async. I/O support" ON)
 if (WITH_AIO)

--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -12,7 +12,7 @@ set_target_properties(iiod PROPERTIES
 	C_STANDARD_REQUIRED ON
 	C_EXTENSIONS OFF
 )
-target_link_libraries(iiod LINK_PRIVATE iio iiod-responder
+target_link_libraries(iiod LINK_PRIVATE iio iio_common_config iiod-responder
 	${PTHREAD_LIBRARIES} ${AVAHI_COMMON_LIBRARIES} ${AVAHI_CLIENT_LIBRARIES}
 )
 target_include_directories(iiod PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -555,7 +555,7 @@ static void rw_thd(struct thread_pool *pool, void *d)
 		}
 
 		if (has_readers) {
-			nb_bytes = iio_block_end(block) - iio_block_start(block);
+			nb_bytes = (char *)iio_block_end(block) - (char *)iio_block_start(block);
 
 			/* We don't use SLIST_FOREACH here. As soon as a thread is
 			 * signaled, its "thd" structure might be freed;

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -284,7 +284,6 @@ static bool iio_buffer_is_tx(const struct iio_buffer *buf)
 
 static int buffer_enqueue_block(void *priv, void *d)
 {
-	struct buffer_entry *buffer = priv;
 	struct block_entry *entry = d;
 	intptr_t ret;
 
@@ -538,7 +537,6 @@ static struct iio_block * get_iio_block(struct parser_pdata *pdata,
 					const struct iiod_command *cmd,
 					struct block_entry **entry_ptr)
 {
-	struct block_entry *entry;
 	struct iio_block *block = NULL;
 
 	iio_mutex_lock(entry_buf->lock);
@@ -752,7 +750,7 @@ static void handle_free_block(struct parser_pdata *pdata,
 	struct iio_buffer *buf;
 	struct iio_block *block;
 	struct iiod_io *io;
-	int ret, ep_fd;
+	int ret;
 
 	buf = get_iio_buffer(pdata, cmd, &buf_entry);
 	ret = iio_err(buf);

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -335,7 +335,7 @@ static int buffer_dequeue_block(void *priv, void *d)
 		}
 
 		data.ptr = iio_block_start(entry->block);
-		data.size = iio_block_end(entry->block) - data.ptr;
+		data.size = (char *)iio_block_end(entry->block) - (char *)data.ptr;
 		nb_data++;
 
 		ret = data.size;
@@ -842,7 +842,7 @@ static void handle_transfer_block(struct parser_pdata *pdata,
 				goto out_send_response;
 		} else {
 			readbuf.ptr = iio_block_start(block);
-			readbuf.size = iio_block_end(block) - readbuf.ptr;
+			readbuf.size = (char *)iio_block_end(block) - (char *)readbuf.ptr;
 
 			ret = iiod_command_data_read(cmd_data, &readbuf);
 			if (ret < 0)

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -232,7 +232,7 @@ static void handle_gettrig(struct parser_pdata *pdata,
 		if (trigger == iio_context_get_device(ctx, i))
 			break;
 
-	ret = i < iio_context_get_devices_count(ctx) ? i : -ENODEV;
+	ret = i < iio_context_get_devices_count(ctx) ? (int)i : -ENODEV;
 
 out_send_response:
 	iiod_io_send_response_code(io, ret);

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -509,7 +509,7 @@ static struct iio_buffer * get_iio_buffer(struct parser_pdata *pdata,
 	if (buf && entry_ptr)
 		*entry_ptr = entry;
 
-	return buf ?: iio_ptr(-EBADF);
+	return buf ? buf : iio_ptr(-EBADF);
 }
 
 static struct iio_block * get_iio_block_unlocked(struct buffer_entry *entry_buf,
@@ -529,7 +529,7 @@ static struct iio_block * get_iio_block_unlocked(struct buffer_entry *entry_buf,
 	if (block && entry_ptr)
 		*entry_ptr = entry;
 
-	return block ?: iio_ptr(-EBADF);
+	return block ? block : iio_ptr(-EBADF);
 }
 
 static struct iio_block * get_iio_block(struct parser_pdata *pdata,

--- a/tinyiiod/CMakeLists.txt
+++ b/tinyiiod/CMakeLists.txt
@@ -17,4 +17,4 @@ set_target_properties(tinyiiod PROPERTIES
 	C_STANDARD_REQUIRED ON
 	C_EXTENSIONS OFF
 )
-target_link_libraries(tinyiiod LINK_PRIVATE iio iiod-responder)
+target_link_libraries(tinyiiod LINK_PRIVATE iio iio_common_config iiod-responder)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -18,7 +18,7 @@ if (WIN32)
 endif()
 
 add_library(iio_tests_helper STATIC iio_common.c gen_code.c)
-target_link_libraries(iio_tests_helper LINK_PRIVATE iio)
+target_link_libraries(iio_tests_helper LINK_PRIVATE iio iio_common_config)
 if (MSVC)
 	target_sources(iio_tests_helper PRIVATE ../deps/wingetopt/src/getopt.c)
 	target_include_directories(iio_tests_helper PUBLIC ../deps/wingetopt/src)

--- a/utils/iio_common.c
+++ b/utils/iio_common.c
@@ -168,9 +168,8 @@ char ** dup_argv(char * name, unsigned int argc, char * argv[])
 	return new_argv;
 
 err_dup:
-	i--;
-	for (; i >= 0; i--)
-		free(new_argv[i]);
+	for (; i > 0; i--)
+		free(new_argv[i - 1]);
 
 	free(new_argv);
 

--- a/utils/iio_common.c
+++ b/utils/iio_common.c
@@ -351,7 +351,7 @@ struct iio_context * handle_common_opts(char * name, int argc,
 		err = iio_snprintf(buf, sizeof(buf), "%s:%s", prefix, arg);
 		if (err < 0)
 			ctx = iio_ptr(err);
-		else if (err >= sizeof(buf))
+		else if ((size_t)err >= sizeof(buf))
 			ctx = iio_ptr(-EINVAL);
 		else
 			ctx = iio_create_context(NULL, buf);


### PR DESCRIPTION
## PR Description

Based on discussion at https://github.com/analogdevicesinc/libiio/issues/1223 do the following:
 - apply a set of compiler flags not just to libiio but also to utils, examples and iiod.
 - make sure the set of flags will not be enforced to libiio clients
 - fix warnings generated after the set of flags has been applied

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [x] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
