### PR TITLE
utils: Fix iio_attr not showing relevant attr info

### DIFF
--- a/utils/iio_attr.c
+++ b/utils/iio_attr.c
@@ -214,6 +214,21 @@ static int dump_channel_attributes(const struct iio_device *dev,
 			type_name = "input";
 
 		gen_function("channel", "ch", attr, NULL);
+		if (quiet == ATTR_VERBOSE) {
+			printf("%s ", iio_device_is_trigger(dev) ? "trig" : "dev");
+			printf("'%s'", get_label_or_name_or_id(dev));
+			printf(", channel '%s' (%s), ",
+					iio_channel_get_id(ch),
+					type_name);
+		}
+		if (iio_channel_get_name(ch) && quiet == ATTR_VERBOSE)
+			printf("id '%s', ", iio_channel_get_name(ch));
+		if (iio_channel_get_label(ch) && quiet == ATTR_VERBOSE)
+			printf("label '%s', ", iio_channel_get_label(ch));
+
+		if (quiet == ATTR_VERBOSE)
+			printf("attr '%s', ", iio_attr_get_name(attr));
+
 		print_attribute_value(dev, attr, "", quiet);
 	}
 	if (wbuf) {


### PR DESCRIPTION
## PR Description
This bug has been introduced with commit
90e5f66dc47d924abb6d34cbad9006399e813b3c where relevant code lines were removed.

See discussion:
https://github.com/analogdevicesinc/libiio/pull/1309#issuecomment-3039854094

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
