### PR TITLE
attr: Fix context attributes getting out of sync with their values

### DIFF
--- a/attr.c
+++ b/attr.c
@@ -291,6 +291,25 @@ int iio_context_add_attr(struct iio_context *ctx,
 		return ret;
 	}
 
+	/* Keep attr values in sync with the names which just got sorted in iio_add_attr() */
+	unsigned int j, new_idx = ctx->attrlist.num - 1;
+
+	/* Find the new index of the added attr */
+	for (j = 0; j < ctx->attrlist.num - 1; j++) {
+		if (!strcmp(ctx->attrlist.attrs[j].name, key)) {
+			new_idx = j;
+			break;
+		}
+	}
+
+	/* If the new position is not at the end, it was inserted at a position
+	causing subsequent attributes to shift forward as they were already sorted */
+	if (new_idx != ctx->attrlist.num - 1) {
+		memmove(&ctx->values[new_idx + 1], &ctx->values[new_idx],
+			(ctx->attrlist.num - new_idx - 1) * sizeof(*ctx->values));
+		ctx->values[new_idx] = new_val;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
## PR Description

Each time a context attribute is added, its value gets appended to a list of values while its name gets appended to a list of names.  But since the names list gets sorted and the values list doesn't, the two lists can become misaligned.

To fix this, after sorting, find where the newly added attribute was inserted. Because the list gets sorted each time a new attribute is added we know attributes positioned after the newly inserted attributes just get shifted towards the end of the list. So we do the same for the values.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
