### PR TITLE
rename iiopp.h to iio.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ endif()
 set(IIO_PUBLIC_HEADERS include/iio/iio.h;include/iio/iio-debug.h;include/iio/iio-lock.h;include/iio/iiod-client.h;include/iio/iio-backend.h)
 
 if (CPP_BINDINGS)
-	list(APPEND IIO_PUBLIC_HEADERS bindings/cpp/iiopp.h)
+	list(APPEND IIO_PUBLIC_HEADERS bindings/cpp/iio.hpp)
 endif()
 
 set_target_properties(iio PROPERTIES

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 project(iiopp-enum LANGUAGES CXX)
-add_executable(iiopp-enum examples/iiopp-enum.cpp iiopp.h ${LIBIIO_RC})
+add_executable(iiopp-enum examples/iiopp-enum.cpp ${LIBIIO_RC})
 target_include_directories(iiopp-enum PRIVATE ./)
 set_target_properties(iiopp-enum PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 target_link_libraries(iiopp-enum iio)

--- a/bindings/cpp/CMakeLists.txt
+++ b/bindings/cpp/CMakeLists.txt
@@ -1,7 +1,49 @@
 cmake_minimum_required(VERSION 3.13)
-
 project(iiopp-enum LANGUAGES CXX)
+
+# Prefer, but do not require, C++17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED OFF)
+
+include(CheckCXXSourceCompiles)
+
+# Check for std::optional
+check_cxx_source_compiles("
+    #include <optional>
+    int main() {
+        std::optional<int> o;
+        return 0;
+    }
+" HAS_STD_OPTIONAL)
+
+if(NOT HAS_STD_OPTIONAL)
+    find_package(Boost COMPONENTS optional REQUIRED)
+    if(Boost_FOUND)
+        set(CMAKE_REQUIRED_INCLUDES ${Boost_INCLUDE_DIRS})
+        check_cxx_source_compiles("
+            #include <boost/optional.hpp>
+            int main() {
+                boost::optional<int> o;
+                return 0;
+            }
+        " HAS_BOOST_OPTIONAL)
+        unset(CMAKE_REQUIRED_INCLUDES)
+        if(HAS_BOOST_OPTIONAL)
+            set(USE_BOOST_OPTIONAL TRUE)
+        else()
+            message(FATAL_ERROR "Neither std::optional nor boost::optional is available")
+        endif()
+    else()
+        message(FATAL_ERROR "Boost not found and std::optional is unavailable")
+    endif()
+else()
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
 add_executable(iiopp-enum examples/iiopp-enum.cpp ${LIBIIO_RC})
 target_include_directories(iiopp-enum PRIVATE ./)
-set_target_properties(iiopp-enum PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
-target_link_libraries(iiopp-enum iio)
+target_link_libraries(iiopp-enum PRIVATE iio)
+
+if(USE_BOOST_OPTIONAL)
+    target_include_directories(iiopp-enum PRIVATE ${Boost_INCLUDE_DIRS})
+endif()

--- a/bindings/cpp/examples/iiopp-enum.cpp
+++ b/bindings/cpp/examples/iiopp-enum.cpp
@@ -9,7 +9,7 @@
  * Author: Tilman Blumhagen <tilman.blumhagen@difitec.de>
  */
 
-#include <iiopp.h>
+#include <iio.hpp>
 
 #include <iostream>
 #include <iomanip>

--- a/bindings/cpp/iio.hpp
+++ b/bindings/cpp/iio.hpp
@@ -6,7 +6,7 @@
  * Author: Tilman Blumhagen <tilman.blumhagen@difitec.de>
  */
 
-/** @file iiopp.h
+/** @file iio.hpp
  * @brief Public C++ interface
  *
  * @see @ref iiopp

--- a/mainpage.dox
+++ b/mainpage.dox
@@ -27,7 +27,7 @@ The basic bricks of the libiio API are the iio_context, iio_device, iio_channel 
 - A iio_device object may be associated with one iio_buffer object, and a iio_buffer object is associated with only one iio_device.
 
 @if CPP_BINDINGS
-A C++ API is provided in @ref iiopp.h
+A C++ API is provided in @ref iio.hpp
 @endif
 
 @section scan_contexts Scanning for IIO contexts


### PR DESCRIPTION
Rename the cpp header file to better match standard conventions.
 - This matches the project name, avoids confusion, and follows the common convention of .h for C headers and .hpp for C++ headers.
 - Anyone looking at the two files will immediately understand iio.h is for C, iio.hpp is for C++.
 - This leaves the namespace as the existing iiopp, to avoid too much pain for those using things.


