### PR TITLE
utilities: Remove unused function iio_list_has_elemt()

### DIFF
--- a/iio-private.h
+++ b/iio-private.h
@@ -208,8 +208,6 @@ bool iio_device_is_tx(const struct iio_device *dev);
 int read_double(const char *str, double *val);
 int write_double(char *buf, size_t len, double val);
 
-bool iio_list_has_elem(const char *list, const char *elem);
-
 struct iio_context *
 iio_create_dynamic_context(const struct iio_context_params *params,
 			   const char *uri);

--- a/utilities.c
+++ b/utilities.c
@@ -359,27 +359,6 @@ ssize_t __iio_printf iio_snprintf(char *buf, size_t len, const char *fmt, ...)
 	return (ssize_t)ret;
 }
 
-bool iio_list_has_elem(const char *list, const char *elem)
-{
-	const char *ptr;
-
-	if (!list)
-		return false;
-
-	while (true) {
-		ptr = strchr(list, ',');
-		if (!ptr)
-			return !strcmp(list, elem);
-
-		if (!strncmp(list, elem,
-			     (uintptr_t) ptr - (uintptr_t) list)) {
-			return true;
-		}
-
-		list = ptr + 1;
-	}
-}
-
 void iio_prm_printf(const struct iio_context_params *params,
 		    enum iio_log_level msg_level,
 		    const char *fmt, ...)


### PR DESCRIPTION
## PR Description
iio_list_has_elems() isn't used anywhere.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
