### PR TITLE
CMake: Install public header iio-backend.h along with the rest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ else()
 	set(OSX_FRAMEWORK OFF)
 endif()
 
-set(IIO_PUBLIC_HEADERS include/iio/iio.h;include/iio/iio-debug.h;include/iio/iio-lock.h;include/iio/iiod-client.h)
+set(IIO_PUBLIC_HEADERS include/iio/iio.h;include/iio/iio-debug.h;include/iio/iio-lock.h;include/iio/iiod-client.h;include/iio/iio-backend.h)
 
 if (CPP_BINDINGS)
 	list(APPEND IIO_PUBLIC_HEADERS bindings/cpp/iiopp.h)


### PR DESCRIPTION
## PR Description
Since iio-bachend.h is a also a public header, make sure it gets installed along with the other public headers.
iio-backend.h is required when defining a custom external backend within a client code.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [x] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
