### PR TITLE
bindings/csharp: Update C# API that binds with the builtin backends api

### DIFF
--- a/bindings/csharp/Context.cs
+++ b/bindings/csharp/Context.cs
@@ -50,61 +50,6 @@ namespace iio
         }
     }
 
-    /// <summary>
-    /// Represents the log levels for IIO.
-    /// </summary>
-    public enum IioLogLevel
-    {
-        NoLog = 1,
-        Error = 2,
-        Warning = 3,
-        Info = 4,
-        Debug = 5
-    }
-
-    /// <summary>
-    /// Represents the parameters for creating an IIO context.
-    /// </summary>
-    [StructLayout(LayoutKind.Sequential)]
-    public struct IioContextParams
-    {
-        /// <summary>
-        /// Handle to the standard output. If null, defaults to stdout.
-        /// </summary>
-        public IntPtr Out;
-
-        /// <summary>
-        /// Handle to the error output. If null, defaults to stderr.
-        /// </summary>
-        public IntPtr Err;
-
-        /// <summary>
-        /// Log level to use. Defaults to the log level specified at compilation.
-        /// </summary>
-        public IioLogLevel LogLevel;
-
-        /// <summary>
-        /// Log level threshold for sending messages to stderr.
-        /// </summary>
-        public IioLogLevel StderrLevel;
-
-        /// <summary>
-        /// Log level threshold for including timestamps in messages.
-        /// </summary>
-        public IioLogLevel TimestampLevel;
-
-        /// <summary>
-        /// Timeout for I/O operations in milliseconds. If zero, the default timeout is used.
-        /// </summary>
-        public uint TimeoutMs;
-
-        /// <summary>
-        /// Reserved for future fields. Must remain unused.
-        /// </summary>
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
-        public byte[] Reserved;
-    }
-
     /// <summary><see cref="iio.Context"/> class:
     /// Contains the representation of an IIO context.</summary>
     public class Context : IIOObject

--- a/bindings/csharp/IioLib.cs
+++ b/bindings/csharp/IioLib.cs
@@ -67,6 +67,61 @@ namespace iio
         }
     }
 
+    /// <summary>
+    /// Represents the log levels for IIO.
+    /// </summary>
+    public enum IioLogLevel
+    {
+        NoLog = 1,
+        Error = 2,
+        Warning = 3,
+        Info = 4,
+        Debug = 5
+    }
+
+    /// <summary>
+    /// Represents the parameters for creating an IIO context.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct IioContextParams
+    {
+        /// <summary>
+        /// Handle to the standard output. If null, defaults to stdout.
+        /// </summary>
+        public IntPtr Out;
+
+        /// <summary>
+        /// Handle to the error output. If null, defaults to stderr.
+        /// </summary>
+        public IntPtr Err;
+
+        /// <summary>
+        /// Log level to use. Defaults to the log level specified at compilation.
+        /// </summary>
+        public IioLogLevel LogLevel;
+
+        /// <summary>
+        /// Log level threshold for sending messages to stderr.
+        /// </summary>
+        public IioLogLevel StderrLevel;
+
+        /// <summary>
+        /// Log level threshold for including timestamps in messages.
+        /// </summary>
+        public IioLogLevel TimestampLevel;
+
+        /// <summary>
+        /// Timeout for I/O operations in milliseconds. If zero, the default timeout is used.
+        /// </summary>
+        public uint TimeoutMs;
+
+        /// <summary>
+        /// Reserved for future fields. Must remain unused.
+        /// </summary>
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+        public byte[] Reserved;
+    }
+
     public abstract class IIOObject : IDisposable
     {
         internal IntPtr hdl;
@@ -121,13 +176,13 @@ namespace iio
 
         [DllImport(IioLib.dllname, CallingConvention = CallingConvention.Cdecl)]
         [return: MarshalAs(UnmanagedType.I1)]
-        private static extern bool iio_has_backend([In()] string backend);
+        private static extern bool iio_has_backend(IntPtr ctx_params, [In()] string backend);
 
         [DllImport(IioLib.dllname, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int iio_get_backends_count();
+        private static extern int iio_get_builtin_backends_count();
 
         [DllImport(IioLib.dllname, CallingConvention = CallingConvention.Cdecl)]
-        private static extern IntPtr iio_get_backend(uint index);
+        private static extern IntPtr iio_get_builtin_backend(uint index);
 
         /// <summary>Get a description of a negative error code.</summary>
         /// <param name="err">Negative error code.</param>
@@ -150,19 +205,44 @@ namespace iio
             if (backend == null)
                 throw new IIOException("The backend string should not be null!");
 
-            return iio_has_backend(backend);
+            return iio_has_backend(IntPtr.Zero, backend);
         }
 
-        /// <summary>Gets the total number of available backends.</summary>
-        public static int get_backends_count()
+        /// <summary>Checks if the given backend is available or not.</summary>
+        /// <param name="ctx_params">Context parameters.</param>
+        /// <param name="backend">The backend's name.</param>
+        public static bool has_backend(IioContextParams ctx_params, string backend)
         {
-            return iio_get_backends_count();
+            if (backend == null)
+                throw new IIOException("The backend string should not be null!");
+
+            // Allocate unmanaged memory for the structure
+            IntPtr contextParamsPtr = Marshal.AllocHGlobal(Marshal.SizeOf<IioContextParams>());
+            try
+            {
+                // Copy the managed structure to unmanaged memory
+                Marshal.StructureToPtr(ctx_params, contextParamsPtr, false);
+
+                // Call the native function
+                return iio_has_backend(contextParamsPtr, backend);
+            }
+            finally
+            {
+                // Free the unmanaged memory
+                Marshal.FreeHGlobal(contextParamsPtr);
+            }
         }
 
-        /// <summary>Gets the backend from the given index.</summary>
-        public static string get_backend(uint index)
+        /// <summary>Gets the total number of available builtin backends.</summary>
+        public static int get_builtin_backends_count()
         {
-            return Marshal.PtrToStringAnsi(iio_get_backend(index));
+            return iio_get_builtin_backends_count();
+        }
+
+        /// <summary>Gets the builtin backend from the given index.</summary>
+        public static string get_builtin_backend(uint index)
+        {
+            return Marshal.PtrToStringAnsi(iio_get_builtin_backend(index));
         }
     }
 }


### PR DESCRIPTION
## PR Description

The current C# bindings were still calling the libiio v0 api. Update to use the v1 api:
`iio_has_backend()` needs updating as it now takes an extra argument
`iio_get_backends_count()` and `iio_get_backend()` need renaming

This results in renaming the C# API as well to match the C API.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
