### PR TITLE
CMake: Bring back lost NO_THREADS definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,6 +626,12 @@ else ()
 	target_sources(iio PRIVATE lock.c)
 endif()
 
+if (WITH_LIBTINYIIOD)
+	set(NO_THREADS 1)
+else()
+	set(NO_THREADS 0)
+endif()
+
 if (IIOD_CLIENT OR WITH_IIOD OR WITH_LIBTINYIIOD)
 	add_library(iiod-responder STATIC iiod-responder.c)
 	target_include_directories(iiod-responder PRIVATE include ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
During the latest cmake options refactoring the NO_THREADS cmake option should have been downgraded from option to a simple definition but instead it was removed entirely.
Bring it back and add NO_THREADS definition when building TINYIIOD.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
