### PR TITLE
python: Raise exception when an actual error occured

### DIFF
--- a/bindings/python/doc/device.rst
+++ b/bindings/python/doc/device.rst
@@ -6,15 +6,3 @@ Members
 .. autoclass:: iio.Device
    :members:
    :inherited-members:
-
-------------------
-
-Device attributes
-------------------
-.. autoclass:: iio.DeviceDebugAttr
-   :members:
-   :inherited-members:
-.. autoclass:: iio.DeviceBufferAttr
-   :members:
-   :inherited-members:
-

--- a/bindings/python/iio.py
+++ b/bindings/python/iio.py
@@ -58,7 +58,9 @@ def _check_null(result, func, arguments):
     if result:
         return result
     err = get_last_error() if "Windows" in _system() else get_errno()
-    raise OSError(err, _strerror(err))
+    if err != 0:  # The fail reason is known so raise an exception
+        raise OSError(err, _strerror(err))
+    return result
 
 
 def _check_negative(result, func, arguments):


### PR DESCRIPTION
## PR Description

When checking if the return type of a function is null, it makes sense to raise an exception when something malfunctioned. If everything worked well but the result type is nothing then it shouldn't be treated as a problem. For example, one could:
 - search for a device that isn't available on the system
 - search for a channel that a device doesn't have
 - search for an attribute that isn't available
 - etc.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
