### PR TITLE
Relicense specific files under MIT license #1210

### DIFF
--- a/COPYING_MIT.txt
+++ b/COPYING_MIT.txt
@@ -1,0 +1,53 @@
+MIT License
+
+Copyright (c) 2025 Analog Devices, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Files covered by the MIT License:
+
+attr.c
+attr.h
+backend.c
+block.c
+buffer.c
+channel.c
+context.c
+device.c
+events.c
+iiod/ops.h
+iiod/responder.c
+iiod-responder.h
+iio-private.h
+include/iio/iio-backend.h
+include/iio/iio-debug.h
+include/iio/iio.h
+include/iio/iio-lock.h
+library.c
+lock-dummy.c
+mask.c
+scan.c
+sort.c
+sort.h
+stream.c
+task.c
+tinyiiod/tinyiiod.c
+tinyiiod/tinyiiod.h
+utilities.c
+xml.c

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Although libiio was primarily developed by Analog Devices Inc., it is an active 
 
 Library License : [![Library License](https://img.shields.io/badge/license-LGPL2+-blue.svg)](https://github.com/analogdevicesinc/libiio/blob/main/COPYING.txt)
 Tests/Examples License : [![Application License](https://img.shields.io/badge/license-GPL2+-blue.svg)](https://github.com/analogdevicesinc/libiio/blob/main/COPYING_GPL.txt)
+Certain Files License : [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/analogdevicesinc/libiio/blob/main/COPYING_MIT.txt)
 Latest Release : [![GitHub release](https://img.shields.io/github/release/analogdevicesinc/libiio.svg)](https://github.com/analogdevicesinc/libiio/releases/latest)
 Downloads :  [![Github All Releases](https://img.shields.io/github/downloads/analogdevicesinc/libiio/total.svg)](https://github.com/analogdevicesinc/libiio/releases/latest)
 

--- a/attr.c
+++ b/attr.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/attr.h
+++ b/attr.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-License-Identifier: MIT */
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/backend.c
+++ b/backend.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/block.c
+++ b/block.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/buffer.c
+++ b/buffer.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/channel.c
+++ b/channel.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/context.c
+++ b/context.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/device.c
+++ b/device.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/events.c
+++ b/events.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/iio-private.h
+++ b/iio-private.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-License-Identifier: MIT */
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/iiod-responder.h
+++ b/iiod-responder.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-License-Identifier: MIT */
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-License-Identifier: MIT */
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-License-Identifier: MIT */
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/include/iio/iio-debug.h
+++ b/include/iio/iio-debug.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-License-Identifier: MIT */
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/include/iio/iio-lock.h
+++ b/include/iio/iio-lock.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-License-Identifier: MIT */
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-License-Identifier: MIT */
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/library.c
+++ b/library.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/lock-dummy.c
+++ b/lock-dummy.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/mask.c
+++ b/mask.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/scan.c
+++ b/scan.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/sort.c
+++ b/sort.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/sort.h
+++ b/sort.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-License-Identifier: MIT */
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/stream.c
+++ b/stream.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/task.c
+++ b/task.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/tinyiiod/tinyiiod.c
+++ b/tinyiiod/tinyiiod.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/tinyiiod/tinyiiod.h
+++ b/tinyiiod/tinyiiod.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: LGPL-2.1-or-later */
+/* SPDX-License-Identifier: MIT */
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/utilities.c
+++ b/utilities.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/xml.c
+++ b/xml.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *


### PR DESCRIPTION
## PR Description

As part of our ongoing efforts to enhance the flexibility and usability of libiio, we are relicensing (#1210) the following files from LGPL-2.1 to the MIT license:

 - attr.c, attr.h
 - backend.c, block.c, buffer.c, channel.c, context.c, device.c, events.c
 - iiod/ops.h, iiod/responder.c, iiod-responder.h
 - iio-private.h
 - include/iio/iio-backend.h, include/iio/iio-debug.h, include/iio/iio.h, include/iio/iio-lock.h
 - library.c, lock-dummy.c, mask.c, scan.c, sort.c, sort.h, stream.c, task.c
 - tinyiiod/tinyiiod.c, tinyiiod/tinyiiod.h
 - utilities.c, xml.c

This change aims to better support environments where static linking is required, such as microcontroller and baremetal/no-OS embedded systems, and to facilitate integration with Zephyr.

The MIT license provides greater permissiveness, allowing for broader use and integration of libiio.

All contributors to those files have provided their written consent for this relicensing.

