### PR TITLE
Added iio_buffer_release() which enqueues the last dequeued buffer back to the kernel

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -120,6 +120,16 @@ int iio_buffer_set_blocking_mode(struct iio_buffer *buffer, bool blocking)
 	return iio_device_set_blocking_mode(buffer->dev, blocking);
 }
 
+ssize_t iio_buffer_release(struct iio_buffer *buffer)
+{
+	const struct iio_device *dev = buffer->dev;
+	ssize_t ret = 0;
+	if (dev->ctx->ops->release_buffer) {
+		ret = dev->ctx->ops->release_buffer(dev, &buffer->buffer, buffer->length);
+	}
+	return ret;
+}
+
 ssize_t iio_buffer_refill(struct iio_buffer *buffer)
 {
 	ssize_t read;

--- a/iio-backend.h
+++ b/iio-backend.h
@@ -42,7 +42,8 @@ struct iio_backend_ops {
 	ssize_t (*get_buffer)(const struct iio_device *dev,
 			void **addr_ptr, size_t bytes_used,
 			uint32_t *mask, size_t words);
-
+	ssize_t (*release_buffer)(const struct iio_device *dev,
+			void **addr_ptr, size_t bytes_used);
 	ssize_t (*read_device_attr)(const struct iio_device *dev,
 			const char *attr, char *dst, size_t len, enum iio_attr_type);
 	ssize_t (*write_device_attr)(const struct iio_device *dev,

--- a/iio.h
+++ b/iio.h
@@ -1509,6 +1509,20 @@ __api __check_ret int iio_buffer_get_poll_fd(struct iio_buffer *buf);
  */
 __api __check_ret int iio_buffer_set_blocking_mode(struct iio_buffer *buf, bool blocking);
 
+/** @brief Releases the last dequeued buffer back to the kernel.
+ *         This is optional since it is implicitly called inside iio_buffer_refill().
+ * 		   This is only applicable to the **local** backend.
+ * 		   This may be useful when manually waiting on data, for example using poll()
+ * 		   on the file descriptor returned by iio_buffer_get_poll_fd() and when the 
+ * 		   number of kernel buffers set by iio_device_set_kernel_buffers_count() is 
+ * 		   exactly 1. Otherwise the expected usage is to call iio_buffer_refill(), then
+ * 		   once actioned, call iio_buffer_release().
+ * @param buf A pointer to an iio_buffer structure
+ * @return On success, returns 0
+ * @return On error, a negative errno code is returned
+ *
+ * <b>NOTE:</b> Only valid for input buffers */
+__api __check_ret ssize_t iio_buffer_release(struct iio_buffer *buf);
 
 /** @brief Fetch more samples from the hardware
  * @param buf A pointer to an iio_buffer structure


### PR DESCRIPTION
## PR Description

Added the `iio_buffer_release()` function which enqueues the last dequeued buffer back to the kernel.
This is only applicable to the local backend and when using the MMAP API.
The implementation of this function in the local backend is essentially copy-pasted from the first part of `local_get_buffer()`.
The use of this function is totally optional and indeed only valid for local and MMAP.
The motivation for this function is when manually calling `poll()` or `select()` on the file descriptor returned by `iio_buffer_get_poll_fd()`. If there is only 1 kernel buffer and it hasn't yet been enqueued back to the kernel then a call to poll() will hang. This is where this function comes in handy. If you first call `iio_buffer_release()` then call `poll()` it will work.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [x] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
