### PR TITLE
local: Fix disabling of IIO buffers in local_enable_buffer

### DIFF
--- a/local.c
+++ b/local.c
@@ -331,7 +331,7 @@ static int local_enable_buffer(struct iio_buffer_pdata *pdata,
 	if ((pdata->dmabuf_supported | pdata->mmap_supported) != !nb_samples)
 		return -EINVAL;
 
-	if (nb_samples) {
+	if (enable && nb_samples) {
 		ret = local_set_buffer_size(pdata, nb_samples);
 		if (ret)
 			return ret;
@@ -341,7 +341,7 @@ static int local_enable_buffer(struct iio_buffer_pdata *pdata,
 			return ret;
 	}
 
-	return local_do_enable_buffer(pdata, true);
+	return local_do_enable_buffer(pdata, enable);
 }
 
 static ssize_t local_readbuf(struct iio_buffer_pdata *buffer,


### PR DESCRIPTION
Currently local_enable_buffer() can not be used to disable IIO buffers. First, instead of propagating the value of the enable parameter to the call to local_do_enable_buffer() a hard-coded value is used. And second, setting both the buffer length and watermark attributes is attempted not only in the enable case but also in the disable case for an already active buffer. This causes local_enable_buffer() to fail early.

To fix the issue, only set buffer attributes in the enable case and properly propagate the requested action to local_do_enable_buffer().

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
