### PR TITLE
usb: Fix warning generated by newer version of MSVC

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -149,7 +149,7 @@ static int usb_reset_pipes(struct iio_context_pdata *pdata)
 			unsigned int timeout)
 */
 	ret = libusb_control_transfer(pdata->hdl,
-			LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_INTERFACE,
+			(uint8_t)LIBUSB_REQUEST_TYPE_VENDOR | (uint8_t)LIBUSB_RECIPIENT_INTERFACE,
 			IIO_USD_CMD_RESET_PIPES,
 			0,
 			pdata->intrfc,
@@ -176,7 +176,7 @@ static int usb_open_pipe(struct iio_context_pdata *pdata, uint16_t pipe_id)
 */
 	ret = libusb_control_transfer(
 			pdata->hdl,
-			LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_INTERFACE,
+			(uint8_t)LIBUSB_REQUEST_TYPE_VENDOR | (uint8_t)LIBUSB_RECIPIENT_INTERFACE,
 			IIO_USD_CMD_OPEN_PIPE,
 			pipe_id,
 			pdata->intrfc,
@@ -192,8 +192,8 @@ static int usb_close_pipe(struct iio_context_pdata *pdata, uint16_t pipe_id)
 {
 	int ret;
 
-	ret = libusb_control_transfer(pdata->hdl, LIBUSB_REQUEST_TYPE_VENDOR |
-		LIBUSB_RECIPIENT_INTERFACE, IIO_USD_CMD_CLOSE_PIPE,
+	ret = libusb_control_transfer(pdata->hdl, (uint8_t)LIBUSB_REQUEST_TYPE_VENDOR |
+		(uint8_t)LIBUSB_RECIPIENT_INTERFACE, IIO_USD_CMD_CLOSE_PIPE,
 		pipe_id, pdata->intrfc, NULL, 0, USB_PIPE_CTRL_TIMEOUT);
 	if (ret < 0)
 		return -(int) libusb_to_errno(ret);


### PR DESCRIPTION
## PR Description
Warning:
D:\a\1\s\usb.c(152,31): error C2220: the following warning is treated as an error [D:\a\1\s\build-msvc\iio.vcxproj] D:\a\1\s\usb.c(152,31): warning C5287: operands are different enum types 'libusb_request_type' and 'libusb_request_recipient'; use an explicit cast to silence this warning [D:\a\1\s\build-msvc\iio.vcxproj]
      D:\a\1\s\usb.c(152,31):
      to simplify migration, consider the temporary use of /Wv:18 flag with the version of the compiler with which you used to build without warnings

Use cast to silence the warnings as they are treated as errors when build is done on CI.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas
- [ ] I have checked that I did not intoduced new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
