### PR TITLE
attr: Fix available detection for buffers

### DIFF
--- a/attr.c
+++ b/attr.c
@@ -344,6 +344,15 @@ int iio_attr_get_range(const struct iio_attr *attr, double *min, double *step, d
 	if (!attr)
 		return -EINVAL;
 
+	/* As of now there are no available attributes for buffers and the
+	 * below wrongly detects data_available as an available kind of
+	 * attribute. If we start to see more exceptions or buffers with
+	 * valid available attributes, we can think about something like
+	 * a blocklist array.
+	 */
+	if (attr->type == IIO_ATTR_TYPE_BUFFER)
+		return -ENXIO;
+
 	if (!string_ends_with(iio_attr_get_name(attr), "available"))
 		return -ENXIO;
 
@@ -380,6 +389,15 @@ int iio_attr_get_available(const struct iio_attr *attr, char ***list, size_t *co
 
 	if (!attr)
 		return -EINVAL;
+
+	/* As of now there are no available attributes for buffers and the
+	 * below wrongly detects data_available as an available kind of
+	 * attribute. If we start to see more exceptions or buffers with
+	 * valid available attributes, we can think about something like
+	 * a blocklist array.
+	 */
+	if (attr->type == IIO_ATTR_TYPE_BUFFER)
+		return -ENXIO;
 
 	if (!string_ends_with(iio_attr_get_name(attr), "available"))
 		return -ENXIO;
@@ -443,6 +461,15 @@ int iio_attr_get_available_buf(const struct iio_attr *attr, char *buf,
 
 	if (!buf || buflen == 0)
 		return -EINVAL;
+
+	/* As of now there are no available attributes for buffers and the
+	 * below wrongly detects data_available as an available kind of
+	 * attribute. If we start to see more exceptions or buffers with
+	 * valid available attributes, we can think about something like
+	 * a blocklist array.
+	 */
+	if (attr->type == IIO_ATTR_TYPE_BUFFER)
+		return -ENXIO;
 
 	if (!string_ends_with(iio_attr_get_name(attr), "available"))
 		return -ENXIO;


### PR DESCRIPTION
## PR Description

As far as I know, buffer attributes don't have available kind of attributes (list or range ones) but one common attribute is 'data_available' which would be wrongly assumed as one of the typical device or channel available attributes. Fix it by check the attr type.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
