### PR TITLE
task: Implement iio_buffer_params struct and make CMA selectable at runtime

### DIFF
--- a/bindings/cpp/iiopp.h
+++ b/bindings/cpp/iiopp.h
@@ -572,7 +572,7 @@ public:
     Device trigger() const {return Device{const_cast<iio_device*>(impl::check(iio_device_get_trigger(p), "iio_device_get_trigger"))};}
     void set_trigger(iio_device const * trigger) {impl::check(iio_device_set_trigger(p, trigger), "iio_device_set_trigger");}
     bool is_trigger() const {return iio_device_is_trigger(p);}
-    BufferPtr create_buffer(unsigned int idx, iio_channels_mask * mask) {return BufferPtr(impl::check(iio_device_create_buffer(p, idx, mask), "iio_device_create_buffer"));}
+    BufferPtr create_buffer(iio_buffer_params * params, iio_channels_mask * mask) {return BufferPtr(impl::check(iio_device_create_buffer(p, params, mask), "iio_device_create_buffer"));}
     bool is_hwmon() const {return iio_device_is_hwmon(p);}
     EventStreamPtr create_event_stream() { return EventStreamPtr{impl::check(iio_device_create_event_stream(p), "iio_device_create_event_stream")};}
     ssize_t sample_size(iio_channels_mask * mask) const {return impl::check_n(iio_device_get_sample_size(p, mask), "iio_device_get_sample_size");}

--- a/bindings/csharp/IOBuffer.cs
+++ b/bindings/csharp/IOBuffer.cs
@@ -22,7 +22,7 @@ namespace iio
     public class IOBuffer : IIOObject
     {
         [DllImport(IioLib.dllname, CallingConvention = CallingConvention.Cdecl)]
-        private static extern IIOPtr iio_device_create_buffer(IntPtr dev, uint index, IntPtr mask);
+        private static extern IIOPtr iio_device_create_buffer(IntPtr dev, IntPtr buffer_params, IntPtr mask);
 
         [DllImport(IioLib.dllname, CallingConvention = CallingConvention.Cdecl)]
         private static extern void iio_buffer_destroy(IntPtr buf);
@@ -75,12 +75,12 @@ namespace iio
         /// <param name="mask">The channels mask to use to create the buffer object.</param>
         /// <param name="index">The index of the hardware buffer. Should be 0 in most cases.</param>
         /// <exception cref="IioLib.IIOException">The buffer could not be created.</exception>
-        public IOBuffer(Device dev, ChannelsMask mask, uint index = 0)
+        public IOBuffer(Device dev, ChannelsMask mask)
         {
             this.mask = mask;
             this.dev = dev;
 
-            IIOPtr ptr = iio_device_create_buffer(dev.dev, index, mask.hdl);
+            IIOPtr ptr = iio_device_create_buffer(dev.dev, IntPtr.Zero, mask.hdl);
             if (!ptr)
                 throw new IIOException("Unable to create buffer", ptr);
 

--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -130,6 +130,9 @@ class _Attr(Structure):
 class ContextParams(Structure):
     pass # TODO
 
+class BufferParams(Structure):
+    pass # TODO
+
 class DataFormat(Structure):
     """Represents the data format of an IIO channel."""
 
@@ -304,6 +307,7 @@ _BufferPtr = _POINTER(_Buffer)
 _BlockPtr = _POINTER(_Block)
 _DataFormatPtr = _POINTER(DataFormat)
 _ContextParamsPtr = _POINTER(ContextParams)
+_BufferParamsPtr = _POINTER(BufferParams)
 _StreamPtr = _POINTER(_Stream)
 _AttrPtr = _POINTER(_Attr)
 
@@ -631,7 +635,7 @@ _create_buffer = _lib.iio_device_create_buffer
 _create_buffer.restype = _BufferPtr
 _create_buffer.argtypes = (
     _DevicePtr,
-    c_uint,
+    _BufferParamsPtr,
     _ChannelsMaskPtr,
 )
 _create_buffer.errcheck = _check_ptr_err
@@ -1080,7 +1084,7 @@ class Block(_IIO_Object):
 class Buffer(_IIO_Object):
     """Represents a hardware I/O buffer."""
 
-    def __init__(self, device, mask, idx=0):
+    def __init__(self, device, mask, params):
         """
         Initialize a new instance of the Buffer class.
 
@@ -1096,7 +1100,7 @@ class Buffer(_IIO_Object):
             An new instance of this class
         """
         try:
-            self._buffer = _create_buffer(device._device, idx, mask._mask)
+            self._buffer = _create_buffer(device._device, params._params, mask._mask)
         except Exception:
             self._buffer = None
             raise

--- a/buffer.c
+++ b/buffer.c
@@ -98,7 +98,8 @@ static int iio_buffer_enqueue_worker(void *_, void *d)
 }
 
 struct iio_buffer *
-iio_device_create_buffer(const struct iio_device *dev, unsigned int idx,
+iio_device_create_buffer(const struct iio_device *dev,
+			 struct iio_buffer_params *params,
 			 const struct iio_channels_mask *mask)
 {
 	const struct iio_backend_ops *ops = dev->ctx->ops;
@@ -121,8 +122,10 @@ iio_device_create_buffer(const struct iio_device *dev, unsigned int idx,
 	if (!buf)
 		return iio_ptr(-ENOMEM);
 
+	if (params)
+		buf->params = *params;
+
 	buf->dev = dev;
-	buf->idx = idx;
 
 	/* Duplicate buffer attributes from the iio_device.
 	 * This ensures that those can contain a pointer to our iio_buffer */
@@ -161,7 +164,7 @@ iio_device_create_buffer(const struct iio_device *dev, unsigned int idx,
 	if (err < 0)
 		goto err_free_mutex;
 
-	buf->pdata = ops->create_buffer(dev, idx, buf->mask);
+	buf->pdata = ops->create_buffer(dev, &buf->params, buf->mask);
 	err = iio_err(buf->pdata);
 	if (err < 0)
 		goto err_destroy_worker;

--- a/compat.c
+++ b/compat.c
@@ -39,6 +39,7 @@ struct iio_channel;
 struct iio_channels_mask;
 struct iio_context;
 struct iio_context_params;
+struct iio_buffer_params;
 struct iio_data_format;
 struct iio_device;
 struct iio_scan;
@@ -167,7 +168,7 @@ struct compat {
 
 	/* Buffers */
 	struct iio_buffer * (*iio_device_create_buffer)(const struct iio_device *,
-							unsigned int,
+							struct iio_buffer_params *,
 							const struct iio_channels_mask *);
 	void (*iio_buffer_destroy)(struct iio_buffer *);
 	void (*iio_buffer_cancel)(struct iio_buffer *);
@@ -2037,7 +2038,7 @@ struct iio_buffer * iio_device_create_buffer(const struct iio_device *dev,
 	len = samples_count * compat->sample_size;
 	compat->size = len;
 
-	buf = IIO_CALL(iio_device_create_buffer)(dev, 0, dev_compat->mask);
+	buf = IIO_CALL(iio_device_create_buffer)(dev, NULL, dev_compat->mask);
 	err = iio_err(buf);
 	if (err)
 		goto err_free_compat;

--- a/iio-private.h
+++ b/iio-private.h
@@ -140,8 +140,7 @@ struct iio_buffer {
 	size_t length;
 
 	struct iio_channels_mask *mask;
-	unsigned int idx;
-
+	struct iio_buffer_params params;
 	struct iio_task *worker;
 
 	/* These two fields are set by the last block created. They are only

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -53,7 +53,7 @@ struct iiod_client_buffer_pdata {
 
 	struct iio_channels_mask *mask;
 	const struct iio_device *dev;
-	uint16_t idx;
+	struct iio_buffer_params params;
 
 	/* TODO: atomic? */
 	uint16_t next_block_idx;
@@ -578,7 +578,7 @@ static ssize_t iiod_client_read_attr_new(struct iiod_client *client,
 			return -ENOENT;
 
 		arg1 = (uint16_t) i;
-		arg2 = (uint16_t) buf->idx;
+		arg2 = (uint16_t) buf->params.idx;
 		break;
 	default:
 		return -EINVAL;
@@ -744,7 +744,7 @@ static ssize_t iiod_client_write_attr_new(struct iiod_client *client,
 			return -ENOENT;
 
 		arg1 = (uint16_t) i;
-		arg2 = (uint16_t) buf->idx;
+		arg2 = (uint16_t) buf->params.idx;
 		break;
 	default:
 		return -EINVAL;
@@ -1421,7 +1421,7 @@ ssize_t iiod_client_writebuf(struct iiod_client_buffer_pdata *pdata,
 struct iiod_client_buffer_pdata *
 iiod_client_create_buffer(struct iiod_client *client,
 			  struct iiod_client *client_fb,
-			  const struct iio_device *dev, unsigned int idx,
+			  const struct iio_device *dev, const struct iio_buffer_params *params,
 			  struct iio_channels_mask *mask)
 {
 	struct iiod_io *io;
@@ -1435,7 +1435,7 @@ iiod_client_create_buffer(struct iiod_client *client,
 		return iio_ptr(-ENOMEM);
 
 	pdata->dev = dev;
-	pdata->idx = (uint16_t) idx;
+	pdata->params = *params;
 	pdata->client = client;
 	pdata->client_fb = client_fb;
 	pdata->mask = mask;
@@ -1445,7 +1445,7 @@ iiod_client_create_buffer(struct iiod_client *client,
 
 		cmd.op = IIOD_OP_CREATE_BUFFER;
 		cmd.dev = (uint8_t) iio_device_get_index(dev);
-		cmd.code = pdata->idx;
+		cmd.code = pdata->params.idx;
 
 		/* TODO: endianness */
 		buf.ptr = mask->mask;
@@ -1474,7 +1474,7 @@ void iiod_client_free_buffer(struct iiod_client_buffer_pdata *pdata)
 
 		cmd.op = IIOD_OP_FREE_BUFFER;
 		cmd.dev = (uint8_t) iio_device_get_index(pdata->dev);
-		cmd.code = pdata->idx;
+		cmd.code = pdata->params.idx;
 
 		iiod_io_exec_simple_command(io, &cmd);
 	}
@@ -1517,7 +1517,7 @@ int iiod_client_enable_buffer(struct iiod_client_buffer_pdata *pdata,
 
 	cmd.op = enable ? IIOD_OP_ENABLE_BUFFER : IIOD_OP_DISABLE_BUFFER;
 	cmd.dev = (uint8_t) iio_device_get_index(pdata->dev);
-	cmd.code = pdata->idx;
+	cmd.code = pdata->params.idx;
 
 	io = iiod_responder_get_default_io(client->responder);
 
@@ -1563,7 +1563,7 @@ iiod_client_create_block(struct iiod_client_buffer_pdata *pdata,
 
 	cmd.op = IIOD_OP_CREATE_BLOCK;
 	cmd.dev = (uint8_t) iio_device_get_index(pdata->dev);
-	cmd.code = pdata->idx | (block->idx << 16);
+	cmd.code = pdata->params.idx | (block->idx << 16);
 
 	ret = iiod_io_exec_command(block->io, &cmd, &buf, NULL);
 	if (ret < 0)
@@ -1599,7 +1599,7 @@ void iiod_client_free_block(struct iio_block_pdata *block)
 
 	cmd.op = IIOD_OP_FREE_BLOCK;
 	cmd.dev = (uint8_t) iio_device_get_index(pdata->dev);
-	cmd.code = pdata->idx | (block->idx << 16);
+	cmd.code = pdata->params.idx | (block->idx << 16);
 
 	/* Cancel any I/O going on. This means we must send the block free
 	 * command through the main I/O as the block's I/O stream is
@@ -1627,7 +1627,7 @@ int iiod_client_enqueue_block(struct iio_block_pdata *block,
 
 	cmd.op = cyclic ? IIOD_OP_ENQUEUE_BLOCK_CYCLIC : IIOD_OP_TRANSFER_BLOCK;
 	cmd.dev = (uint8_t) iio_device_get_index(pdata->dev);
-	cmd.code = pdata->idx | (block->idx << 16);
+	cmd.code = pdata->params.idx | (block->idx << 16);
 
 	block->bytes_used = bytes_used;
 	buf[0].ptr = &block->bytes_used;
@@ -1677,7 +1677,7 @@ int iiod_client_dequeue_block(struct iio_block_pdata *block, bool nonblock)
 		/* The previous enqueue succeeded, but the dequeue failed. */
 		cmd.op = IIOD_OP_RETRY_DEQUEUE_BLOCK;
 		cmd.dev = (uint8_t) iio_device_get_index(pdata->dev);
-		cmd.code = pdata->idx | (block->idx << 16);
+		cmd.code = pdata->params.idx | (block->idx << 16);
 		buf.ptr = block->data;
 		buf.size = block->bytes_used;
 

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -358,6 +358,7 @@ static void handle_create_buffer(struct parser_pdata *pdata,
 	struct buffer_entry *entry;
 	struct iio_buffer *buf;
 	struct iiod_buf data;
+ 	struct iio_buffer_params buffer_params = {0};
 	unsigned int i, nb_channels;
 	size_t nb_words;
 	int ret = -EINVAL;
@@ -428,7 +429,8 @@ static void handle_create_buffer(struct parser_pdata *pdata,
 	if (ret)
 		goto err_destroy_dequeue_task;
 
-	buf = iio_device_create_buffer(dev, entry->idx, mask);
+	buffer_params.idx = entry->idx;
+	buf = iio_device_create_buffer(dev, &buffer_params, mask);
 	ret = iio_err(buf);
 	if (ret)
 		goto err_destroy_lock;

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -104,7 +104,7 @@ struct iio_backend_ops {
 	int (*set_timeout)(struct iio_context *ctx, unsigned int timeout);
 
 	struct iio_buffer_pdata *(*create_buffer)(const struct iio_device *dev,
-						  unsigned int idx,
+						  struct iio_buffer_params *params,
 						  struct iio_channels_mask *mask);
 	void (*free_buffer)(struct iio_buffer_pdata *pdata);
 	int (*enable_buffer)(struct iio_buffer_pdata *pdata,

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -156,6 +156,34 @@ struct iio_context_params {
 	char __rsrv[32];
 };
 
+/**
+ * @enum iio_buffer_dma_allocator
+ * @brief Provides low-level control over DMA buffer allocation.
+ */
+enum iio_buffer_dma_allocator {
+	/** @brief May use scattered DMA memory (default). */
+	IIO_DMA_ALLOCATOR_SYSTEM = 0,
+
+	/** @brief Enforces contiguous DMA memory (for expert use only). */
+	IIO_DMA_ALLOCATOR_CMA_LINUX = 1,
+};
+
+/**
+ * @struct iio_buffer_params
+ * @brief Used to pass parameters to the iio_device_create_buffer function
+ */
+struct iio_buffer_params {
+	/** @brief The index of the hardware buffer. Should be 0 in most cases.
+	 * (default: 0) */
+	unsigned int idx;
+
+	/** @brief Use the allocator to allocate a DMA buffer.
+	 * In most cases, this should be set to IIO_DMA_ALLOCATOR_SYSTEM.
+	 * ONLY change this to a different option if you fully understand the
+	 * implications. (default: IIO_DMA_ALLOCATOR_SYSTEM) */
+	enum iio_buffer_dma_allocator dma_allocator;
+};
+
 /*
  * <linux/iio/types.h> header guard to protect these enums from being defined
  * twice

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1080,12 +1080,15 @@ iio_buffer_find_attr(const struct iio_buffer *buf, const char *name);
 
 /** @brief Create an input or output buffer associated to the given device
  * @param dev A pointer to an iio_device structure
- * @param idx The index of the hardware buffer. Should be 0 in most cases.
- * @param mask A pointer to an iio_channels_mask structure
+ * @param params A pointer to an iio_buffer_params structure.
+ * @param mask A pointer to an iio_channels_mask structure. If NULL is passed,
+ *        default values are used, for more information see comments in
+ *        struct iio_buffer_params.
  * @return On success, a pointer to an iio_buffer structure
  * @return On failure, a pointer-encoded error is returned */
 __api __check_ret struct iio_buffer *
-iio_device_create_buffer(const struct iio_device *dev, unsigned int idx,
+iio_device_create_buffer(const struct iio_device *dev,
+			 struct iio_buffer_params *params,
 			 const struct iio_channels_mask *mask);
 
 

--- a/include/iio/iiod-client.h
+++ b/include/iio/iiod-client.h
@@ -17,6 +17,7 @@ struct iiod_client;
 struct iiod_client_io;
 struct iiod_client_pdata;
 struct iio_event_stream_pdata;
+struct iio_buffer_params;
 
 struct iiod_client_ops {
 	ssize_t (*write)(struct iiod_client_pdata *desc,
@@ -70,7 +71,7 @@ iiod_client_create_context(struct iiod_client *client,
 __api struct iiod_client_buffer_pdata *
 iiod_client_create_buffer(struct iiod_client *client,
 			  struct iiod_client *client_fb,
-			  const struct iio_device *dev, unsigned int idx,
+			  const struct iio_device *dev, const struct iio_buffer_params *params,
 			  struct iio_channels_mask *mask);
 __api void iiod_client_free_buffer(struct iiod_client_buffer_pdata *pdata);
 __api int iiod_client_enable_buffer(struct iiod_client_buffer_pdata *pdata,

--- a/local-dmabuf.c
+++ b/local-dmabuf.c
@@ -78,13 +78,20 @@ local_create_dmabuf(struct iio_buffer_pdata *pdata, size_t size, void **data)
 		.fd_flags = O_CLOEXEC | O_RDWR,
 	};
 	struct iio_block_pdata *priv;
-	int ret, fd, devfd;
+	int ret, fd, devfd = -1;
 
 	priv = zalloc(sizeof(*priv));
 	if (!priv)
 		return iio_ptr(-ENOMEM);
 
-	devfd = open("/dev/dma_heap/system", O_RDONLY | O_CLOEXEC | O_NOFOLLOW); /* Flawfinder: ignore */
+	switch (pdata->params->dma_allocator) {
+	case IIO_DMA_ALLOCATOR_SYSTEM:
+		devfd = open("/dev/dma_heap/system", O_RDONLY | O_CLOEXEC | O_NOFOLLOW); /* Flawfinder: ignore */
+		break;
+	case IIO_DMA_ALLOCATOR_CMA_LINUX:
+		devfd = open("/dev/dma_heap/linux,cma", O_RDONLY | O_CLOEXEC | O_NOFOLLOW); /* Flawfinder: ignore */
+		break;
+	}
 	if (devfd < 0) {
 		ret = -errno;
 

--- a/local.h
+++ b/local.h
@@ -15,13 +15,14 @@
 struct iio_buffer_impl_pdata;
 struct iio_block_impl_pdata;
 struct iio_device;
+struct iio_buffer_params;
 struct timespec;
 
 struct iio_buffer_pdata {
 	const struct iio_device *dev;
 	struct iio_buffer_impl_pdata *pdata;
 	int fd, cancel_fd;
-	unsigned int idx;
+	struct iio_buffer_params *params;
 	bool dmabuf_supported;
 	bool mmap_supported;
 	size_t size;

--- a/network.c
+++ b/network.c
@@ -435,11 +435,12 @@ static int network_set_timeout(struct iio_context *ctx, unsigned int timeout)
 }
 
 static struct iio_buffer_pdata *
-network_create_buffer(const struct iio_device *dev, unsigned int idx,
+network_create_buffer(const struct iio_device *dev,
+		      struct iio_buffer_params *buffer_params,
 		      struct iio_channels_mask *mask)
 {
 	const struct iio_context *ctx = iio_device_get_context(dev);
-	const struct iio_context_params *params = iio_context_get_params(ctx);
+	const struct iio_context_params *ctx_params = iio_context_get_params(ctx);
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 	struct iio_buffer_pdata *buf;
 	int ret;
@@ -448,7 +449,7 @@ network_create_buffer(const struct iio_device *dev, unsigned int idx,
 	if (!buf)
 		return iio_ptr(-ENOMEM);
 
-	buf->io_ctx.params = params;
+	buf->io_ctx.params = ctx_params;
 	buf->io_ctx.ctx_pdata = pdata;
 	buf->dev = dev;
 
@@ -461,7 +462,7 @@ network_create_buffer(const struct iio_device *dev, unsigned int idx,
 
 	buf->pdata = iiod_client_create_buffer(buf->iiod_client,
 					       pdata->iiod_client,
-					       dev, idx, mask);
+					       dev, buffer_params, mask);
 	ret = iio_err(buf->pdata);
 	if (ret) {
 		dev_perror(dev, ret, "Unable to create buffer");

--- a/serial.c
+++ b/serial.c
@@ -226,7 +226,8 @@ static int serial_set_trigger(const struct iio_device *dev,
 }
 
 static struct iio_buffer_pdata *
-serial_create_buffer(const struct iio_device *dev, unsigned int idx,
+serial_create_buffer(const struct iio_device *dev,
+		     struct iio_buffer_params *params,
 		     struct iio_channels_mask *mask)
 {
 	const struct iio_context *ctx = iio_device_get_context(dev);
@@ -240,7 +241,7 @@ serial_create_buffer(const struct iio_device *dev, unsigned int idx,
 
 	buf->pdata = iiod_client_create_buffer(pdata->iiod_client,
 					       pdata->iiod_client,
-					       dev, idx, mask);
+					       dev, params, mask);
 	ret = iio_err(buf->pdata);
 	if (ret) {
 		dev_perror(dev, ret, "Unable to create buffer");

--- a/usb.c
+++ b/usb.c
@@ -403,11 +403,12 @@ usb_writebuf(struct iio_buffer_pdata *pdata, const void *src, size_t len)
 }
 
 static struct iio_buffer_pdata *
-usb_create_buffer(const struct iio_device *dev, unsigned int idx,
+usb_create_buffer(const struct iio_device *dev,
+		  struct iio_buffer_params *params,
 		  struct iio_channels_mask *mask)
 {
 	const struct iio_context *ctx = iio_device_get_context(dev);
-	const struct iio_context_params *params = iio_context_get_params(ctx);
+	const struct iio_context_params *ctx_params = iio_context_get_params(ctx);
 	struct iio_context_pdata *ctx_pdata = iio_context_get_pdata(ctx);
 	struct iio_buffer_pdata *buf;
 	int ret;
@@ -436,7 +437,7 @@ usb_create_buffer(const struct iio_device *dev, unsigned int idx,
 		goto err_free_ep;
 	}
 
-	buf->io_ctx.iiod_client = iiod_client_new(params, &buf->io_ctx,
+	buf->io_ctx.iiod_client = iiod_client_new(ctx_params, &buf->io_ctx,
 						  &usb_iiod_client_ops);
 	ret = iio_err(buf->io_ctx.iiod_client);
 	if (ret) {
@@ -446,7 +447,7 @@ usb_create_buffer(const struct iio_device *dev, unsigned int idx,
 
 	buf->pdata = iiod_client_create_buffer(buf->io_ctx.iiod_client,
 					       ctx_pdata->io_ctx.iiod_client,
-					       dev, idx, mask);
+					       dev, params, mask);
 	ret = iio_err(buf->pdata);
 	if (ret) {
 		dev_perror(dev, ret, "Unable to create iiod-client buffer");

--- a/utils/iio_rwdev.c
+++ b/utils/iio_rwdev.c
@@ -223,6 +223,7 @@ int main(int argc, char **argv)
 	struct iio_stream *stream;
 	const struct iio_block *block;
 	struct iio_channels_mask *mask;
+	struct iio_buffer_params buffer_params = {0};
 	const struct iio_channels_mask *hw_mask;
 	const struct iio_attr *uri, *attr;
 	struct option *opts;
@@ -437,7 +438,7 @@ int main(int argc, char **argv)
 		goto err_free_mask;
 	}
 
-	buffer = iio_device_create_buffer(dev, 0, mask);
+	buffer = iio_device_create_buffer(dev, &buffer_params, mask);
 	ret = iio_err(buffer);
 	if (ret) {
 		dev_perror(dev, ret, "Unable to allocate buffer");

--- a/utils/iio_rwdev.c
+++ b/utils/iio_rwdev.c
@@ -41,12 +41,13 @@ static const struct option options[] = {
 	  {"write", no_argument, 0, 'w'},
 	  {"cyclic", no_argument, 0, 'c'},
 	  {"benchmark", no_argument, 0, 'B'},
+	  {"cma", no_argument, 0, 'C'},
 	  {0, 0, 0, 0},
 };
 
 static const char *options_descriptions[] = {
 	"[-t <trigger>] [-b <buffer-size>]"
-		"[-s <samples>] <iio_device> [<channel> ...]",
+		"[-s <samples>] <iio_device> [<channel> ...] [-C]",
 	"Use the specified trigger.",
 	"Set the trigger to the specified rate (Hz). Default is 100 Hz.",
 	"Size of the transfer buffer. Default is 256.",
@@ -56,6 +57,7 @@ static const char *options_descriptions[] = {
 	"Use cyclic buffer mode.",
 	"Benchmark throughput."
 		"\n\t\t\tStatistics will be printed on the standard input.",
+	"Use CMA-Linux allocator for DMA buffer."
 };
 
 static struct iio_context *ctx;
@@ -205,7 +207,7 @@ static ssize_t transfer_sample(const struct iio_channel *chn,
 	return (ssize_t) nb;
 }
 
-#define MY_OPTS "t:b:s:T:r:wcB"
+#define MY_OPTS "t:b:s:T:r:wcBC"
 
 int main(int argc, char **argv)
 {
@@ -294,6 +296,9 @@ int main(int argc, char **argv)
 			break;
 		case 'w':
 			is_write = true;
+			break;
+		case 'C':
+			buffer_params.dma_allocator = IIO_DMA_ALLOCATOR_CMA_LINUX;
 			break;
 		case '?':
 			printf("Unknown argument '%c'\n", c);

--- a/utils/iio_stresstest.c
+++ b/utils/iio_stresstest.c
@@ -226,6 +226,7 @@ static void *client_thread(void *data)
 	const struct iio_device *dev;
 	const struct iio_channel *ch;
 	struct iio_channels_mask *mask;
+	struct iio_buffer_params buffer_params = {0};
 	struct timeval start, end;
 	int id = -1, stamp, r_errno;
 	ssize_t ret;
@@ -307,10 +308,11 @@ static void *client_thread(void *data)
 		if (info->verbose == VERYVERBOSE)
 			printf("%2d: Running\n", id);
 
+		buffer_params.idx = info->buffer_size;
 		i = 0;
 		while (threads_running || i == 0) {
 			info->buffers[id]++;
-			buffer = iio_device_create_buffer(dev, info->buffer_size, false);
+			buffer = iio_device_create_buffer(dev, &buffer_params, false);
 			ret = iio_err(buffer);
 			if (ret) {
 				struct timespec wait;
@@ -398,6 +400,7 @@ int main(int argc, char **argv)
 	struct iio_buffer *buffer;
 	struct iio_context *ctx;
 	struct iio_channel *ch;
+	struct iio_buffer_params buffer_params = {0};
 	struct iio_channels_mask *mask;
 	const char *name;
 	int c, pret, option_index, err;
@@ -492,7 +495,7 @@ int main(int argc, char **argv)
 							iio_channel_enable(ch, mask);
 					}
 
-					buffer = iio_device_create_buffer(dev, 0, mask);
+					buffer = iio_device_create_buffer(dev, &buffer_params, mask);
 					if (!iio_err(buffer)) {
 						iio_buffer_destroy(buffer);
 

--- a/utils/iio_stresstest.c
+++ b/utils/iio_stresstest.c
@@ -103,19 +103,21 @@ static const struct option options[] = {
 	{"samples", required_argument, 0, 's' },
 	{"duration", required_argument, 0, 'd'},
 	{"threads", required_argument, 0, 't'},
+	{"cma", no_argument, 0, 'C'},
 	{"verbose", no_argument, 0, 'v'},
 	{0, 0, 0, 0},
 };
 
 static const char *options_descriptions[] = {
 	("[-n <hostname>] [-u <vid>:<pid>] [-t <trigger>] [-b <buffer-size>] [-s <samples>]"
-		"<iio_device> [<channel> ...]"),
+		"<iio_device> [<channel> ...] [-C]"),
 	"Show this help and quit.",
 	"Use the context at the provided URI.",
 	"Size of the capture buffer. Default is 256.",
 	"Number of samples to capture, 0 = infinite. Default is 0.",
 	"Time to wait (in s) between stopping all threads",
 	"Number of Threads",
+	"Use CMA-Linux allocator for DMA buffer.",
 	"Increase verbosity (-vv and -vvv for more)",
 };
 
@@ -429,7 +431,7 @@ int main(int argc, char **argv)
 	if(!min_samples)
 		min_samples = 128;
 
-	while ((c = getopt_long(argc, argv, "hvu:b:s:t:T:",
+	while ((c = getopt_long(argc, argv, "hvu:b:s:t:T:C",
 					options, &option_index)) != -1) {
 		switch (c) {
 		case 'h':
@@ -456,6 +458,9 @@ int main(int argc, char **argv)
 			/* Max number threads 1024, min 1 */
 			info.num_threads = sanitize_clamp("threads", info.argv[info.arg_index],
 					1, 1024);
+			break;
+		case 'C':
+			buffer_params.dma_allocator = IIO_DMA_ALLOCATOR_CMA_LINUX;
 			break;
 		case 'v':
 			if (!info.verbose)


### PR DESCRIPTION
See #1260

Therefor this PR impelments the possibility to decide which block is using CMA at runtime using a newly introduce `struct iio_block_params` struct.

Reviewing of the general idea requested.