### PR TITLE
Set ENABLE_PACKAGING on build example, add nuance on Python Virtual Environment usage

### DIFF
--- a/README_BUILD.md
+++ b/README_BUILD.md
@@ -146,6 +146,23 @@ Note: Some things (specifically building doc)  need to find libiio or the bindin
 That means that you configure (with -DWITH_DOC=OFF), build, install, configure
 (with -DWITH_DOC=ON), build again to get the doc. If you have issues, please ask.
 
+### Python Virtual Environment
+
+The python binding (iio.py) is installed to /usr/lib/python3.X/site-packages,
+which is not on path inside python virtual environments.
+
+A simple solution is to add it to one of the sources paths by virtual environment:
+
+```
+analog@precision:~/some/library$ python3 -m venv venv
+analog@precision:~/some/library$ source venv/bin/activate
+analog@precision:~/some/library$ python3 -c "import sys; print('\n'.join(sys.path))"
+...
+/home/analog/some/library/venv/lib/python3.x/site-packages
+/home/analog/some/library
+
+analog@precision:~/some/library$ ln -s /usr/lib/python3.x/site-packages/iio.py
+```
 
 ## Notes
 

--- a/README_BUILD.md
+++ b/README_BUILD.md
@@ -125,11 +125,19 @@ Cmake Options       | Default | Description                                    |
 ```shell
 analog@precision:~/libiio$ mkdir build
 analog@precision:~/libiio/build$ cd build
-analog@precision:~/libiio/build$ cmake ../ -DCPP_BINDINGS=ON -DPYTHON_BINDINGS=ON
+analog@precision:~/libiio/build$ cmake ../ -DCPP_BINDINGS=ON -DPYTHON_BINDINGS=ON -DENABLE_PACKAGING=ON
 analog@precision:~/libiio/build$ make -j$(nproc)
 ```
 
 ## Install
+If using the .deb/.rpm
+```shell
+analog@precision:~/libiio/build$ make package
+analog@precision:~/libiio/build$ sudo apt install libiio-*.deb
+analog@precision:~/libiio/build$ sudo dnf install libiio-*.rpm
+```
+
+Or directly
 ```shell
 analog@precision:~/libiio/build$ sudo make install
 ```


### PR DESCRIPTION
## PR Description
Put ENABLE_PACKAGING .deb/.rpm before the `sudo make install`
alternative, to have higher precedence. We should recommend a install
method that allows for easy uninstall, even if the build files are
deleted.

For the python binding, explain how to add to path.
Another alternative is --system-site-packages, but that assumes the user
system environment is not messed-up already, so just recommend exposing
the binding file.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
