### PR TITLE
CMake: Use linker flag -Bsymbolic only on the shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 message(STATUS "cmake version: ${CMAKE_VERSION}")
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 cmake_policy(SET CMP0048 NEW) # project() sets the VERSION variables
 project(libiio LANGUAGES C VERSION 1.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,9 +54,9 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang" AND NOT ${CMAKE_SYSTEM_NAME} STREQUA
 	# within Libiio itself first. This makes sure that the library won't
 	# call the symbols from the compat layer if the compat layer is used.
 
-	# TODO: Use cmake_link_options() in CMake 3.13+
-	SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Bsymbolic")
-	SET(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-Bsymbolic")
+	if (BUILD_SHARED_LIBS)
+		target_link_options(iio PRIVATE -Wl,-Bsymbolic)
+	endif()
 endif()
 
 if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|MSVC")

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 project(iiopp-enum LANGUAGES CXX)
 add_executable(iiopp-enum examples/iiopp-enum.cpp iiopp.h ${LIBIIO_RC})

--- a/bindings/csharp/CMakeLists.txt
+++ b/bindings/csharp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 project(libiio-sharp NONE)
 
 if (WIN32)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 project(libiio-py NONE)
 
 if(${CMAKE_VERSION} VERSION_LESS "3.12.0") 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 project(ad9361-iiostream C)
 project(ad9371-iiostream C)

--- a/iiod/CMakeLists.txt
+++ b/iiod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 project(iiod C)
 
 include(${CMAKE_SOURCE_DIR}/cmake/Utilities.cmake)

--- a/tinyiiod/CMakeLists.txt
+++ b/tinyiiod/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 project(tinyiiod C)
 
 add_library(tinyiiod STATIC

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 set(IIO_TESTS_TARGETS iio_genxml iio_info iio_attr iio_rwdev iio_reg iio_event)
 if (PTHREAD_LIBRARIES OR ANDROID)


### PR DESCRIPTION
## PR Description

-Bsymbolic is intended for dynamic linking and so it doesn't make sense to used when building a static library. User modern cmake approach to apply the flag only to the library and not globally to all targets.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [x] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
