### PR TITLE
usb: Fix warning generated by newer version of MSVC

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -158,7 +158,7 @@ static int usb_reset_pipes(struct iio_context_pdata *pdata)
 			unsigned int timeout)
 */
 	ret = libusb_control_transfer(pdata->hdl,
-			LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_INTERFACE,
+			(uint8_t)LIBUSB_REQUEST_TYPE_VENDOR | (uint8_t)LIBUSB_RECIPIENT_INTERFACE,
 			IIO_USD_CMD_RESET_PIPES,
 			0,
 			pdata->intrfc,
@@ -185,7 +185,7 @@ static int usb_open_pipe(struct iio_context_pdata *pdata, uint16_t pipe_id)
 */
 	ret = libusb_control_transfer(
 			pdata->hdl,
-			LIBUSB_REQUEST_TYPE_VENDOR | LIBUSB_RECIPIENT_INTERFACE,
+			(uint8_t)LIBUSB_REQUEST_TYPE_VENDOR | (uint8_t)LIBUSB_RECIPIENT_INTERFACE,
 			IIO_USD_CMD_OPEN_PIPE,
 			pipe_id,
 			pdata->intrfc,
@@ -201,8 +201,8 @@ static int usb_close_pipe(struct iio_context_pdata *pdata, uint16_t pipe_id)
 {
 	int ret;
 
-	ret = libusb_control_transfer(pdata->hdl, LIBUSB_REQUEST_TYPE_VENDOR |
-		LIBUSB_RECIPIENT_INTERFACE, IIO_USD_CMD_CLOSE_PIPE,
+	ret = libusb_control_transfer(pdata->hdl, (uint8_t)LIBUSB_REQUEST_TYPE_VENDOR |
+		(uint8_t)LIBUSB_RECIPIENT_INTERFACE, IIO_USD_CMD_CLOSE_PIPE,
 		pipe_id, pdata->intrfc, NULL, 0, USB_PIPE_CTRL_TIMEOUT);
 	if (ret < 0)
 		return -(int) libusb_to_errno(ret);


### PR DESCRIPTION
## PR Description

Fixes the warnings (which are treated as errors) reported by the MSVC2022 CI job.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
