### PR TITLE
CI: Stop creating artifacts for macOS-13

### DIFF
--- a/CI/azure/prepare_assets.sh
+++ b/CI/azure/prepare_assets.sh
@@ -14,7 +14,7 @@ release_artifacts() {
                 rm -r "Linux-${i}"
         done
 
-	local pkg_assets='macOS-13-x64 macOS-13-arm64 macOS-14-x64 macOS-15-x64'
+	local pkg_assets='macOS-13-arm64 macOS-14-x64 macOS-15-x64'
         cd "${BUILD_ARTIFACTSTAGINGDIRECTORY}"
         for i in $pkg_assets; do
                 cd "${i}"
@@ -82,7 +82,7 @@ swdownloads_artifacts() {
                 rm -r ../Linux-"${distribution}"
         done
 
-	local macOS_dist='macOS-13-x64 macOS-13-arm64 macOS-14-x64 macOS-15-x64'
+	local macOS_dist='macOS-13-arm64 macOS-14-x64 macOS-15-x64'
 	for distribution in $macOS_dist; do
                 cd "${BUILD_ARTIFACTSTAGINGDIRECTORY}/${distribution}"
                 find . -name '*.pkg' -exec mv {} ../"${distribution}_latest_main_libiio.pkg" ";"


### PR DESCRIPTION
## PR Description

Remove the step that creates MacOS-13-x64 package and pushes it to swdownloads.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
