### PR TITLE
azure-pipelines: Avoid unsupported mapping values

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,8 +5,10 @@ variables:
   isMain: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
   isRelease: $[startsWith(variables['Build.SourceBranch'], 'refs/tags/v')]
   # Default build type for all builds
-  cmakeBuildType: $[ if eq(variables.isRelease, true) ]: 'Release'
-                  $[ if ne(variables.isRelease, true) ]: 'RelWithDebInfo'
+  ${{ if startsWith(variables['Build.SourceBranch'], 'refs/tags/v') }}:
+    cmakeBuildType: 'Release'
+  ${{ else }}:
+    cmakeBuildType: 'RelWithDebInfo'
 
 trigger:
   branches:


### PR DESCRIPTION
## PR Description

This ensure the syntax is correct allowing the jobs to be triggered. The azure pipelines error was:
"This is an informational run. There was a YAML error preventing Azure Pipelines from determining if the pipeline should run. If you expected this pipeline to run, please validate your YAML. If it's valid, please try again later."

Thank you @liviutomoiaga.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
