### PR TITLE
xml: Call xmlMemoryDump() only if not deprecated

### DIFF
--- a/xml.c
+++ b/xml.c
@@ -456,5 +456,7 @@ void libiio_cleanup_xml_backend(void)
 	 * detect a memory leak.
 	 */
 	xmlCleanupParser();
+#if LIBXML_VERSION < 21200  /* Version 2.12.0 */
 	xmlMemoryDump();
+#endif
 }


### PR DESCRIPTION
## PR Description
xmlMemoryDump() has been deprecated since version 2.12.0. See: https://github.com/GNOME/libxml2/blob/master/NEWS
This triggers a compile warning which is treated as error in the CI builds.

Closes #1323 

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
