### PR TITLE
Enforce MSVC libxml build

### DIFF
--- a/CI/azure/windows_build_deps.cmd
+++ b/CI/azure/windows_build_deps.cmd
@@ -38,5 +38,5 @@ rm .\libxml2-2.9.14.tar.xz
 %msbuild% .\zstd\build\VS2010\zstd.sln /p:Platform=%ARCH% /p:Configuration=Release /p:PlatformToolset=%PLATFORM_TOOLSET%
 %msbuild% .\libserialport\libserialport.vcxproj /p:Platform=%ARCH% /p:Configuration=Release /p:PlatformToolset=%PLATFORM_TOOLSET%
 :: build libxml with cmake
-cmake -DCMAKE_INSTALL_PREFIX=libxml2-install -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_PYTHON=OFF -DLIBXML2_WITH_ZLIB=OFF -S .\libxml2-2.9.14\ -B libxml2-build
+cmake -G "%COMPILER%" -A %ARCH% -DCMAKE_INSTALL_PREFIX=libxml2-install -DLIBXML2_WITH_ICONV=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_PYTHON=OFF -DLIBXML2_WITH_ZLIB=OFF -S .\libxml2-2.9.14\ -B libxml2-build
 cmake --build libxml2-build --config Release --target install


### PR DESCRIPTION
## PR Description

The issue:
While running this script locally, using the MSVC2022, cmake picked some MinGW/MSYS toolchain which built fine but produced a libxml2.dll.a instead of libxml2.dll.
Moreover, since this script takes the compiler, toolset and architecture as parameters it makes sense to pass the to the libxml build as well.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
