### PR TITLE
iio.h: Fix desctiption for iio_device_create_buffer()

### DIFF
--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1082,10 +1082,10 @@ iio_buffer_find_attr(const struct iio_buffer *buf, const char *name);
 
 /** @brief Create an input or output buffer associated to the given device
  * @param dev A pointer to an iio_device structure
- * @param params A pointer to an iio_buffer_params structure.
- * @param mask A pointer to an iio_channels_mask structure. If NULL is passed,
+ * @param params A pointer to an iio_buffer_params structure. If NULL is passed,
  *        default values are used, for more information see comments in
  *        struct iio_buffer_params.
+ * @param mask A pointer to an iio_channels_mask structure.
  * @return On success, a pointer to an iio_buffer structure
  * @return On failure, a pointer-encoded error is returned */
 __api __check_ret struct iio_buffer *


### PR DESCRIPTION
Only 'params' can be NULL, the 'mask' parameter needs to be a valid pointer.

## PR Description
Fix description for the parameters of iio_device_create_buffer().

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particulary complex or unclear areas
- [x] I have checked that I did not intoduced new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [x] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
