### PR TITLE
local: Properly initialize device fd

### DIFF
--- a/local.c
+++ b/local.c
@@ -1433,7 +1433,7 @@ local_open_fd(const struct iio_device *dev, bool events, unsigned int idx)
 	iio_mutex_lock(lock);
 
 	dev_fd = dev->pdata->fd;
-	open_dev_fd = !dev_fd;
+	open_dev_fd = dev_fd < 0;
 
 	if (open_dev_fd) {
 		dev_fd = open(buf, O_RDWR | O_CLOEXEC | O_NONBLOCK);
@@ -1471,7 +1471,7 @@ static void local_close_fd(const struct iio_device *dev, int fd)
 
 	iio_mutex_lock(lock);
 	if (dev->pdata->fd == fd)
-		dev->pdata->fd = 0;
+		dev->pdata->fd = -1;
 
 	close(fd);
 	iio_mutex_unlock(lock);
@@ -1789,6 +1789,7 @@ static int init_devices(struct iio_context *ctx)
 		dev->pdata = calloc(1, sizeof(*dev->pdata));
 		if (!dev->pdata)
 			return -ENOMEM;
+		dev->pdata->fd = -1;
 	}
 
 	return 0;


### PR DESCRIPTION
## PR Description

During device initialization iio_device_pdata is not explicitly initialized after allocation. This may leave pdata->fd initialized to 0, which is a valid file descriptor, corresponding to stdin of the calling process. Later, in local_shutdown(), which is called during iio_context_destroy(), closing of file descriptors of all IIO devices is attempted. This effectively closes fd 0 of the calling process, making it available for reallocation whenever a new file descriptor is requested. This can have unintended side effects, because now, stdin of the calling process is referring to a file that was not meant to be used in that role.

To prevent accidental fd operations, initialize iio_device_pdata.fd to -1, an invalid file descriptor.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
