### PR TITLE
Enable re-reading the channel data format

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -414,6 +414,25 @@ const struct iio_data_format * iio_channel_get_data_format(
 	return &chn->format;
 }
 
+int iio_channel_refresh_data_format(struct iio_channel *chn)
+{
+	const struct iio_device *dev;
+	const struct iio_context *ctx;
+
+	if (!chn)
+		return -EINVAL;
+
+	dev = iio_channel_get_device(chn);
+	if (!dev)
+		return -EINVAL;
+
+	ctx = iio_device_get_context(dev);
+	if (!ctx || !ctx->ops || !ctx->ops->refresh_format)
+		return -ENOSYS;
+
+	return ctx->ops->refresh_format(chn);
+}
+
 bool iio_channel_is_enabled(const struct iio_channel *chn,
 			    const struct iio_channels_mask *mask)
 {

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -138,6 +138,8 @@ struct iio_backend_ops {
 	int (*read_ev)(struct iio_event_stream_pdata *pdata,
 		       struct iio_event *out_event,
 		       bool nonblock);
+
+	int (*refresh_format)(struct iio_channel *chn);
 };
 
 /**

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1606,6 +1606,13 @@ __api __check_ret __pure long iio_channel_get_index(const struct iio_channel *ch
 __api __check_ret __cnst const struct iio_data_format * iio_channel_get_data_format(
 		const struct iio_channel *chn);
 
+/** @brief Refresh the data format for a given channel
+ * @param chn A pointer to an iio_channel structure
+ * @return On error, a negative errno code is returned. -ENOSYS if
+ *         operation is not supported.
+ */
+__api __check_ret int iio_channel_refresh_data_format(struct iio_channel *chn);
+
 
 /** @brief Convert the sample from hardware format to host format
  * @param chn A pointer to an iio_channel structure


### PR DESCRIPTION
## PR Description

The problem:

The scan-element format (e.g. le:S24/32>>0 vs le:S20/32>>0) can change at runtime when users modify oversampling / resolution attributes. Libiio caches the original type string at context creation time with no means of changing it afterwards.
This could affect downstream size calculations and conversion logic.

The fix:
 - Add public API: iio_channel_refresh_data_format() - explicit manual refresh
 - A refresh on all relevant channels is done right before buffer enable. This guarantees format correctness at the moment streaming starts.

Note: this implementation targets only the local backend. The rest of the backends need to be updated as well.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
