### PR TITLE
iiod: responder: make sure to unlock buffer_entry lock

### DIFF
--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -761,8 +761,10 @@ static void handle_free_block(struct parser_pdata *pdata,
 
 	block = get_iio_block_unlocked(buf_entry, cmd, &entry);
 	ret = iio_err(block);
-	if (ret)
+	if (ret) {
+		iio_mutex_unlock(buf_entry->lock);
 		goto out_send_response;
+	}
 
 	/* make sure the block is not being used by the enqueue or dequeue tasks */
 	iio_task_cancel_sync(entry->enqueue_token, 0);


### PR DESCRIPTION
On handle_free_block(), we need to make sure to unlock the buffer_entry lock if we fail to get the IIO block.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
