### PR TITLE
iiod-client: Export Event symbols

### DIFF
--- a/include/iio/iiod-client.h
+++ b/include/iio/iiod-client.h
@@ -93,11 +93,11 @@ __api ssize_t iiod_client_readbuf(struct iiod_client_buffer_pdata *pdata,
 __api ssize_t iiod_client_writebuf(struct iiod_client_buffer_pdata *pdata,
 				   const void *src, size_t len);
 
-struct iio_event_stream_pdata *
+__api struct iio_event_stream_pdata *
 iiod_client_open_event_stream(struct iiod_client *client,
 			      const struct iio_device *dev);
-void iiod_client_close_event_stream(struct iio_event_stream_pdata *pdata);
-int iiod_client_read_event(struct iio_event_stream_pdata *pdata,
+__api void iiod_client_close_event_stream(struct iio_event_stream_pdata *pdata);
+__api int iiod_client_read_event(struct iio_event_stream_pdata *pdata,
 			   struct iio_event *out_event,
 			   bool nonblock);
 


### PR DESCRIPTION
## PR Description

Building the source with cmake with WITH_MODULES=ON would fail in windows due to not finding events related functions. Exporting them as symbols would resolve the issue.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
