### PR TITLE
network-windows: Fix race condition in wait_cancellable

### DIFF
--- a/network-windows.c
+++ b/network-windows.c
@@ -12,8 +12,15 @@
 #include <errno.h>
 #include <ws2tcpip.h>
 #include <iio/iio-debug.h>
+#include <iio/iio-lock.h>
 
 #define close(s) closesocket(s)
+
+struct iiod_client_pdata_os {
+	struct iio_mutex *event_lock;
+	int read_waiters;
+	int write_waiters;
+};
 
 int set_blocking_mode(int s, bool blocking)
 {
@@ -42,11 +49,33 @@ int setup_cancel(struct iiod_client_pdata *io_ctx)
 		return -ENOMEM;
 	}
 
-	return 0;
+    struct iiod_client_pdata_os *os_priv = malloc(sizeof(*os_priv));
+    if (!os_priv)
+        goto err_close_events;
+
+    os_priv->event_lock = iio_mutex_create();
+    if (!os_priv->event_lock)
+        goto err_free_os_priv;
+
+    os_priv->read_waiters = 0;
+    os_priv->write_waiters = 0;
+    io_ctx->os_priv = os_priv;
+
+    return 0;
+err_free_os_priv:
+	free(os_priv);
+err_close_events:
+    WSACloseEvent(io_ctx->events[0]);
+    WSACloseEvent(io_ctx->events[1]);
+    io_ctx->events[0] = NULL;
+    io_ctx->events[1] = NULL;
+    return -ENOMEM;
 }
 
 void cleanup_cancel(struct iiod_client_pdata *io_ctx)
 {
+	iio_mutex_destroy(io_ctx->os_priv->event_lock);
+	free(io_ctx->os_priv);
 	WSACloseEvent(io_ctx->events[0]);
 	WSACloseEvent(io_ctx->events[1]);
 }
@@ -59,20 +88,36 @@ void do_cancel(struct iiod_client_pdata *io_ctx)
 int wait_cancellable(struct iiod_client_pdata *io_ctx,
 		     bool read, unsigned int timeout_ms)
 {
+	struct iio_mutex *lock = io_ctx->os_priv->event_lock;
 	long wsa_events = FD_CLOSE;
 	DWORD ret, timeout = timeout_ms > 0 ? (DWORD) timeout_ms : WSA_INFINITE;
 
+	iio_mutex_lock(lock);
 	if (read)
-		wsa_events |= FD_READ;
+		io_ctx->os_priv->read_waiters++;
 	else
+		io_ctx->os_priv->write_waiters++;
+
+	if (io_ctx->os_priv->read_waiters > 0) 
+		wsa_events |= FD_READ;
+	if (io_ctx->os_priv->write_waiters > 0) 
 		wsa_events |= FD_WRITE;
 
 	WSAEventSelect(io_ctx->fd, NULL, 0);
 	WSAResetEvent(io_ctx->events[0]);
 	WSAEventSelect(io_ctx->fd, io_ctx->events[0], wsa_events);
 
+	iio_mutex_unlock(lock);
+
 	ret = WSAWaitForMultipleEvents(2, io_ctx->events, FALSE,
 				       timeout, FALSE);
+
+	iio_mutex_lock(lock);
+	if (read)
+		io_ctx->os_priv->read_waiters--;
+	else
+		io_ctx->os_priv->write_waiters--;
+	iio_mutex_unlock(lock);
 
 	if (ret == WSA_WAIT_TIMEOUT)
 		return -ETIMEDOUT;

--- a/network.h
+++ b/network.h
@@ -18,9 +18,11 @@ struct iio_context_params;
 struct iio_context_pdata;
 struct addrinfo;
 
+struct iiod_client_pdata_os;
 struct iiod_client_pdata {
 	int fd;
-
+	/* Platform-specific private data */
+	struct iiod_client_pdata_os *os_priv;
 	bool cancelled;
 	void * events[2];
 	int cancel_fd[2];


### PR DESCRIPTION
## PR Description

Multiple threads calling wait_cancellable (e.g., one reading, one writing)  were overwriting the socket's WSAEventSelect configuration.

This commit adds a CriticalSection and waiter-counting logic to:
- Ensure FD_READ and FD_WRITE are merged rather than overwritten.
- Protect the shared event object reset and selection logic.
- Defer decrementing waiter counts until after the wait to prevent prematurely clearing the socket event mask.

Edit:
Issue: https://github.com/analogdevicesinc/libiio/issues/1402

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
