### PR TITLE
local-dmabuf: Improve checks for DMABUF interface support

### DIFF
--- a/local-dmabuf.c
+++ b/local-dmabuf.c
@@ -139,6 +139,14 @@ local_create_dmabuf(struct iio_buffer_pdata *pdata, size_t size, void **data)
 			ret = -ENOSYS;
 		}
 
+		if (ret == -EPERM) {
+			/* If the ioctl is available, but the buffer implementation used
+			 * in the kernel driver does not provide the necessary
+			 * DMABUF iio_buffer_access_funcs, mark the DMABUF interface as
+			 * unavailable. */
+			ret = -ENOSYS;
+		}
+
 		goto err_data_unmap;
 	}
 


### PR DESCRIPTION
To create an IIO block associated with a buffer, local_create_block() attempts to use the DMABUF API, and if that fails it uses the MMAP API. However, the availability check for the DMABUF API in local_create_dmabuf() is incomplete: In recent kernels the DMABUF IOCTLs are available, but still, the DMABUF related iio_buffer_access_funcs may not be implemented for the buffer used in the kernel driver [1], [2]. In this case, the returned error is propagated through local_create_block() up to the caller and block setup fails without an attempt to use one of the alternative interfaces.
To fix this issue, add another check for the error code set by the DMABUF attach IOCTL and mark the DMABUF interface as unavailable.

[1]: https://elixir.bootlin.com/linux/v6.14.3/source/drivers/iio/industrialio-buffer.c#L1664
[2]: https://github.com/analogdevicesinc/libiio/issues/1278

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
