### PR TITLE
python: Remove deprecated license classifier. Use 'license' key instead.

### DIFF
--- a/bindings/python/setup.py.cmakein
+++ b/bindings/python/setup.py.cmakein
@@ -88,9 +88,9 @@ config.update(
         url="https://github.com/analogdevicesinc/libiio",
         py_modules=["iio"],
         cmdclass={"install": InstallWrapper},
+        license="LGPL-2.1-or-later",
         classifiers=[
             "Programming Language :: Python :: 3",
-            "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
             "Operating System :: OS Independent",
         ],
     )


### PR DESCRIPTION
## PR Description

Closes #1291.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
