### PR TITLE
utils: Fix iio_device_create_buffer() called with wrong parameters

### DIFF
--- a/utils/iio_stresstest.c
+++ b/utils/iio_stresstest.c
@@ -310,11 +310,10 @@ static void *client_thread(void *data)
 		if (info->verbose == VERYVERBOSE)
 			printf("%2d: Running\n", id);
 
-		buffer_params.idx = info->buffer_size;
 		i = 0;
 		while (threads_running || i == 0) {
 			info->buffers[id]++;
-			buffer = iio_device_create_buffer(dev, &buffer_params, false);
+			buffer = iio_device_create_buffer(dev, &buffer_params, mask);
 			ret = iio_err(buffer);
 			if (ret) {
 				struct timespec wait;


### PR DESCRIPTION
## PR Description
Update the call of `iio_device_create_buffer()` to match its v1.0 signature.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
