### PR TITLE
local: Expose ENV to allow switching the DMA buffers allocator

### DIFF
--- a/local-dmabuf.c
+++ b/local-dmabuf.c
@@ -84,7 +84,11 @@ local_create_dmabuf(struct iio_buffer_pdata *pdata, size_t size, void **data)
 	if (!priv)
 		return iio_ptr(-ENOMEM);
 
-	devfd = open("/dev/dma_heap/system", O_RDONLY | O_CLOEXEC | O_NOFOLLOW); /* Flawfinder: ignore */
+	if (pdata->dmabuf_alloc_type == DMABUF_ALLOC_SC) {
+		devfd = open("/dev/dma_heap/system", O_RDONLY | O_CLOEXEC | O_NOFOLLOW); /* Flawfinder: ignore */
+	} else {
+		devfd = open("/dev/dma_heap/cma,linux", O_RDONLY | O_CLOEXEC | O_NOFOLLOW); /* Flawfinder: ignore */
+	}
 	if (devfd < 0) {
 		ret = -errno;
 

--- a/local.c
+++ b/local.c
@@ -1484,12 +1484,20 @@ local_create_buffer(const struct iio_device *dev, unsigned int idx,
 	const struct iio_channel *chn;
 	int err, cancel_fd, fd;
 	unsigned int i;
+	const char *use_cma_for_device;
 
 	pdata = zalloc(sizeof(*pdata));
 	if (!pdata)
 		return iio_ptr(-ENOMEM);
 
 	pdata->dev = dev;
+
+	pdata->dmabuf_alloc_type = DMABUF_ALLOC_SC;
+	use_cma_for_device = iio_getenv("CMA_FOR_DEVICE");
+	if (use_cma_for_device) {
+		if (strstr(dev->name, use_cma_for_device))
+			pdata->dmabuf_alloc_type = DMABUF_ALLOC_CMA;
+	}
 
 	if (WITH_LOCAL_MMAP_API) {
 		pdata->pdata = local_alloc_mmap_buffer_impl();

--- a/local.h
+++ b/local.h
@@ -17,12 +17,18 @@ struct iio_block_impl_pdata;
 struct iio_device;
 struct timespec;
 
+enum dma_allocator_type {
+	DMABUF_ALLOC_SC,  /* System allocator (generic - uses Scatter-Gather) */
+	DMABUF_ALLOC_CMA, /* Continuous memory allocator */
+};
+
 struct iio_buffer_pdata {
 	const struct iio_device *dev;
 	struct iio_buffer_impl_pdata *pdata;
 	int fd, cancel_fd;
 	unsigned int idx;
 	bool dmabuf_supported;
+	enum dma_allocator_type dmabuf_alloc_type;
 	bool mmap_supported;
 	size_t size;
 };


### PR DESCRIPTION
The default allocator is a generic allocator that does not garantee continous memory. Some hardware require contiguous DMA buffers. See #1259.

Set the environment variable CMA_FOR_DEVICES with a string that contains the name of the iio device for which it is desired the CMA allocator to be used. Multiple device names can be set.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particulary complex or unclear areas
- [x] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
