### PR TITLE
channel type: Improve code readability for channel type

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -353,6 +353,9 @@ enum iio_modifier iio_channel_get_modifier(const struct iio_channel *chn)
 
 enum iio_chan_type iio_channel_get_type(const struct iio_channel *chn)
 {
+	if (iio_device_is_hwmon(iio_channel_get_device(chn))) {
+		chn_warn(chn, "iio_channel_get_type() called on non-hwmon channel\n");
+	}
 	return chn->type;
 }
 
@@ -412,6 +415,15 @@ const struct iio_data_format * iio_channel_get_data_format(
 		const struct iio_channel *chn)
 {
 	return &chn->format;
+}
+
+enum hwmon_chan_type hwmon_channel_get_type(
+		const struct iio_channel* chn)
+{
+	if (!iio_device_is_hwmon(iio_channel_get_device(chn))) {
+		chn_warn(chn, "hwmon_channel_get_type() called on non-hwmon channel\n");
+	}
+	return (enum hwmon_chan_type)chn->type;
 }
 
 bool iio_channel_is_enabled(const struct iio_channel *chn,

--- a/events.c
+++ b/events.c
@@ -72,7 +72,7 @@ iio_event_get_channel(const struct iio_event *event,
 	for (i = 0; i < dev->nb_channels; i++) {
 		chn = dev->channels[i];
 
-		if (chn->type != iio_event_get_chan_type(event)
+		if (chn->type != (int)iio_event_get_chan_type(event)
 		    || chn->modifier != iio_event_get_modifier(event)) {
 			continue;
 		}

--- a/iio-private.h
+++ b/iio-private.h
@@ -112,7 +112,7 @@ struct iio_channel {
 	char *name, *id, *label;
 	long index;
 	enum iio_modifier modifier;
-	enum iio_chan_type type;
+	int type;
 
 	struct iio_attr_list attrlist;
 

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1064,9 +1064,11 @@ __api void * iio_channel_get_data(const struct iio_channel *chn);
 
 
 /** @brief Get the type of the given channel
+ * @note Before calling this function, iio_device_is_hwmon() must be called
+ * to ensure the device is compatible.
  * @param chn A pointer to an iio_channel structure
  * @return The type of the channel */
-__api __check_ret __pure enum iio_chan_type iio_channel_get_type(
+__api __check_ret enum iio_chan_type iio_channel_get_type(
 		const struct iio_channel *chn);
 
 
@@ -1389,13 +1391,12 @@ enum hwmon_chan_type {
 
 /**
  * @brief Get the type of the given hwmon channel
+ * @note Before calling this function, iio_device_is_hwmon() must be called
+ * to ensure the device is compatible.
  * @param chn A pointer to an iio_channel structure
  * @return The type of the hwmon channel */
-static inline enum hwmon_chan_type
-hwmon_channel_get_type(const struct iio_channel *chn)
-{
-	return (enum hwmon_chan_type) iio_channel_get_type(chn);
-}
+__api __check_ret enum hwmon_chan_type
+hwmon_channel_get_type(const struct iio_channel* chn);
 
 /**
  * @brief Get whether or not the device is a hardware monitoring device


### PR DESCRIPTION
## PR Description

Currently, the channel type is stored as enum iio_chan_type, even when it represents a hwmon_chan_type. By changing this field to int, we improve code readability and flexibility. This change also enables the implementation of validation checks, such as in hwmon_channel_get_type(), which now issues a warning if a hwmon function is incorrectly called for a non-hwmon channel and vice versa.

- Issue: https://github.com/analogdevicesinc/libiio/issues/1401

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)

