### PR TITLE
utils: Fix improper end of option list

### DIFF
--- a/utils/iio_info.c
+++ b/utils/iio_info.c
@@ -36,7 +36,7 @@ static struct iio_context *ctx;
 static const struct option options[] = {
 	{ "read-debug-attr", no_argument, NULL, 'd' },
 	{ "no-read-attr", no_argument, NULL, 'n' },
-	{ }
+	{0, 0, 0, 0},
 };
 
 static const char *options_descriptions[] = {


### PR DESCRIPTION
## PR Description

The following build error was caught only by the MSVC 2019 compiler:
`libiio\utils\iio_info.c(39,4): error C2059: syntax error: '}'`

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
