### PR TITLE
Fix iio_info crashing when scanning for contexts on Windows

### DIFF
--- a/dns_sd_windows.c
+++ b/dns_sd_windows.c
@@ -339,6 +339,7 @@ int dnssd_find_hosts(const struct iio_context_params *params,
 	const char service[] = "_iio._tcp.local";
 	size_t rec, records, capacity = 2048;
 	struct dns_sd_discovery_data *d;
+	struct dns_sd_cb_data cb_data;
 	unsigned int isock, num_sockets;
 	void *buffer;
 	int sockets[32];
@@ -366,6 +367,9 @@ int dnssd_find_hosts(const struct iio_context_params *params,
 	ret = iio_err(d->lock);
 	if (ret)
 		goto out_wsa_cleanup;
+
+	cb_data.d = d;
+	cb_data.params = params;
 
 	buffer = malloc(capacity);
 	if (!buffer)
@@ -421,7 +425,7 @@ int dnssd_find_hosts(const struct iio_context_params *params,
 				if (FD_ISSET(sockets[isock], &readfs)) {
 					rec = mdns_query_recv(sockets[isock], buffer,
 							      capacity, query_callback,
-							      d, transaction_id[isock]);
+							      &cb_data, transaction_id[isock]);
 					if (rec > 0)
 						records += rec;
 				}


### PR DESCRIPTION
## PR Description

Fix a critical access violation that occurred when `iio_mutex_lock(dd->lock)`
was called in the `query_callback` function. The crash was caused by a data
type mismatch in the callback mechanism:

- The query_callback function expected `user_data` to be a `dns_sd_cb_data*`
- However, `mdns_query_recv` was passing a `dns_sd_discovery_data*` directly
- This caused invalid memory access when trying to dereference `cb_data->d`

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
