### PR TITLE
CI: Update name of the libxml dll used in the MinGW job

### DIFF
--- a/CI/publish_deps.ps1
+++ b/CI/publish_deps.ps1
@@ -5,7 +5,7 @@ $ErrorView = "NormalView"
 if ("$Env:COMPILER" -eq "MinGW Makefiles") {
 	cp C:\msys64\mingw64\bin\libserialport-0.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 	cp C:\msys64\mingw64\bin\libusb-1.0.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
-	cp C:\msys64\mingw64\bin\libxml2-2.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
+	cp C:\msys64\mingw64\bin\libxml2-16.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 	cp C:\msys64\mingw64\bin\libzstd.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 	cp C:\msys64\mingw64\bin\libgcc_s_seh-1.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY
 	cp C:\msys64\mingw64\bin\libiconv-2.dll $env:BUILD_ARTIFACTSTAGINGDIRECTORY


### PR DESCRIPTION
## PR Description
MSYS2’s libxml2 package changed. The runtime DLL was renamed from libxml2-2.dll to libxml2-16.dll.
https://discourse.gnome.org/t/libxml2-2-14-0-released/28025

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
