### PR TITLE
Staging/consistent timeout convention

### DIFF
--- a/context.c
+++ b/context.c
@@ -375,7 +375,7 @@ const char * iio_context_get_version_tag(const struct iio_context *ctx)
 	return LIBIIO_VERSION_GIT;
 }
 
-int iio_context_set_timeout(struct iio_context *ctx, unsigned int timeout)
+int iio_context_set_timeout(struct iio_context *ctx, int timeout)
 {
 	int ret = 0;
 
@@ -487,10 +487,7 @@ struct iio_context * iio_create_context(const struct iio_context_params *params,
 		if (!params2.timeout_ms) {
 			/* Zero means use backend default */
 			params2.timeout_ms = backend->default_timeout_ms;
-		} else if (params2.timeout_ms < 0) {
-			/* Negative means infinite - translate to 0 for backends */
-			params2.timeout_ms = 0;
-		} /* Positive values pass through unchanged */
+		}
 
 		ctx = backend->ops->create(&params2,
 					   uri + strlen(backend->uri_prefix));

--- a/dns_sd.c
+++ b/dns_sd.c
@@ -161,10 +161,10 @@ void port_knock_discovery_data(const struct iio_context_params *params,
 			       struct dns_sd_discovery_data **ddata)
 {
 	struct dns_sd_discovery_data *d, *ndata;
-	unsigned int timeout_ms;
+	int timeout_ms;
 	int i, ret;
 
-	if (params->timeout_ms)
+	if (params->timeout_ms != 0)
 		timeout_ms = params->timeout_ms;
 	else
 		timeout_ms = DEFAULT_TIMEOUT_MS;

--- a/dynamic.c
+++ b/dynamic.c
@@ -148,10 +148,7 @@ iio_create_dynamic_context(const struct iio_context_params *params,
 	if (!params2.timeout_ms) {
 		/* Zero means use backend default */
 		params2.timeout_ms = backend->default_timeout_ms;
-	} else if (params2.timeout_ms < 0) {
-		/* Negative means infinite - translate to 0 for backends */
-		params2.timeout_ms = 0;
-	} /* Positive values pass through unchanged */
+	}
 
 	uri += strlen(backend->uri_prefix);
 	ctx = (*backend->ops->create)(&params2, uri);

--- a/iiod-responder.h
+++ b/iiod-responder.h
@@ -83,10 +83,10 @@ struct iiod_responder *
 iiod_responder_create(const struct iiod_responder_ops *ops, void *d);
 void iiod_responder_destroy(struct iiod_responder *responder);
 
-/* Set the timeout for I/O operations (default is 0 == infinite) */
+/* Set the timeout for I/O operations (negative = infinite, 0 = default, positive = timeout in ms) */
 void iiod_responder_set_timeout(struct iiod_responder *priv,
-				unsigned int timeout_ms);
-void iiod_io_set_timeout(struct iiod_io *io, unsigned int timeout_ms);
+				int timeout_ms);
+void iiod_io_set_timeout(struct iiod_io *io, int timeout_ms);
 
 /* Read the current value of the micro-second counter */
 uint64_t iiod_responder_read_counter_us(void);

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -1421,7 +1421,7 @@ ssize_t get_trigger(struct parser_pdata *pdata, struct iio_device *dev)
 	return ret;
 }
 
-int set_timeout(struct parser_pdata *pdata, unsigned int timeout)
+int set_timeout(struct parser_pdata *pdata, int timeout)
 {
 	int ret = iio_context_set_timeout(pdata->ctx, timeout);
 	print_value(pdata, ret);

--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -175,7 +175,7 @@ ssize_t get_trigger(struct parser_pdata *pdata, struct iio_device *dev);
 ssize_t set_trigger(struct parser_pdata *pdata,
 		struct iio_device *dev, const char *trig);
 
-int set_timeout(struct parser_pdata *pdata, unsigned int timeout);
+int set_timeout(struct parser_pdata *pdata, int timeout);
 int set_buffers_count(struct parser_pdata *pdata,
 		struct iio_device *dev, long value);
 

--- a/iiod/parser.y
+++ b/iiod/parser.y
@@ -180,7 +180,7 @@ Line:
 	| TIMEOUT SPACE WORD END {
 		char *word = $3;
 		struct parser_pdata *pdata = yyget_extra(scanner);
-		unsigned int timeout = (unsigned int) atoi(word);
+		int timeout = atoi(word);
 		int ret = set_timeout(pdata, timeout);
 		free(word);
 		if (ret < 0)

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -107,7 +107,7 @@ struct iio_backend_ops {
 	int (*get_version)(const struct iio_context *ctx, unsigned int *major,
 			unsigned int *minor, char git_tag[8]);
 
-	int (*set_timeout)(struct iio_context *ctx, unsigned int timeout);
+	int (*set_timeout)(struct iio_context *ctx, int timeout);
 
 	struct iio_buffer_pdata *(*create_buffer)(const struct iio_device *dev,
 						  unsigned int idx,
@@ -152,7 +152,7 @@ struct iio_backend {
 	const char			*name;
 	const char			*uri_prefix;
 	const struct iio_backend_ops	*ops;
-	unsigned int			default_timeout_ms;
+	int				default_timeout_ms;
 };
 
 /*

--- a/include/iio/iio-lock.h
+++ b/include/iio/iio-lock.h
@@ -29,7 +29,7 @@ __api struct iio_cond * iio_cond_create(void);
 __api void iio_cond_destroy(struct iio_cond *cond);
 
 __api int iio_cond_wait(struct iio_cond *cond, struct iio_mutex *lock,
-			unsigned int timeout_ms);
+			int timeout_ms);
 __api void iio_cond_signal(struct iio_cond *cond);
 
 __api struct iio_thrd * iio_thrd_create(int (*thrd)(void *),
@@ -51,8 +51,8 @@ __api int iio_task_enqueue_autoclear(struct iio_task *task, void *elm);
 __api int iio_task_token_enqueue(struct iio_task_token *token);
 
 __api _Bool iio_task_is_done(struct iio_task_token *token);
-__api int iio_task_sync(struct iio_task_token *token, unsigned int timeout_ms);
-__api int iio_task_cancel_sync(struct iio_task_token *token, unsigned int timeout_ms);
+__api int iio_task_sync(struct iio_task_token *token, int timeout_ms);
+__api int iio_task_cancel_sync(struct iio_task_token *token, int timeout_ms);
 __api void iio_task_cancel(struct iio_task_token *token);
 
 #undef __api

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -759,11 +759,11 @@ __api __check_ret __pure struct iio_device * iio_context_find_device(
 /** @brief Set a timeout for I/O operations
  * @param ctx A pointer to an iio_context structure
  * @param timeout_ms Timeout value in milliseconds:
- * - Negative values (typically -1): infinite timeout (wait forever)
+ * - Negative values: infinite timeout (wait forever)
  * - Zero: use backend default timeout
  * - Positive values: explicit timeout in milliseconds
  * @return On success, 0 is returned
- * @return On error, a negative errno code is returned (e.g., -EINVAL for timeout < -1) */
+ * @return On error, a negative errno code is returned */
 __api __check_ret int iio_context_set_timeout(
 		struct iio_context *ctx, int timeout_ms);
 

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -758,13 +758,14 @@ __api __check_ret __pure struct iio_device * iio_context_find_device(
 
 /** @brief Set a timeout for I/O operations
  * @param ctx A pointer to an iio_context structure
- * @param timeout_ms A positive integer representing the time in milliseconds
- * after which a timeout occurs. A value of 0 is used to specify that no
- * timeout should occur.
+ * @param timeout_ms Timeout value in milliseconds:
+ * - Negative values (typically -1): infinite timeout (wait forever)
+ * - Zero: use backend default timeout
+ * - Positive values: explicit timeout in milliseconds
  * @return On success, 0 is returned
- * @return On error, a negative errno code is returned */
+ * @return On error, a negative errno code is returned (e.g., -EINVAL for timeout < -1) */
 __api __check_ret int iio_context_set_timeout(
-		struct iio_context *ctx, unsigned int timeout_ms);
+		struct iio_context *ctx, int timeout_ms);
 
 
 /** @brief Get a pointer to the params structure

--- a/include/iio/iiod-client.h
+++ b/include/iio/iiod-client.h
@@ -20,11 +20,11 @@ struct iio_event_stream_pdata;
 
 struct iiod_client_ops {
 	ssize_t (*write)(struct iiod_client_pdata *desc,
-			 const char *src, size_t len, unsigned int timeout_ms);
+			 const char *src, size_t len, int timeout_ms);
 	ssize_t (*read)(struct iiod_client_pdata *desc,
-			char *dst, size_t len, unsigned int timeout_ms);
+			char *dst, size_t len, int timeout_ms);
 	ssize_t (*read_line)(struct iiod_client_pdata *desc,
-			     char *dst, size_t len, unsigned int timeout_ms);
+			     char *dst, size_t len, int timeout_ms);
 	void (*cancel)(struct iiod_client_pdata *desc);
 };
 
@@ -49,7 +49,7 @@ __api int iiod_client_set_trigger(struct iiod_client *client,
 				  const struct iio_device *trigger);
 
 __api int iiod_client_set_timeout(struct iiod_client *client,
-				  unsigned int timeout);
+				  int timeout);
 
 __api ssize_t iiod_client_attr_read(struct iiod_client *client,
 				    const struct iio_attr *attr,

--- a/local.c
+++ b/local.c
@@ -217,12 +217,12 @@ static int set_channel_name(struct iio_channel *chn)
  * before each poll() invocation the timeout is recalculated relative to the
  * start of refill() or push() operation.
  */
-static int get_rel_timeout_ms(struct timespec *start, unsigned int timeout_rel)
+static int get_rel_timeout_ms(struct timespec *start, int timeout_rel)
 {
 	struct timespec now;
 	int diff_ms;
 
-	if (timeout_rel == 0) /* No timeout */
+	if (timeout_rel <= 0) /* No timeout or infinite timeout */
 		return -1;
 
 	clock_gettime(CLOCK_MONOTONIC, &now);
@@ -230,14 +230,14 @@ static int get_rel_timeout_ms(struct timespec *start, unsigned int timeout_rel)
 	diff_ms = (now.tv_sec - start->tv_sec) * 1000;
 	diff_ms += (now.tv_nsec - start->tv_nsec) / 1000000;
 
-	if (diff_ms >= (int) timeout_rel) /* Expired */
+	if (diff_ms >= timeout_rel) /* Expired */
 		return 0;
 	if (diff_ms > 0) /* Should never be false, but lets be safe */
 		timeout_rel -= diff_ms;
 	if (timeout_rel > INT_MAX)
 		return INT_MAX;
 
-	return (int) timeout_rel;
+	return timeout_rel;
 }
 
 int buffer_check_ready(struct iio_buffer_pdata *pdata, int fd,

--- a/lock-dummy.c
+++ b/lock-dummy.c
@@ -59,7 +59,7 @@ void iio_cond_destroy(struct iio_cond *cond)
 }
 
 int iio_cond_wait(struct iio_cond *cond, struct iio_mutex *lock,
-		  unsigned int timeout_ms)
+		  int timeout_ms)
 {
 	return -ETIMEDOUT;
 }

--- a/lock-windows.c
+++ b/lock-windows.c
@@ -76,14 +76,17 @@ void iio_cond_destroy(struct iio_cond *cond)
 }
 
 int iio_cond_wait(struct iio_cond *cond, struct iio_mutex *lock,
-		  unsigned int timeout_ms)
+		  int timeout_ms)
 {
 	BOOL ret;
+	DWORD win_timeout;
 
-	if (timeout_ms == 0)
-		timeout_ms = INFINITE;
+	if (timeout_ms <= 0)
+		win_timeout = INFINITE;
+	else
+		win_timeout = (DWORD)timeout_ms;
 
-	ret = SleepConditionVariableCS(&cond->cond, &lock->lock, timeout_ms);
+	ret = SleepConditionVariableCS(&cond->cond, &lock->lock, win_timeout);
 
 	return ret ? 0 : -ETIMEDOUT;
 }

--- a/lock.c
+++ b/lock.c
@@ -90,13 +90,13 @@ void iio_cond_destroy(struct iio_cond *cond)
 }
 
 int iio_cond_wait(struct iio_cond *cond, struct iio_mutex *lock,
-		  unsigned int timeout_ms)
+		  int timeout_ms)
 {
 	struct timespec ts;
 	uint64_t usec;
 	int ret = 0;
 
-	if (timeout_ms == 0) {
+	if (timeout_ms <= 0) {
 		pthread_cond_wait(&cond->cond, &lock->lock);
 	} else {
 		clock_gettime(CLOCK_REALTIME, &ts);

--- a/network-unix.c
+++ b/network-unix.c
@@ -102,9 +102,8 @@ void do_cancel(struct iiod_client_pdata *io_ctx)
 }
 
 int wait_cancellable(struct iiod_client_pdata *io_ctx,
-		     bool read, unsigned int timeout_ms)
+		     bool read, int timeout_ms)
 {
-	int timeout = timeout_ms > 0 ? (int) timeout_ms : -1;
 	struct pollfd pfd[2];
 	int ret;
 
@@ -120,7 +119,7 @@ int wait_cancellable(struct iiod_client_pdata *io_ctx,
 
 	do {
 		do {
-			ret = poll(pfd, 2, timeout);
+			ret = poll(pfd, 2, timeout_ms);
 		} while (ret == -1 && errno == EINTR);
 
 		if (ret == -1)
@@ -190,23 +189,17 @@ int do_create_socket(const struct addrinfo *addrinfo)
 	return fd;
 }
 
-int do_select(int fd, unsigned int timeout)
+int do_select(int fd, int timeout)
 {
 	struct pollfd pfd;
 	int ret;
-	int poll_timeout;
 
 	pfd.fd = fd;
 	pfd.events = POLLOUT | POLLERR;
 	pfd.revents = 0;
 
-	if (!timeout)
-		poll_timeout = -1;
-	else
-		poll_timeout = (int)timeout;
-
 	do {
-		ret = poll(&pfd, 1, poll_timeout);
+		ret = poll(&pfd, 1, timeout);
 	} while (ret == -1 && errno == EINTR);
 
 	if (ret < 0)

--- a/network-windows.c
+++ b/network-windows.c
@@ -57,10 +57,10 @@ void do_cancel(struct iiod_client_pdata *io_ctx)
 }
 
 int wait_cancellable(struct iiod_client_pdata *io_ctx,
-		     bool read, unsigned int timeout_ms)
+		     bool read, int timeout_ms)
 {
 	long wsa_events = FD_CLOSE;
-	DWORD ret, timeout = timeout_ms > 0 ? (DWORD) timeout_ms : WSA_INFINITE;
+	DWORD ret, timeout = timeout_ms < 0 ? WSA_INFINITE : (DWORD) timeout_ms;
 
 	if (read)
 		wsa_events |= FD_READ;
@@ -134,7 +134,7 @@ int do_create_socket(const struct addrinfo *addrinfo)
 	return (int) s;
 }
 
-int do_select(int fd, unsigned int timeout)
+int do_select(int fd, int timeout)
 {
 	struct timeval tv;
 	struct timeval *ptv;
@@ -154,12 +154,12 @@ int do_select(int fd, unsigned int timeout)
 #pragma warning(default: 4389)
 #endif
 
-	if (timeout != 0) {
+	if (timeout >= 0) {
 		tv.tv_sec = timeout / 1000;
 		tv.tv_usec = (timeout % 1000) * 1000;
 		ptv = &tv;
 	} else {
-		ptv = NULL;
+		ptv = NULL; /* Infinite timeout */
 	}
 
 	ret = select(fd + 1, NULL, &set, &set, ptv);

--- a/network.c
+++ b/network.c
@@ -78,10 +78,10 @@ network_create_context(const struct iio_context_params *params,
 
 static ssize_t
 network_write_data(struct iiod_client_pdata *io_ctx, const char *src, size_t len,
-		   unsigned int timeout_ms);
+		   int timeout_ms);
 static ssize_t
 network_read_data(struct iiod_client_pdata *io_ctx, char *dst, size_t len,
-		  unsigned int timeout_ms);
+		  int timeout_ms);
 static void network_cancel(struct iiod_client_pdata *io_ctx);
 
 static const struct iiod_client_ops network_iiod_client_ops = {
@@ -91,7 +91,7 @@ static const struct iiod_client_ops network_iiod_client_ops = {
 };
 
 static ssize_t network_recv(struct iiod_client_pdata *io_ctx, void *data,
-			    size_t len, int flags, unsigned int timeout_ms)
+			    size_t len, int flags, int timeout_ms)
 {
 	bool cancellable = true;
 	ssize_t ret;
@@ -128,7 +128,7 @@ static ssize_t network_recv(struct iiod_client_pdata *io_ctx, void *data,
 }
 
 static ssize_t network_send(struct iiod_client_pdata *io_ctx, const void *data,
-			    size_t len, int flags, unsigned int timeout_ms)
+			    size_t len, int flags, int timeout_ms)
 {
 	ssize_t ret;
 	int err;
@@ -180,7 +180,7 @@ network_writebuf(struct iio_buffer_pdata *pdata, const void *src, size_t len)
 /* The purpose of this function is to provide a version of connect()
  * that does not ignore timeouts... */
 static int do_connect(int fd, const struct addrinfo *addrinfo,
-	unsigned int timeout)
+	int timeout)
 {
 	int ret, error;
 	socklen_t len;
@@ -217,7 +217,7 @@ static int do_connect(int fd, const struct addrinfo *addrinfo,
 	return 0;
 }
 
-int create_socket(const struct addrinfo *addrinfo, unsigned int timeout)
+int create_socket(const struct addrinfo *addrinfo, int timeout)
 {
 	int ret, fd, yes = 1;
 
@@ -424,7 +424,7 @@ static void network_shutdown(struct iio_context *ctx)
 	freeaddrinfo(pdata->addrinfo);
 }
 
-static int network_set_timeout(struct iio_context *ctx, unsigned int timeout)
+static int network_set_timeout(struct iio_context *ctx, int timeout)
 {
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 	int ret;
@@ -551,13 +551,13 @@ const struct iio_backend iio_ip_backend = {
 
 static ssize_t network_write_data(struct iiod_client_pdata *io_ctx,
 				  const char *src, size_t len,
-				  unsigned int timeout_ms)
+				  int timeout_ms)
 {
 	return network_send(io_ctx, src, len, MSG_NOSIGNAL, timeout_ms);
 }
 
 static ssize_t network_read_data(struct iiod_client_pdata *io_ctx,
-				 char *dst, size_t len, unsigned int timeout_ms)
+				 char *dst, size_t len, int timeout_ms)
 {
 	return network_recv(io_ctx, dst, len, 0, timeout_ms);
 }

--- a/network.h
+++ b/network.h
@@ -33,11 +33,11 @@ int setup_cancel(struct iiod_client_pdata *io_ctx);
 void cleanup_cancel(struct iiod_client_pdata *io_ctx);
 void do_cancel(struct iiod_client_pdata *io_ctx);
 int wait_cancellable(struct iiod_client_pdata *io_ctx,
-		     bool read, unsigned int timeout_ms);
+		     bool read, int timeout_ms);
 
-int create_socket(const struct addrinfo *addrinfo, unsigned int timeout);
+int create_socket(const struct addrinfo *addrinfo, int timeout);
 int do_create_socket(const struct addrinfo *addrinfo);
-int do_select(int fd, unsigned int timeout);
+int do_select(int fd, int timeout);
 
 int set_blocking_mode(int s, bool blocking);
 

--- a/serial.c
+++ b/serial.c
@@ -129,7 +129,7 @@ serial_write_attr(const struct iio_attr *attr, const char *src, size_t len)
 
 static ssize_t serial_write_data(struct iiod_client_pdata *io_data,
 				 const char *data, size_t len,
-				 unsigned int timeout_ms)
+				 int timeout_ms)
 {
 	struct iio_context_pdata *pdata = (struct iio_context_pdata *) io_data;
 	enum sp_return sp_ret;
@@ -167,7 +167,7 @@ void sleep_one_ms(void)
 }
 
 static ssize_t serial_read_data(struct iiod_client_pdata *io_data,
-				char *buf, size_t len, unsigned int timeout_ms)
+				char *buf, size_t len, int timeout_ms)
 {
 	struct iio_context_pdata *pdata = (struct iio_context_pdata *) io_data;
 	long long time_left_ms = (long long)timeout_ms;
@@ -175,7 +175,7 @@ static ssize_t serial_read_data(struct iiod_client_pdata *io_data,
 	ssize_t ret = 0;
 
 	while (true) {
-		if (timeout_ms && time_left_ms <= 0)
+		if (timeout_ms > 0 && time_left_ms <= 0)
 			break;
 
 		sp_ret = sp_nonblocking_read(pdata->port, buf, len);

--- a/task.c
+++ b/task.c
@@ -87,7 +87,7 @@ static int iio_task_run(void *d)
 
 	return 0;
 }
-static int iio_task_sync_core(struct iio_task_token *token, unsigned int timeout_ms, bool token_destroy)
+static int iio_task_sync_core(struct iio_task_token *token, int timeout_ms, bool token_destroy)
 {
 	int ret;
 
@@ -301,7 +301,7 @@ int iio_task_enqueue_autoclear(struct iio_task *task, void *elm)
 	return iio_err(iio_task_do_enqueue(task, elm, true));
 }
 
-int iio_task_sync(struct iio_task_token *token, unsigned int timeout_ms)
+int iio_task_sync(struct iio_task_token *token, int timeout_ms)
 {
 	return iio_task_sync_core(token, timeout_ms, true);
 }
@@ -355,7 +355,7 @@ bool iio_task_is_done(struct iio_task_token *token)
 	return token->done;
 }
 
-int iio_task_cancel_sync(struct iio_task_token *token, unsigned int timeout_ms)
+int iio_task_cancel_sync(struct iio_task_token *token, int timeout_ms)
 {
 	iio_task_cancel(token);
 	return iio_task_sync_core(token, timeout_ms, false);

--- a/usb.c
+++ b/usb.c
@@ -109,9 +109,9 @@ usb_create_context_from_args(const struct iio_context_params *params,
 static int usb_context_scan(const struct iio_context_params *params,
 			    struct iio_scan *scan, const char *args);
 static ssize_t write_data_sync(struct iiod_client_pdata *ep, const char *data,
-			       size_t len, unsigned int timeout_ms);
+			       size_t len, int timeout_ms);
 static ssize_t read_data_sync(struct iiod_client_pdata *ep, char *buf,
-			      size_t len, unsigned int timeout_ms);
+			      size_t len, int timeout_ms);
 static void usb_cancel(struct iiod_client_pdata *io_ctx);
 
 static int usb_io_context_init(struct iiod_client_pdata *io_ctx)
@@ -268,7 +268,7 @@ usb_write_attr(const struct iio_attr *attr, const char *src, size_t len)
 	return iiod_client_attr_write(client, attr, src, len);
 }
 
-static int usb_set_timeout(struct iio_context *ctx, unsigned int timeout)
+static int usb_set_timeout(struct iio_context *ctx, int timeout)
 {
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
@@ -557,7 +557,7 @@ static void LIBUSB_CALL sync_transfer_cb(struct libusb_transfer *transfer)
 static int usb_sync_transfer(struct iio_context_pdata *pdata,
 			     struct iiod_client_pdata *io_ctx,
 			     unsigned int ep_type, char *data, size_t len,
-			     int *transferred, unsigned int timeout_ms)
+			     int *transferred, int timeout_ms)
 {
 	unsigned char ep;
 	struct libusb_transfer *transfer = NULL;
@@ -662,7 +662,7 @@ unlock:
 
 static ssize_t write_data_sync(struct iiod_client_pdata *ep,
 			       const char *data, size_t len,
-			       unsigned int timeout_ms)
+			       int timeout_ms)
 {
 	int transferred, ret;
 
@@ -675,7 +675,7 @@ static ssize_t write_data_sync(struct iiod_client_pdata *ep,
 }
 
 static ssize_t read_data_sync(struct iiod_client_pdata *ep,
-			      char *buf, size_t len, unsigned int timeout_ms)
+			      char *buf, size_t len, int timeout_ms)
 {
 	int transferred, ret;
 

--- a/utils/gen_code.c
+++ b/utils/gen_code.c
@@ -246,7 +246,7 @@ void gen_ch(const struct iio_channel *ch)
 	}
 }
 
-void gen_context_timeout(unsigned int timeout_ms)
+void gen_context_timeout(int timeout_ms)
 {
 	if (!fd)
 		return;

--- a/utils/gen_code.h
+++ b/utils/gen_code.h
@@ -21,5 +21,5 @@ void gen_dev(const struct iio_device *dev);
 void gen_ch(const struct iio_channel *ch);
 void gen_function(const char* prefix, const char* target,
 		  const struct iio_attr *attr, const char *wbuf);
-void gen_context_timeout(unsigned int timeout_ms);
+void gen_context_timeout(int timeout_ms);
 #endif


### PR DESCRIPTION
## PR Description

This PR makes the timeout values consistent across libiio.

Before, there were 2 conventions:
Using `iio_context_set_timeout()`:
 -  0 value meant no wait
 - Greater than 0 value meant wait that amount of milliseconds
 - no option to wait forever!

Using `struct_iio_context_params`:
 - Zero: use backend default timeout
 - Negative values: no timeout (wait indefinitely)
 - Positive values: timeout after specified milliseconds

With changes in this PR:
For both `iio_context_set_timeout()` and `struct_iio_context_params the following applies:
 - Zero: use backend default timeout
 - Negative values: no timeout (wait indefinitely)
 - Positive values: timeout after specified milliseconds

To do:
- [ ] Handle how this affects the backward compatibility with v0

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
