### PR TITLE
dns_sd: Improve time at scanning

### DIFF
--- a/dns_sd.c
+++ b/dns_sd.c
@@ -97,14 +97,14 @@ static int dnssd_add_scan_result(const struct iio_context_params *params,
 	int err;
 
 	if (port == IIOD_PORT) {
-		iio_snprintf(uri, sizeof(uri), "ip:%s", hostname);
+		iio_snprintf(uri, sizeof(uri), "ip:%s", addr_str);
 	} else {
 #ifdef HAVE_IPV6
 		if (strchr(addr_str, ':'))
-			iio_snprintf(uri, sizeof(uri), "ip:[%s]:%hu", hostname, port);
+			iio_snprintf(uri, sizeof(uri), "ip:[%s]:%hu", addr_str, port);
 		else
 #endif
-			iio_snprintf(uri, sizeof(uri), "ip:%s:%hu", hostname, port);
+			iio_snprintf(uri, sizeof(uri), "ip:%s:%hu", addr_str, port);
 	}
 
 	ctx = iio_create_context(params, uri);
@@ -149,7 +149,7 @@ static int dnssd_add_scan_result(const struct iio_context_params *params,
 
 	iio_context_destroy(ctx);
 
-	return iio_scan_add_result(scan_ctx, description, uri);
+	return iio_scan_add_result(scan_ctx, description, hostname);
 }
 
 /*


### PR DESCRIPTION
## PR Description
In libiiov1, the switch to hostnames introduced a significant performance regression on Windows systems. This is due to the overhead of network name resolution (DNS/LLMNR/NetBIOS), which adds a delay of 1–3 seconds per host. By returning to the v0 approach of using direct IP addresses, we reduce execution time by approximately 1.5 seconds per host.
The latency is cumulative. For a typical setup with 4 hosts, the scan time scales poorly:
With Hostnames: ~8.0 seconds total
With IP Addresses: ~2.7 seconds total


## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
