### PR TITLE
utils: iio_rwdev: no error on missing trigger frequency attr

### DIFF
--- a/utils/iio_rwdev.c
+++ b/utils/iio_rwdev.c
@@ -387,9 +387,7 @@ int main(int argc, char **argv)
 
 		if (!attr || iio_attr_write_longlong(attr, trigger_rate) < 0) {
 			attr = iio_device_find_attr(trigger, "frequency");
-			if (!attr)
-				ret = -ENOENT;
-			else
+			if (attr)
 				ret = iio_attr_write_longlong(attr, trigger_rate);
 			if (ret < 0)
 				dev_perror(trigger, ret, "Sample rate not set");


### PR DESCRIPTION

## PR Description

Some software triggers doesn't have sampling frequency associated with them, instead just maps a particular interrupt with to iio_trigger_poll.

```
# before
$ iio_rwdev -s 4 -b 4  ad4062 --trigger ad4062-dev0
ERROR: trigger0: Sample rate not set: No such file or directory (2)
������������
```
```
# after

$ iio_rwdev -s 4 -b 4  ad4062 --trigger ad4062-dev0
������������
```

## PR Type
- [X] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [X] I have commented new code, particularly complex or unclear areas
- [X] I have checked that I did not introduce new warnings or errors (CI output)
- [X] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
