### PR TITLE
Change API timeout semantics to signed int with defined constants

### DIFF
--- a/bindings/cpp/iio.hpp
+++ b/bindings/cpp/iio.hpp
@@ -650,7 +650,7 @@ public:
     unsigned int devices_count() const {return iio_context_get_devices_count(p);}
     optional<Device> device(unsigned int idx) const { return impl::maybe<Device>(iio_context_get_device(p, idx)); }
     optional<Device> find_device(cstr name) const {return impl::maybe<Device>(iio_context_find_device(p, name));}
-    void set_timeout(unsigned int timeout_ms){impl::check(iio_context_set_timeout(p, timeout_ms), "iio_context_set_timeout");}
+    void set_timeout(int timeout_ms){impl::check(iio_context_set_timeout(p, timeout_ms), "iio_context_set_timeout");}
     iio_context_params const * params() const {return iio_context_get_params(p);}
     void set_data(void * data){iio_context_set_data(p, data);}
     void * data() const {return iio_context_get_data(p);}

--- a/bindings/csharp/Context.cs
+++ b/bindings/csharp/Context.cs
@@ -82,7 +82,7 @@ namespace iio
         private static extern bool iio_device_is_trigger(IntPtr dev);
 
         [DllImport(IioLib.dllname, CallingConvention = CallingConvention.Cdecl)]
-        private static extern int iio_context_set_timeout(IntPtr ctx, uint timeout_ms);
+        private static extern int iio_context_set_timeout(IntPtr ctx, int timeout_ms);
 
         [DllImport(IioLib.dllname, CallingConvention = CallingConvention.Cdecl)]
         private static extern uint iio_context_get_attrs_count(IntPtr ctx);
@@ -225,9 +225,10 @@ namespace iio
         }
 
         /// <summary>Set a timeout for I/O operations.</summary>
-        /// <param name="timeout">The timeout value, in milliseconds</param>
+        /// <param name="timeout">The timeout value, in milliseconds.
+        /// 0 = use backend default, -1 = infinite, int.MinValue = nonblock</param>
         /// <exception cref="IioLib.IIOException">The timeout could not be applied.</exception>
-        public void set_timeout(uint timeout)
+        public void set_timeout(int timeout)
         {
             int ret = iio_context_set_timeout(hdl, timeout);
             if (ret < 0)

--- a/bindings/python/iio/__init__.py
+++ b/bindings/python/iio/__init__.py
@@ -442,7 +442,7 @@ _set_timeout = _lib.iio_context_set_timeout
 _set_timeout.restype = c_int
 _set_timeout.argtypes = (
     _ContextPtr,
-    c_uint,
+    c_int,
 )
 _set_timeout.errcheck = _check_negative
 

--- a/block.c
+++ b/block.c
@@ -93,7 +93,7 @@ void iio_block_destroy(struct iio_block *block)
 
 	if (block->token) {
 		iio_task_cancel(block->token);
-		iio_task_sync(block->token, 0);
+		iio_task_sync(block->token, -1);
 	}
 	if (ops->free_block && block->pdata)
 		ops->free_block(block->pdata);
@@ -192,7 +192,7 @@ int iio_block_dequeue(struct iio_block *block, bool nonblock)
 		return -EPERM;
 	}
 
-	return iio_task_sync(token, 0);
+	return iio_task_sync(token, -1);
 }
 
 void *iio_block_start(const struct iio_block *block)

--- a/compat.c
+++ b/compat.c
@@ -714,7 +714,14 @@ iio_context_find_device(const struct iio_context *ctx, const char *name)
 
 int iio_context_set_timeout(struct iio_context *ctx, unsigned int timeout_ms)
 {
-	return IIO_CALL(iio_context_set_timeout)(ctx, timeout_ms);
+	/*
+	 * In libiio 0.x, 0 meant "wait forever". In 1.x, that semantic
+	 * is represented by IIO_TIMEOUT_INFINITE (-1), while 0 now means
+	 * "use backend default". Translate for backwards compatibility.
+	 */
+	int timeout = timeout_ms == 0 ? -1 : (int)timeout_ms;
+
+	return IIO_CALL(iio_context_set_timeout)(ctx, timeout);
 }
 
 unsigned int iio_context_get_attrs_count(const struct iio_context *ctx)

--- a/context.c
+++ b/context.c
@@ -14,6 +14,7 @@
 #include <iio/iio-debug.h>
 
 #include <errno.h>
+#include <limits.h>
 #include <string.h>
 
 static const char xml_header[] = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
@@ -639,17 +640,35 @@ const char * iio_context_get_version_tag(const struct iio_context *ctx)
 	return LIBIIO_VERSION_GIT;
 }
 
-int iio_context_set_timeout(struct iio_context *ctx, unsigned int timeout)
+int iio_resolve_timeout(int timeout, unsigned int default_timeout_ms)
 {
-	int ret = 0;
+	if (timeout == IIO_TIMEOUT_BACKEND)
+		return (int)default_timeout_ms;
+	if (timeout == IIO_TIMEOUT_INFINITE)
+		return -1;
+	if (timeout == IIO_TIMEOUT_NONBLOCK)
+		return 0;
+	if (timeout > 0)
+		return timeout;
+
+	return -EINVAL;
+}
+
+int iio_context_set_timeout(struct iio_context *ctx, int timeout)
+{
+	int resolved, ret = 0;
+
+	resolved = iio_resolve_timeout(timeout, ctx->default_timeout_ms);
+	if (resolved == -EINVAL)
+		return -EINVAL;
 
 	if (ctx->ops->set_timeout) {
-		ret = ctx->ops->set_timeout(ctx, timeout);
+		ret = ctx->ops->set_timeout(ctx, resolved);
 		if (ret)
 			return ret;
 	}
 
-	ctx->params.timeout_ms = timeout;
+	ctx->params.timeout_ms = resolved;
 
 	return 0;
 }
@@ -750,16 +769,17 @@ struct iio_context * iio_create_context(const struct iio_context_params *params,
 	}
 
 	if (backend) {
-		if (!params2.timeout_ms) {
-			/* Zero means use backend default */
-			params2.timeout_ms = backend->default_timeout_ms;
-		} else if (params2.timeout_ms < 0) {
-			/* Negative means infinite - translate to 0 for backends */
-			params2.timeout_ms = 0;
-		} /* Positive values pass through unchanged */
+		params2.timeout_ms = iio_resolve_timeout(params2.timeout_ms,
+							 backend->default_timeout_ms);
+		if (params2.timeout_ms == -EINVAL) {
+			free(uri_dup);
+			return iio_ptr(-EINVAL);
+		}
 
 		ctx = backend->ops->create(&params2,
 					   uri + strlen(backend->uri_prefix));
+		if (!iio_err(ctx))
+			ctx->default_timeout_ms = backend->default_timeout_ms;
 	} else if (WITH_MODULES) {
 		ctx = iio_create_dynamic_context(&params2, uri);
 	} else {

--- a/dns_sd.c
+++ b/dns_sd.c
@@ -161,10 +161,10 @@ void port_knock_discovery_data(const struct iio_context_params *params,
 			       struct dns_sd_discovery_data **ddata)
 {
 	struct dns_sd_discovery_data *d, *ndata;
-	unsigned int timeout_ms;
+	int timeout_ms;
 	int i, ret;
 
-	if (params->timeout_ms)
+	if (params->timeout_ms > 0)
 		timeout_ms = params->timeout_ms;
 	else
 		timeout_ms = DEFAULT_TIMEOUT_MS;

--- a/dynamic.c
+++ b/dynamic.c
@@ -145,13 +145,12 @@ iio_create_dynamic_context(const struct iio_context_params *params,
 
 	prm_dbg(params, "Found backend: %s\n", backend->name);
 
-	if (!params2.timeout_ms) {
-		/* Zero means use backend default */
-		params2.timeout_ms = backend->default_timeout_ms;
-	} else if (params2.timeout_ms < 0) {
-		/* Negative means infinite - translate to 0 for backends */
-		params2.timeout_ms = 0;
-	} /* Positive values pass through unchanged */
+	params2.timeout_ms = iio_resolve_timeout(params2.timeout_ms,
+					      backend->default_timeout_ms);
+	if (params2.timeout_ms == -EINVAL) {
+		ret = -EINVAL;
+		goto out_release_module;
+	}
 
 	uri += strlen(backend->uri_prefix);
 	ctx = (*backend->ops->create)(&params2, uri);
@@ -159,6 +158,7 @@ iio_create_dynamic_context(const struct iio_context_params *params,
 	if (ret)
 		goto out_release_module;
 
+	ctx->default_timeout_ms = backend->default_timeout_ms;
 	ctx->lib = lib;
 	return ctx;
 

--- a/iio-private.h
+++ b/iio-private.h
@@ -97,6 +97,8 @@ struct iio_context {
 
 	struct iio_context_params params;
 
+	unsigned int default_timeout_ms;
+
 	struct iio_module *lib;
 };
 
@@ -216,6 +218,8 @@ ssize_t iio_snprintf_device_xml(char *str, ssize_t slen,
 				const struct iio_device *dev);
 
 int iio_context_init(struct iio_context *ctx);
+
+int iio_resolve_timeout(int timeout, unsigned int default_timeout_ms);
 
 int read_double(const char *str, double *val);
 int write_double(char *buf, size_t len, double val);

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -95,8 +95,9 @@ void iiod_client_mutex_unlock(struct iiod_client *client)
 static ssize_t iiod_client_read_integer(struct iiod_client *client, int *val)
 {
 	bool accept_eol = false, has_read_line = !!client->ops->read_line;
-	unsigned int i, nb, first = 0, timeout_ms = client->params->timeout_ms;
-	unsigned int remaining = 0;
+	unsigned int i, nb, first = 0;
+	int timeout_ms = client->params->timeout_ms;
+	int remaining = timeout_ms;
 	int64_t start_time = 0, diff_ms;
 	char buf[1024], *end;
 	ssize_t ret;
@@ -118,11 +119,11 @@ static ssize_t iiod_client_read_integer(struct iiod_client *client, int *val)
 		if (!has_read_line) {
 			diff_ms = (iiod_responder_read_counter_us() - start_time) / 1000;
 
-			if (timeout_ms) {
+			if (timeout_ms > 0) {
 				if (diff_ms >= timeout_ms)
 					return -ETIMEDOUT;
 
-				remaining = (unsigned int)((int64_t)timeout_ms - diff_ms);
+				remaining = (int)((int64_t)timeout_ms - diff_ms);
 			}
 
 			ret = client->ops->read(client->desc, &buf[i], 1, remaining);
@@ -158,24 +159,27 @@ static ssize_t iiod_client_write_all(struct iiod_client *client,
 	const struct iiod_client_ops *ops = client->ops;
 	struct iiod_client_pdata *desc = client->desc;
 	uintptr_t ptr = (uintptr_t) src;
-	unsigned int remaining = 0, timeout_ms = client->params->timeout_ms;
+	int remaining = 0, timeout_ms = client->params->timeout_ms;
 	uint64_t start_time, diff_ms;
 	ssize_t ret;
 
 	start_time = iiod_responder_read_counter_us();
 
 	if (iiod_client_uses_binary_interface(client))
-		timeout_ms = 0;
+		timeout_ms = -1;
 
 	while (len) {
 		diff_ms = (iiod_responder_read_counter_us() - start_time) / 1000;
 
-		if (timeout_ms) {
-			if (diff_ms >= timeout_ms)
+		if (timeout_ms < 0) {
+			/* Infinite timeout */
+			remaining = -1;
+		} else if (timeout_ms > 0) {
+			if (diff_ms >= (uint64_t)timeout_ms)
 				return -ETIMEDOUT;
 
-			remaining = (unsigned int)((int64_t)timeout_ms - diff_ms);
-		}
+			remaining = (int)((int64_t)timeout_ms - diff_ms);
+		} /* else timeout_ms == 0, remaining stays 0 (nonblock) */
 
 		ret = ops->write(desc, (const void *) ptr, len, remaining);
 		if (ret < 0) {
@@ -213,24 +217,27 @@ static ssize_t iiod_client_read_all(struct iiod_client *client,
 {
 	const struct iiod_client_ops *ops = client->ops;
 	uintptr_t ptr = (uintptr_t) dst;
-	unsigned int remaining = 0, timeout_ms = client->params->timeout_ms;
+	int remaining = 0, timeout_ms = client->params->timeout_ms;
 	uint64_t start_time, diff_ms;
 	ssize_t ret;
 
 	start_time = iiod_responder_read_counter_us();
 
 	if (iiod_client_uses_binary_interface(client))
-		timeout_ms = 0;
+		timeout_ms = -1;
 
 	while (len) {
 		diff_ms = (iiod_responder_read_counter_us() - start_time) / 1000;
 
-		if (timeout_ms) {
-			if (diff_ms >= timeout_ms)
+		if (timeout_ms < 0) {
+			/* Infinite timeout */
+			remaining = -1;
+		} else if (timeout_ms > 0) {
+			if (diff_ms >= (uint64_t)timeout_ms)
 				return -ETIMEDOUT;
 
-			remaining = (unsigned int)((int64_t)timeout_ms - diff_ms);
-		}
+			remaining = (int)((int64_t)timeout_ms - diff_ms);
+		} /* else timeout_ms == 0, remaining stays 0 (nonblock) */
 
 		ret = ops->read(client->desc, (void *) ptr, len, remaining);
 		if (ret < 0) {
@@ -441,16 +448,20 @@ int iiod_client_set_trigger(struct iiod_client *client,
 	return ret;
 }
 
-static unsigned int calculate_remote_timeout(unsigned int timeout_ms)
+static int calculate_remote_timeout(int timeout_ms)
 {
+	/* Infinite and nonblock are passed through as-is */
+	if (timeout_ms <= 0)
+		return timeout_ms;
+
 	/* XXX(pcercuei): We currently hardcode timeout / 2 for the backend used
 	 * by the remote. Is there something better to do here? */
 	return timeout_ms / 2;
 }
 
-int iiod_client_set_timeout(struct iiod_client *client, unsigned int timeout)
+int iiod_client_set_timeout(struct iiod_client *client, int timeout)
 {
-	unsigned int remote_timeout = calculate_remote_timeout(timeout);
+	int remote_timeout = calculate_remote_timeout(timeout);
 	struct iiod_io *io;
 	int ret;
 
@@ -468,7 +479,7 @@ int iiod_client_set_timeout(struct iiod_client *client, unsigned int timeout)
 		char buf[1024];
 
 		iio_mutex_lock(client->lock);
-		iio_snprintf(buf, sizeof(buf), "TIMEOUT %u\r\n", remote_timeout);
+		iio_snprintf(buf, sizeof(buf), "TIMEOUT %d\r\n", remote_timeout);
 		ret = iiod_client_exec_command(client, buf);
 		iio_mutex_unlock(client->lock);
 

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -448,20 +448,34 @@ int iiod_client_set_trigger(struct iiod_client *client,
 	return ret;
 }
 
-static int calculate_remote_timeout(int timeout_ms)
+static int calculate_remote_timeout(struct iiod_client *client, int timeout_ms)
 {
-	/* Infinite and nonblock are passed through as-is */
-	if (timeout_ms <= 0)
+	/* Handle infinite timeout with backward compatibility:
+	 * - Non-binary servers (v0/tinyiiod) expect 0 for infinite (unsigned int semantic)
+	 * - Binary servers (v1+) expect -1 for infinite (signed int semantic)
+	 */
+	if (timeout_ms == -1) {
+		if (!iiod_client_uses_binary_interface(client))
+			return 0;  /* v0 semantic: 0 = infinite */
+		else
+			return -1; /* v1 semantic: -1 = infinite */
+	}
+
+	/* Nonblock and backend default passed through */
+	if (timeout_ms == 0 || timeout_ms == INT_MIN)
 		return timeout_ms;
 
 	/* XXX(pcercuei): We currently hardcode timeout / 2 for the backend used
 	 * by the remote. Is there something better to do here? */
-	return timeout_ms / 2;
+	if (timeout_ms > 0)
+		return timeout_ms / 2;
+
+	return timeout_ms;
 }
 
 int iiod_client_set_timeout(struct iiod_client *client, int timeout)
 {
-	int remote_timeout = calculate_remote_timeout(timeout);
+	int remote_timeout = calculate_remote_timeout(client, timeout);
 	struct iiod_io *io;
 	int ret;
 

--- a/iiod-responder.c
+++ b/iiod-responder.c
@@ -60,7 +60,7 @@ struct iiod_io {
 	struct iiod_client_data w_io, r_io;
 
 	/* Timeout (in milli-seconds) for I/O operations */
-	unsigned int timeout_ms;
+	int timeout_ms;
 
 	struct iio_task_token *write_token;
 };
@@ -78,7 +78,7 @@ struct iiod_responder {
 
 	bool thrd_stop;
 	int thrd_err_code;
-	unsigned int timeout_ms;
+	int timeout_ms;
 };
 
 static uint64_t read_counter_us(void)
@@ -409,8 +409,8 @@ bool iiod_io_command_is_done(struct iiod_io *io)
 
 	done = io->write_token && iio_task_is_done(io->write_token);
 
-	if (!done && io->timeout_ms) {
-		timeout_us = io->timeout_ms * 1000;
+	if (!done && io->timeout_ms > 0) {
+		timeout_us = (uint64_t)io->timeout_ms * 1000;
 
 		done = read_counter_us() - io->w_io.start_time > timeout_us;
 	}
@@ -422,7 +422,8 @@ bool iiod_io_command_is_done(struct iiod_io *io)
 
 int iiod_io_wait_for_command_done(struct iiod_io *io)
 {
-	uint64_t diff_ms = 0, timeout_ms = io->timeout_ms;
+	uint64_t diff_ms = 0;
+	int timeout_ms = io->timeout_ms;
 	struct iiod_responder *priv = io->responder;
 	struct iio_task_token *token;
 
@@ -434,44 +435,47 @@ int iiod_io_wait_for_command_done(struct iiod_io *io)
 	if (!token)
 		return 0;
 
-	if (timeout_ms) {
+	if (timeout_ms > 0) {
 		diff_ms = (read_counter_us() - io->w_io.start_time) / 1000;
 
-		if (diff_ms >= timeout_ms)
+		if (diff_ms >= (uint64_t)timeout_ms)
 			iio_task_cancel(token);
 	}
 
-	return iio_task_sync(token, (unsigned int)(timeout_ms - diff_ms));
+	if (timeout_ms <= 0)
+		return iio_task_sync(token, timeout_ms);
+
+	return iio_task_sync(token, (int)(timeout_ms - diff_ms));
 }
 
 bool iiod_io_has_response(struct iiod_io *io)
 {
-	uint64_t timeout_us = io->timeout_ms * 1000;
-
 	if (io->r_done)
 		return true;
 
-	if (!io->timeout_ms)
+	if (io->timeout_ms <= 0)
 		return false;
 
-	timeout_us = io->timeout_ms * 1000;
-
-	return read_counter_us() - io->w_io.start_time > timeout_us;
+	return read_counter_us() - io->w_io.start_time >
+		(uint64_t)io->timeout_ms * 1000;
 }
 
 static int iiod_io_cond_wait(const struct iiod_io *io)
 {
-	uint64_t diff_ms, timeout_ms = io->timeout_ms;
+	uint64_t diff_ms;
+	int timeout_ms = io->timeout_ms;
 
-	if (!timeout_ms)
-		return iio_cond_wait(io->cond, io->lock, 0);
+	if (timeout_ms < 0)
+		return iio_cond_wait(io->cond, io->lock, -1);
+
+	if (timeout_ms == 0)
+		return -ETIMEDOUT;
 
 	diff_ms = (read_counter_us() - io->r_io.start_time) / 1000;
 
-	if (diff_ms < timeout_ms) {
+	if (diff_ms < (uint64_t)timeout_ms)
 		return iio_cond_wait(io->cond, io->lock,
-				     (unsigned int)(timeout_ms - diff_ms));
-	}
+				     (int)(timeout_ms - diff_ms));
 
 	return -ETIMEDOUT;
 }
@@ -638,14 +642,14 @@ err_free_io:
 }
 
 void
-iiod_responder_set_timeout(struct iiod_responder *priv, unsigned int timeout_ms)
+iiod_responder_set_timeout(struct iiod_responder *priv, int timeout_ms)
 {
 	priv->timeout_ms = timeout_ms;
 	priv->default_io->timeout_ms = timeout_ms;
 }
 
 void
-iiod_io_set_timeout(struct iiod_io *io, unsigned int timeout_ms)
+iiod_io_set_timeout(struct iiod_io *io, int timeout_ms)
 {
 	io->timeout_ms = timeout_ms;
 }
@@ -662,6 +666,7 @@ iiod_responder_create(const struct iiod_responder_ops *ops, void *d)
 
 	priv->ops = ops;
 	priv->d = d;
+	priv->timeout_ms = -1;  /* Default to infinite timeout */
 
 	priv->lock = iio_mutex_create();
 	err = iio_err(priv->lock);
@@ -752,7 +757,7 @@ void iiod_io_cancel(struct iiod_io *io)
 	/* Discard the entry from the writers list */
 	if (token) {
 		iio_task_cancel(token);
-		iio_task_sync(token, 0);
+		iio_task_sync(token, -1);
 	}
 
 	/* Cancel any pending response request */

--- a/iiod-responder.h
+++ b/iiod-responder.h
@@ -86,10 +86,9 @@ struct iiod_responder *
 iiod_responder_create(const struct iiod_responder_ops *ops, void *d);
 void iiod_responder_destroy(struct iiod_responder *responder);
 
-/* Set the timeout for I/O operations (default is 0 == infinite) */
-void iiod_responder_set_timeout(struct iiod_responder *priv,
-				unsigned int timeout_ms);
-void iiod_io_set_timeout(struct iiod_io *io, unsigned int timeout_ms);
+/* Set the timeout for I/O operations (default is -1 == infinite) */
+void iiod_responder_set_timeout(struct iiod_responder *priv, int timeout_ms);
+void iiod_io_set_timeout(struct iiod_io *io, int timeout_ms);
 
 /* Read the current value of the micro-second counter */
 uint64_t iiod_responder_read_counter_us(void);

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -1421,7 +1421,7 @@ ssize_t get_trigger(struct parser_pdata *pdata, struct iio_device *dev)
 	return ret;
 }
 
-int set_timeout(struct parser_pdata *pdata, unsigned int timeout)
+int set_timeout(struct parser_pdata *pdata, int timeout)
 {
 	int ret = iio_context_set_timeout(pdata->ctx, timeout);
 	print_value(pdata, ret);

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -1423,7 +1423,19 @@ ssize_t get_trigger(struct parser_pdata *pdata, struct iio_device *dev)
 
 int set_timeout(struct parser_pdata *pdata, int timeout)
 {
-	int ret = iio_context_set_timeout(pdata->ctx, timeout);
+	int translated_timeout = timeout;
+	int ret;
+
+	/* Translate v0 client timeout semantics to v1 semantics:
+	 * - v0 clients (non-binary) use: 0 = infinite, positive = timeout
+	 * - v1 clients (binary) use: -1 = infinite, 0 = backend default, positive = timeout
+	 */
+	if (!pdata->binary && timeout == 0) {
+		/* v0 client sending 0 (infinite) -> translate to v1 infinite (-1) */
+		translated_timeout = -1;
+	}
+
+	ret = iio_context_set_timeout(pdata->ctx, translated_timeout);
 	print_value(pdata, ret);
 	return ret;
 }

--- a/iiod/ops.h
+++ b/iiod/ops.h
@@ -175,7 +175,7 @@ ssize_t get_trigger(struct parser_pdata *pdata, struct iio_device *dev);
 ssize_t set_trigger(struct parser_pdata *pdata,
 		struct iio_device *dev, const char *trig);
 
-int set_timeout(struct parser_pdata *pdata, unsigned int timeout);
+int set_timeout(struct parser_pdata *pdata, int timeout);
 int set_buffers_count(struct parser_pdata *pdata,
 		struct iio_device *dev, long value);
 

--- a/iiod/parser.y
+++ b/iiod/parser.y
@@ -180,7 +180,7 @@ Line:
 	| TIMEOUT SPACE WORD END {
 		char *word = $3;
 		struct parser_pdata *pdata = yyget_extra(scanner);
-		unsigned int timeout = (unsigned int) atoi(word);
+		int timeout = atoi(word);
 		int ret = set_timeout(pdata, timeout);
 		free(word);
 		if (ret < 0)

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -768,8 +768,8 @@ static void handle_free_block(struct parser_pdata *pdata,
 	}
 
 	/* make sure the block is not being used by the enqueue or dequeue tasks */
-	iio_task_cancel_sync(entry->enqueue_token, 0);
-	iio_task_cancel_sync(entry->dequeue_token, 0);
+	iio_task_cancel_sync(entry->enqueue_token, -1);
+	iio_task_cancel_sync(entry->dequeue_token, -1);
 
 	if (WITH_IIOD_USB_DMABUF && entry->dmabuf_fd > 0)
 		usb_detach_dmabuf(entry->ep_fd, entry->dmabuf_fd);

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -107,7 +107,7 @@ struct iio_backend_ops {
 	int (*get_version)(const struct iio_context *ctx, unsigned int *major,
 			unsigned int *minor, char git_tag[8]);
 
-	int (*set_timeout)(struct iio_context *ctx, unsigned int timeout);
+	int (*set_timeout)(struct iio_context *ctx, int timeout);
 
 	struct iio_buffer_pdata *(*open_buffer)(const struct iio_device *dev,
 						unsigned int idx,

--- a/include/iio/iio-lock.h
+++ b/include/iio/iio-lock.h
@@ -29,7 +29,7 @@ __api struct iio_cond * iio_cond_create(void);
 __api void iio_cond_destroy(struct iio_cond *cond);
 
 __api int iio_cond_wait(struct iio_cond *cond, struct iio_mutex *lock,
-			unsigned int timeout_ms);
+			int timeout_ms);
 __api void iio_cond_signal(struct iio_cond *cond);
 
 __api struct iio_thrd * iio_thrd_create(int (*thrd)(void *),
@@ -51,8 +51,8 @@ __api int iio_task_enqueue_autoclear(struct iio_task *task, void *elm);
 __api int iio_task_token_enqueue(struct iio_task_token *token);
 
 __api _Bool iio_task_is_done(struct iio_task_token *token);
-__api int iio_task_sync(struct iio_task_token *token, unsigned int timeout_ms);
-__api int iio_task_cancel_sync(struct iio_task_token *token, unsigned int timeout_ms);
+__api int iio_task_sync(struct iio_task_token *token, int timeout_ms);
+__api int iio_task_cancel_sync(struct iio_task_token *token, int timeout_ms);
 __api void iio_task_cancel(struct iio_task_token *token);
 
 #undef __api

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -146,6 +146,13 @@ enum iio_log_level {
 	LEVEL_DEBUG = 5,
 };
 
+/** @brief Use backend default timeout */
+#define IIO_TIMEOUT_BACKEND	0
+/** @brief Wait indefinitely (no timeout) */
+#define IIO_TIMEOUT_INFINITE	(-1)
+/** @brief Non-blocking operation */
+#define IIO_TIMEOUT_NONBLOCK	INT_MIN
+
 /**
  * @enum iio_context_flags
  * @brief Flags controlling context behavior;
@@ -189,9 +196,11 @@ struct iio_context_params {
 	enum iio_log_level timestamp_level;
 
 	/** @brief Timeout for I/O operations in milliseconds.
-	 * - Zero: use backend default timeout
-	 * - Negative values: no timeout (wait indefinitely)
-	 * - Positive values: timeout after specified milliseconds */
+	 * - IIO_TIMEOUT_BACKEND (0): use backend default timeout
+	 * - IIO_TIMEOUT_INFINITE (-1): no timeout (wait indefinitely)
+	 * - IIO_TIMEOUT_NONBLOCK (INT_MIN): non-blocking
+	 * - Positive values: timeout after specified milliseconds
+	 * - Other negative values: invalid (returns -EINVAL) */
 	int timeout_ms;
 
 	/** @brief Flags that control context behavior.
@@ -802,13 +811,16 @@ __api __check_ret __pure struct iio_device * iio_context_find_device(
 
 /** @brief Set a timeout for I/O operations
  * @param ctx A pointer to an iio_context structure
- * @param timeout_ms A positive integer representing the time in milliseconds
- * after which a timeout occurs. A value of 0 is used to specify that no
- * timeout should occur.
+ * @param timeout_ms Timeout value in milliseconds:
+ *   - IIO_TIMEOUT_BACKEND (0): use backend default timeout
+ *   - IIO_TIMEOUT_INFINITE (-1): no timeout (wait indefinitely)
+ *   - IIO_TIMEOUT_NONBLOCK (INT_MIN): non-blocking
+ *   - Positive: timeout after specified milliseconds
+ *   - Other negative values: returns -EINVAL
  * @return On success, 0 is returned
  * @return On error, a negative errno code is returned */
 __api __check_ret int iio_context_set_timeout(
-		struct iio_context *ctx, unsigned int timeout_ms);
+		struct iio_context *ctx, int timeout_ms);
 
 
 /** @brief Get a pointer to the params structure

--- a/include/iio/iiod-client.h
+++ b/include/iio/iiod-client.h
@@ -20,11 +20,11 @@ struct iio_event_stream_pdata;
 
 struct iiod_client_ops {
 	ssize_t (*write)(struct iiod_client_pdata *desc,
-			 const char *src, size_t len, unsigned int timeout_ms);
+			 const char *src, size_t len, int timeout_ms);
 	ssize_t (*read)(struct iiod_client_pdata *desc,
-			char *dst, size_t len, unsigned int timeout_ms);
+			char *dst, size_t len, int timeout_ms);
 	ssize_t (*read_line)(struct iiod_client_pdata *desc,
-			     char *dst, size_t len, unsigned int timeout_ms);
+			     char *dst, size_t len, int timeout_ms);
 	void (*cancel)(struct iiod_client_pdata *desc);
 };
 
@@ -48,8 +48,7 @@ __api int iiod_client_set_trigger(struct iiod_client *client,
 				  const struct iio_device *dev,
 				  const struct iio_device *trigger);
 
-__api int iiod_client_set_timeout(struct iiod_client *client,
-				  unsigned int timeout);
+__api int iiod_client_set_timeout(struct iiod_client *client, int timeout);
 
 __api ssize_t iiod_client_attr_read(struct iiod_client *client,
 				    const struct iio_attr *attr,

--- a/local.c
+++ b/local.c
@@ -220,27 +220,28 @@ static int set_channel_name(struct iio_channel *chn)
  * before each poll() invocation the timeout is recalculated relative to the
  * start of refill() or push() operation.
  */
-static int get_rel_timeout_ms(struct timespec *start, unsigned int timeout_rel)
+static int get_rel_timeout_ms(struct timespec *start, int timeout_rel)
 {
 	struct timespec now;
 	int diff_ms;
 
-	if (timeout_rel == 0) /* No timeout */
+	if (timeout_rel < 0) /* Infinite timeout */
 		return -1;
+
+	if (timeout_rel == 0) /* Non-blocking */
+		return 0;
 
 	clock_gettime(CLOCK_MONOTONIC, &now);
 
 	diff_ms = (now.tv_sec - start->tv_sec) * 1000;
 	diff_ms += (now.tv_nsec - start->tv_nsec) / 1000000;
 
-	if (diff_ms >= (int) timeout_rel) /* Expired */
+	if (diff_ms >= timeout_rel) /* Expired */
 		return 0;
 	if (diff_ms > 0) /* Should never be false, but lets be safe */
 		timeout_rel -= diff_ms;
-	if (timeout_rel > INT_MAX)
-		return INT_MAX;
 
-	return (int) timeout_rel;
+	return timeout_rel;
 }
 
 int buffer_check_ready(struct iio_buffer_pdata *pdata, int fd,
@@ -255,7 +256,7 @@ int buffer_check_ready(struct iio_buffer_pdata *pdata, int fd,
 			.events = POLLIN,
 		}
 	};
-	unsigned int rw_timeout_ms = pdata->dev->ctx->params.timeout_ms;
+	int rw_timeout_ms = pdata->dev->ctx->params.timeout_ms;
 	int timeout_rel, ret;
 
 	do {

--- a/lock-dummy.c
+++ b/lock-dummy.c
@@ -59,7 +59,7 @@ void iio_cond_destroy(struct iio_cond *cond)
 }
 
 int iio_cond_wait(struct iio_cond *cond, struct iio_mutex *lock,
-		  unsigned int timeout_ms)
+		  int timeout_ms)
 {
 	return -ETIMEDOUT;
 }

--- a/lock-windows.c
+++ b/lock-windows.c
@@ -76,14 +76,17 @@ void iio_cond_destroy(struct iio_cond *cond)
 }
 
 int iio_cond_wait(struct iio_cond *cond, struct iio_mutex *lock,
-		  unsigned int timeout_ms)
+		  int timeout_ms)
 {
 	BOOL ret;
+	DWORD dwTimeout;
 
-	if (timeout_ms == 0)
-		timeout_ms = INFINITE;
+	if (timeout_ms < 0)
+		dwTimeout = INFINITE;
+	else
+		dwTimeout = (DWORD)timeout_ms;
 
-	ret = SleepConditionVariableCS(&cond->cond, &lock->lock, timeout_ms);
+	ret = SleepConditionVariableCS(&cond->cond, &lock->lock, dwTimeout);
 
 	return ret ? 0 : -ETIMEDOUT;
 }

--- a/lock.c
+++ b/lock.c
@@ -90,19 +90,21 @@ void iio_cond_destroy(struct iio_cond *cond)
 }
 
 int iio_cond_wait(struct iio_cond *cond, struct iio_mutex *lock,
-		  unsigned int timeout_ms)
+		  int timeout_ms)
 {
 	struct timespec ts;
 	uint64_t usec;
 	int ret = 0;
 
-	if (timeout_ms == 0) {
+	if (timeout_ms < 0) {
 		pthread_cond_wait(&cond->cond, &lock->lock);
+	} else if (timeout_ms == 0) {
+		ret = -ETIMEDOUT;
 	} else {
 		clock_gettime(CLOCK_REALTIME, &ts);
 
 		usec = ts.tv_sec * 1000000ull + ts.tv_nsec / 1000;
-		usec += timeout_ms * 1000ull;
+		usec += (uint64_t)timeout_ms * 1000ull;
 
 		ts.tv_sec = usec / 1000000;
 		ts.tv_nsec = (usec % 1000000) * 1000;

--- a/man/iio_common_opts.1
+++ b/man/iio_common_opts.1
@@ -36,4 +36,4 @@ with no address part.
 .RE
 .TP
 .B \-T, \-\-timeout <arg>
-Context timeout in milliseconds. 0 = no timeout (wait forever). Default is 0.
+Context timeout in milliseconds. 0 = use backend default, -1 = wait forever, 'nb' or 'nonblocking' = non-blocking mode. Default is 0.

--- a/network-unix.c
+++ b/network-unix.c
@@ -102,9 +102,9 @@ void do_cancel(struct iiod_client_pdata *io_ctx)
 }
 
 int wait_cancellable(struct iiod_client_pdata *io_ctx,
-		     bool read, unsigned int timeout_ms)
+		     bool read, int timeout_ms)
 {
-	int timeout = timeout_ms > 0 ? (int) timeout_ms : -1;
+	int timeout = timeout_ms;
 	struct pollfd pfd[2];
 	int ret;
 
@@ -190,23 +190,17 @@ int do_create_socket(const struct addrinfo *addrinfo)
 	return fd;
 }
 
-int do_select(int fd, unsigned int timeout)
+int do_select(int fd, int timeout)
 {
 	struct pollfd pfd;
 	int ret;
-	int poll_timeout;
 
 	pfd.fd = fd;
 	pfd.events = POLLOUT | POLLERR;
 	pfd.revents = 0;
 
-	if (!timeout)
-		poll_timeout = -1;
-	else
-		poll_timeout = (int)timeout;
-
 	do {
-		ret = poll(&pfd, 1, poll_timeout);
+		ret = poll(&pfd, 1, timeout);
 	} while (ret == -1 && errno == EINTR);
 
 	if (ret < 0)

--- a/network-windows.c
+++ b/network-windows.c
@@ -86,11 +86,16 @@ void do_cancel(struct iiod_client_pdata *io_ctx)
 }
 
 int wait_cancellable(struct iiod_client_pdata *io_ctx,
-		     bool read, unsigned int timeout_ms)
+		     bool read, int timeout_ms)
 {
 	struct iio_mutex *lock = io_ctx->os_priv->event_lock;
 	long wsa_events = FD_CLOSE;
-	DWORD ret, timeout = timeout_ms > 0 ? (DWORD) timeout_ms : WSA_INFINITE;
+	DWORD ret, timeout;
+
+	if (timeout_ms < 0)
+		timeout = WSA_INFINITE;
+	else
+		timeout = (DWORD) timeout_ms;
 
 	iio_mutex_lock(lock);
 	if (read)
@@ -179,7 +184,7 @@ int do_create_socket(const struct addrinfo *addrinfo)
 	return (int) s;
 }
 
-int do_select(int fd, unsigned int timeout)
+int do_select(int fd, int timeout)
 {
 	struct timeval tv;
 	struct timeval *ptv;
@@ -199,7 +204,7 @@ int do_select(int fd, unsigned int timeout)
 #pragma warning(default: 4389)
 #endif
 
-	if (timeout != 0) {
+	if (timeout >= 0) {
 		tv.tv_sec = timeout / 1000;
 		tv.tv_usec = (timeout % 1000) * 1000;
 		ptv = &tv;

--- a/network.c
+++ b/network.c
@@ -78,10 +78,10 @@ network_create_context(const struct iio_context_params *params,
 
 static ssize_t
 network_write_data(struct iiod_client_pdata *io_ctx, const char *src, size_t len,
-		   unsigned int timeout_ms);
+		   int timeout_ms);
 static ssize_t
 network_read_data(struct iiod_client_pdata *io_ctx, char *dst, size_t len,
-		  unsigned int timeout_ms);
+		  int timeout_ms);
 static void network_cancel(struct iiod_client_pdata *io_ctx);
 
 static const struct iiod_client_ops network_iiod_client_ops = {
@@ -91,7 +91,7 @@ static const struct iiod_client_ops network_iiod_client_ops = {
 };
 
 static ssize_t network_recv(struct iiod_client_pdata *io_ctx, void *data,
-			    size_t len, int flags, unsigned int timeout_ms)
+			    size_t len, int flags, int timeout_ms)
 {
 	bool cancellable = true;
 	ssize_t ret;
@@ -128,7 +128,7 @@ static ssize_t network_recv(struct iiod_client_pdata *io_ctx, void *data,
 }
 
 static ssize_t network_send(struct iiod_client_pdata *io_ctx, const void *data,
-			    size_t len, int flags, unsigned int timeout_ms)
+			    size_t len, int flags, int timeout_ms)
 {
 	ssize_t ret;
 	int err;
@@ -180,7 +180,7 @@ network_writebuf(struct iio_buffer_pdata *pdata, const void *src, size_t len)
 /* The purpose of this function is to provide a version of connect()
  * that does not ignore timeouts... */
 static int do_connect(int fd, const struct addrinfo *addrinfo,
-	unsigned int timeout)
+	int timeout)
 {
 	int ret, error;
 	socklen_t len;
@@ -217,7 +217,7 @@ static int do_connect(int fd, const struct addrinfo *addrinfo,
 	return 0;
 }
 
-int create_socket(const struct addrinfo *addrinfo, unsigned int timeout)
+int create_socket(const struct addrinfo *addrinfo, int timeout)
 {
 	int ret, fd, yes = 1;
 
@@ -424,7 +424,7 @@ static void network_shutdown(struct iio_context *ctx)
 	freeaddrinfo(pdata->addrinfo);
 }
 
-static int network_set_timeout(struct iio_context *ctx, unsigned int timeout)
+static int network_set_timeout(struct iio_context *ctx, int timeout)
 {
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 	int ret;
@@ -584,13 +584,13 @@ const struct iio_backend iio_ip_backend = {
 
 static ssize_t network_write_data(struct iiod_client_pdata *io_ctx,
 				  const char *src, size_t len,
-				  unsigned int timeout_ms)
+				  int timeout_ms)
 {
 	return network_send(io_ctx, src, len, MSG_NOSIGNAL, timeout_ms);
 }
 
 static ssize_t network_read_data(struct iiod_client_pdata *io_ctx,
-				 char *dst, size_t len, unsigned int timeout_ms)
+				 char *dst, size_t len, int timeout_ms)
 {
 	return network_recv(io_ctx, dst, len, 0, timeout_ms);
 }

--- a/network.c
+++ b/network.c
@@ -8,6 +8,7 @@
 
 #include "dns_sd.h"
 #include "iio-config.h"
+#include "iio-private.h"
 #include "network.h"
 
 #include <iio/iio.h>
@@ -326,7 +327,7 @@ network_setup_iiod_client(const struct iio_device *dev,
 	 * Use the timeout that was set when creating the context.
 	 * See commit 9eff490 for more info.
 	 */
-	ret = create_socket(pdata->addrinfo, NETWORK_TIMEOUT_MS);
+	ret = create_socket(pdata->addrinfo, ctx->params.timeout_ms);
 	if (ret < 0) {
 		dev_perror(dev, ret, "Unable to create socket");
 		return iio_ptr(ret);

--- a/network.h
+++ b/network.h
@@ -35,11 +35,11 @@ int setup_cancel(struct iiod_client_pdata *io_ctx);
 void cleanup_cancel(struct iiod_client_pdata *io_ctx);
 void do_cancel(struct iiod_client_pdata *io_ctx);
 int wait_cancellable(struct iiod_client_pdata *io_ctx,
-		     bool read, unsigned int timeout_ms);
+		     bool read, int timeout_ms);
 
-int create_socket(const struct addrinfo *addrinfo, unsigned int timeout);
+int create_socket(const struct addrinfo *addrinfo, int timeout);
 int do_create_socket(const struct addrinfo *addrinfo);
-int do_select(int fd, unsigned int timeout);
+int do_select(int fd, int timeout);
 
 int set_blocking_mode(int s, bool blocking);
 

--- a/scan.c
+++ b/scan.c
@@ -114,10 +114,13 @@ struct iio_scan * iio_scan(const struct iio_context_params *params,
 			continue;
 		}
 
-		if (params->timeout_ms)
-			params2.timeout_ms = params->timeout_ms;
-		else
-			params2.timeout_ms = backend->default_timeout_ms;
+		params2.timeout_ms = iio_resolve_timeout(params->timeout_ms,
+						  backend->default_timeout_ms);
+		if (params2.timeout_ms == -EINVAL) {
+			prm_perror(params, -EINVAL,
+				   "Invalid timeout: %d for backend %s\n", params->timeout_ms, token);
+			continue;
+		}
 
 		ret = backend->ops->scan(&params2, ctx, args);
 		if (ret < 0) {

--- a/serial.c
+++ b/serial.c
@@ -355,7 +355,7 @@ const struct iio_backend iio_serial_backend = {
 	.name = "serial",
 	.uri_prefix = "serial:",
 	.ops = &serial_ops,
-	.default_timeout_ms = 1000,
+	.default_timeout_ms = 10000,
 };
 
 static const struct iiod_client_ops serial_iiod_client_ops = {

--- a/serial.c
+++ b/serial.c
@@ -129,13 +129,14 @@ serial_write_attr(const struct iio_attr *attr, const char *src, size_t len)
 
 static ssize_t serial_write_data(struct iiod_client_pdata *io_data,
 				 const char *data, size_t len,
-				 unsigned int timeout_ms)
+				 int timeout_ms)
 {
 	struct iio_context_pdata *pdata = (struct iio_context_pdata *) io_data;
 	enum sp_return sp_ret;
 	ssize_t ret;
 
-	sp_ret = sp_blocking_write(pdata->port, data, len, timeout_ms);
+	sp_ret = sp_blocking_write(pdata->port, data, len,
+				   timeout_ms > 0 ? (unsigned int) timeout_ms : 0);
 	ret = (ssize_t) libserialport_to_errno(sp_ret);
 
 	prm_dbg(&pdata->params, "Write returned %li: %s\n", (long) ret, data);
@@ -167,7 +168,7 @@ void sleep_one_ms(void)
 }
 
 static ssize_t serial_read_data(struct iiod_client_pdata *io_data,
-				char *buf, size_t len, unsigned int timeout_ms)
+				char *buf, size_t len, int timeout_ms)
 {
 	struct iio_context_pdata *pdata = (struct iio_context_pdata *) io_data;
 	long long time_left_ms = (long long)timeout_ms;
@@ -175,7 +176,7 @@ static ssize_t serial_read_data(struct iiod_client_pdata *io_data,
 	ssize_t ret = 0;
 
 	while (true) {
-		if (timeout_ms && time_left_ms <= 0)
+		if (timeout_ms > 0 && time_left_ms <= 0)
 			break;
 
 		sp_ret = sp_nonblocking_read(pdata->port, buf, len);

--- a/task.c
+++ b/task.c
@@ -45,7 +45,7 @@ static void iio_task_process(struct iio_task *task)
 	iio_cond_signal(task->cond);
 
 	while (!task->stop && !(task->list && task->running)) {
-		iio_cond_wait(task->cond, task->lock, 0);
+		iio_cond_wait(task->cond, task->lock, -1);
 
 		/* If iio_task_stop() was called while we were waiting
 		 * for clients, notify that we're idle. */
@@ -87,7 +87,7 @@ static int iio_task_run(void *d)
 
 	return 0;
 }
-static int iio_task_sync_core(struct iio_task_token *token, unsigned int timeout_ms, bool token_destroy)
+static int iio_task_sync_core(struct iio_task_token *token, int timeout_ms, bool token_destroy)
 {
 	int ret;
 
@@ -301,7 +301,7 @@ int iio_task_enqueue_autoclear(struct iio_task *task, void *elm)
 	return iio_err(iio_task_do_enqueue(task, elm, true));
 }
 
-int iio_task_sync(struct iio_task_token *token, unsigned int timeout_ms)
+int iio_task_sync(struct iio_task_token *token, int timeout_ms)
 {
 	return iio_task_sync_core(token, timeout_ms, true);
 }
@@ -355,7 +355,7 @@ bool iio_task_is_done(struct iio_task_token *token)
 	return token->done;
 }
 
-int iio_task_cancel_sync(struct iio_task_token *token, unsigned int timeout_ms)
+int iio_task_cancel_sync(struct iio_task_token *token, int timeout_ms)
 {
 	iio_task_cancel(token);
 	return iio_task_sync_core(token, timeout_ms, false);
@@ -399,6 +399,6 @@ void iio_task_stop(struct iio_task *task)
 	iio_mutex_lock(task->lock);
 	task->running = false;
 	iio_cond_signal(task->cond);
-	iio_cond_wait(task->cond, task->lock, 0);
+	iio_cond_wait(task->cond, task->lock, -1);
 	iio_mutex_unlock(task->lock);
 }

--- a/tests/api/test_context.c
+++ b/tests/api/test_context.c
@@ -10,8 +10,15 @@
 #include <iio/iio.h>
 #include <errno.h>
 #include <string.h>
+#include <time.h>
 
 static struct iio_context *test_ctx = NULL;
+
+static inline long get_elapsed_ms(struct timespec *start, struct timespec *end)
+{
+	return (end->tv_sec - start->tv_sec) * 1000 +
+	       (end->tv_nsec - start->tv_nsec) / 1000000;
+}
 
 static void setup_test_context(void)
 {
@@ -263,19 +270,101 @@ TEST_FUNCTION(context_timeout)
 		DEBUG_PRINT("  INFO: Setting timeout failed with error %d\n", ret);
 	}
 
-	ret = iio_context_set_timeout(test_ctx, 0);
+	ret = iio_context_set_timeout(test_ctx, IIO_TIMEOUT_BACKEND);
 	if (ret == 0) {
-		DEBUG_PRINT("  INFO: Successfully set timeout to 0 (no timeout)\n");
+		DEBUG_PRINT("  INFO: Successfully set timeout to IIO_TIMEOUT_BACKEND\n");
 	} else {
-		DEBUG_PRINT("  INFO: Setting timeout to 0 failed with error %d\n", ret);
+		DEBUG_PRINT("  INFO: Setting timeout to IIO_TIMEOUT_BACKEND failed with error %d\n", ret);
 	}
 
-	ret = iio_context_set_timeout(test_ctx, UINT_MAX);
+	ret = iio_context_set_timeout(test_ctx, IIO_TIMEOUT_INFINITE);
 	if (ret == 0) {
-		DEBUG_PRINT("  INFO: Successfully set timeout to UINT_MAX\n");
+		DEBUG_PRINT("  INFO: Successfully set timeout to IIO_TIMEOUT_INFINITE\n");
 	} else {
-		DEBUG_PRINT("  INFO: Setting timeout to UINT_MAX failed with error %d\n", ret);
+		DEBUG_PRINT("  INFO: Setting timeout to IIO_TIMEOUT_INFINITE failed with error %d\n", ret);
 	}
+
+	ret = iio_context_set_timeout(test_ctx, IIO_TIMEOUT_NONBLOCK);
+	if (ret == 0) {
+		DEBUG_PRINT("  INFO: Successfully set timeout to IIO_TIMEOUT_NONBLOCK\n");
+	} else {
+		DEBUG_PRINT("  INFO: Setting timeout to IIO_TIMEOUT_NONBLOCK failed with error %d\n", ret);
+	}
+
+	ret = iio_context_set_timeout(test_ctx, -42);
+	TEST_ASSERT_INT_EQUAL(ret, -EINVAL, "Invalid negative timeout should return -EINVAL");
+}
+
+TEST_FUNCTION(context_timeout_measurement)
+{
+	struct iio_context_params params;
+	struct iio_context *ctx;
+	struct timespec start, end;
+	long elapsed_ms;
+	int err;
+
+	/*
+	 * Use an IP address from TEST-NET-1 (RFC 5737) - reserved for
+	 * documentation and should not route, causing connection timeout.
+	 * Port 30431 is the default iiod port.
+	 */
+	const char *unreachable_uri = "ip:192.0.2.1:30431";
+
+	/* Test 1: 1000ms timeout */
+	DEBUG_PRINT("  INFO: Testing 1000ms timeout...\n");
+	params = (struct iio_context_params){
+		.timeout_ms = 1000,
+	};
+
+	clock_gettime(CLOCK_MONOTONIC, &start);
+	ctx = iio_create_context(&params, unreachable_uri);
+	clock_gettime(CLOCK_MONOTONIC, &end);
+
+	err = iio_err(ctx);
+	elapsed_ms = get_elapsed_ms(&start, &end);
+
+	DEBUG_PRINT("  INFO: 1000ms timeout: error=%d, elapsed=%ld ms\n", err, elapsed_ms);
+	TEST_ASSERT(iio_err(ctx), "Connection to unreachable host should fail");
+
+	/* Allow ±500ms tolerance (some overhead for DNS, connection setup, etc.) */
+	TEST_ASSERT_DURATION_RANGE(elapsed_ms, 500, 2000,
+		"1000ms timeout should complete within expected range");
+
+	/* Test 2: 4000ms timeout */
+	DEBUG_PRINT("  INFO: Testing 4000ms timeout...\n");
+	params.timeout_ms = 4000;
+
+	clock_gettime(CLOCK_MONOTONIC, &start);
+	ctx = iio_create_context(&params, unreachable_uri);
+	clock_gettime(CLOCK_MONOTONIC, &end);
+
+	err = iio_err(ctx);
+	elapsed_ms = get_elapsed_ms(&start, &end);
+
+	DEBUG_PRINT("  INFO: 4000ms timeout: error=%d, elapsed=%ld ms\n", err, elapsed_ms);
+	TEST_ASSERT(iio_err(ctx), "Connection to unreachable host should fail");
+
+	/* Allow ±1000ms tolerance */
+	TEST_ASSERT_DURATION_RANGE(elapsed_ms, 3000, 5500,
+		"4000ms timeout should complete within expected range");
+
+	/* Test 3: Non-blocking mode */
+	DEBUG_PRINT("  INFO: Testing non-blocking mode...\n");
+	params.timeout_ms = IIO_TIMEOUT_NONBLOCK;
+
+	clock_gettime(CLOCK_MONOTONIC, &start);
+	ctx = iio_create_context(&params, unreachable_uri);
+	clock_gettime(CLOCK_MONOTONIC, &end);
+
+	err = iio_err(ctx);
+	elapsed_ms = get_elapsed_ms(&start, &end);
+
+	DEBUG_PRINT("  INFO: Non-blocking: error=%d, elapsed=%ld ms\n", err, elapsed_ms);
+	TEST_ASSERT(iio_err(ctx), "Connection to unreachable host should fail");
+
+	/* Non-blocking should return almost immediately (within 500ms) */
+	TEST_ASSERT_DURATION_RANGE(elapsed_ms, 0, 500,
+		"Non-blocking mode should return immediately");
 }
 
 TEST_FUNCTION(context_user_data)
@@ -321,6 +410,7 @@ int main(void)
 	RUN_TEST(context_attributes);
 	RUN_TEST(context_devices);
 	RUN_TEST(context_timeout);
+	RUN_TEST(context_timeout_measurement);
 	RUN_TEST(context_user_data);
 	RUN_TEST(context_destroy_behavior);
 

--- a/tests/api/test_framework.h
+++ b/tests/api/test_framework.h
@@ -83,6 +83,32 @@ static int test_failed = 0;
 		} \
 	} while (0)
 
+#define TEST_ASSERT_INT_EQUAL(actual, expected, message) \
+	do { \
+		test_count++; \
+		if ((actual) == (expected)) { \
+			test_passed++; \
+			DEBUG_PRINT("  PASS: %s (got %d, expected %d)\n", message, (int)(actual), (int)(expected)); \
+		} else { \
+			test_failed++; \
+			DEBUG_PRINT("  FAIL: %s (got %d, expected %d)\n", message, (int)(actual), (int)(expected)); \
+		} \
+	} while (0)
+
+#define TEST_ASSERT_DURATION_RANGE(duration_ms, min_ms, max_ms, message) \
+	do { \
+		test_count++; \
+		if ((duration_ms) >= (min_ms) && (duration_ms) <= (max_ms)) { \
+			test_passed++; \
+			DEBUG_PRINT("  PASS: %s (duration %ld ms in range [%ld, %ld] ms)\n", \
+				message, (long)(duration_ms), (long)(min_ms), (long)(max_ms)); \
+		} else { \
+			test_failed++; \
+			DEBUG_PRINT("  FAIL: %s (duration %ld ms out of range [%ld, %ld] ms)\n", \
+				message, (long)(duration_ms), (long)(min_ms), (long)(max_ms)); \
+		} \
+	} while (0)
+
 #define TEST_FUNCTION(name) \
 	static void test_##name(void); \
 	static void test_##name(void)

--- a/usb.c
+++ b/usb.c
@@ -109,9 +109,9 @@ usb_create_context_from_args(const struct iio_context_params *params,
 static int usb_context_scan(const struct iio_context_params *params,
 			    struct iio_scan *scan, const char *args);
 static ssize_t write_data_sync(struct iiod_client_pdata *ep, const char *data,
-			       size_t len, unsigned int timeout_ms);
+			       size_t len, int timeout_ms);
 static ssize_t read_data_sync(struct iiod_client_pdata *ep, char *buf,
-			      size_t len, unsigned int timeout_ms);
+			      size_t len, int timeout_ms);
 static void usb_cancel(struct iiod_client_pdata *io_ctx);
 
 static int usb_io_context_init(struct iiod_client_pdata *io_ctx)
@@ -268,7 +268,7 @@ usb_write_attr(const struct iio_attr *attr, const char *src, size_t len)
 	return iiod_client_attr_write(client, attr, src, len);
 }
 
-static int usb_set_timeout(struct iio_context *ctx, unsigned int timeout)
+static int usb_set_timeout(struct iio_context *ctx, int timeout)
 {
 	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
 
@@ -590,7 +590,7 @@ static void LIBUSB_CALL sync_transfer_cb(struct libusb_transfer *transfer)
 static int usb_sync_transfer(struct iio_context_pdata *pdata,
 			     struct iiod_client_pdata *io_ctx,
 			     unsigned int ep_type, char *data, size_t len,
-			     int *transferred, unsigned int timeout_ms)
+			     int *transferred, int timeout_ms)
 {
 	unsigned char ep;
 	struct libusb_transfer *transfer = NULL;
@@ -635,7 +635,8 @@ static int usb_sync_transfer(struct iio_context_pdata *pdata,
 
 	libusb_fill_bulk_transfer(transfer, pdata->hdl, ep,
 			(unsigned char *) data, (int) len, sync_transfer_cb,
-			&completed, timeout_ms);
+			&completed,
+			timeout_ms > 0 ? (unsigned int) timeout_ms : 0);
 	transfer->type = LIBUSB_TRANSFER_TYPE_BULK;
 
 	ret = libusb_submit_transfer(transfer);
@@ -695,7 +696,7 @@ unlock:
 
 static ssize_t write_data_sync(struct iiod_client_pdata *ep,
 			       const char *data, size_t len,
-			       unsigned int timeout_ms)
+			       int timeout_ms)
 {
 	int transferred, ret;
 
@@ -708,7 +709,7 @@ static ssize_t write_data_sync(struct iiod_client_pdata *ep,
 }
 
 static ssize_t read_data_sync(struct iiod_client_pdata *ep,
-			      char *buf, size_t len, unsigned int timeout_ms)
+			      char *buf, size_t len, int timeout_ms)
 {
 	int transferred, ret;
 

--- a/utils/gen_code.c
+++ b/utils/gen_code.c
@@ -259,14 +259,14 @@ void gen_ch(const struct iio_channel *ch)
 	}
 }
 
-void gen_context_timeout(unsigned int timeout_ms)
+void gen_context_timeout(int timeout_ms)
 {
 	if (!fd)
 		return;
 
 	if (lang == C_LANG) {
 		fprintf(fd, "\t/* Set the context timeout in ms */\n");
-		fprintf(fd, "\tiio_context_set_timeout(ctx, %ui);\n", timeout_ms);
+		fprintf(fd, "\tiio_context_set_timeout(ctx, %d);\n", timeout_ms);
 	}
 }
 

--- a/utils/gen_code.h
+++ b/utils/gen_code.h
@@ -22,5 +22,5 @@ void gen_buf(const struct iio_buffer *buffer);
 void gen_ch(const struct iio_channel *ch);
 void gen_function(const char* prefix, const char* target,
 		  const struct iio_attr *attr, const char *wbuf);
-void gen_context_timeout(unsigned int timeout_ms);
+void gen_context_timeout(int timeout_ms);
 #endif

--- a/utils/iio_common.c
+++ b/utils/iio_common.c
@@ -14,6 +14,7 @@
 #include <getopt.h>
 #include <string.h>
 #include <time.h>
+#include <limits.h>
 
 #include "iio_common.h"
 #include "gen_code.h"
@@ -246,7 +247,8 @@ static const char *common_options_descriptions[] = {
 		"\n\t\t\tavailable use it. <arg> filters backend(s)"
 		"\n\t\t\t    'ip', 'usb' or 'ip,usb'"),
 	("Context timeout in milliseconds."
-		"\n\t\t\t0 = no timeout (wait forever)"),
+		"\n\t\t\t0 = use backend default, -1 = wait forever"
+		"\n\t\t\t'nb' or 'nonblocking' = non-blocking mode"),
 };
 
 
@@ -332,10 +334,11 @@ struct iio_context * handle_common_opts(char * name, int argc,
 				fprintf(stderr, "Timeout requires an argument\n");
 				goto err_fail;
 			}
-			params.timeout_ms = sanitize_clamp("timeout", optarg, 0, INT_MAX);
-			/* Wait forever if timeout is explicitly set to 0 */
-			if (!params.timeout_ms)
-				params.timeout_ms = -1;
+			if (strcmp(optarg, "nb") == 0 || strcmp(optarg, "nonblocking") == 0) {
+				params.timeout_ms = IIO_TIMEOUT_NONBLOCK;
+			} else {
+				params.timeout_ms = (int) strtol(optarg, NULL, 10);
+			}
 			break;
 		case '?':
 			break;

--- a/utils/iio_stresstest.c
+++ b/utils/iio_stresstest.c
@@ -274,7 +274,7 @@ static void *client_thread(void *data)
 		/* started another context */
 		info->starts[id]++;
 
-		ret = iio_context_set_timeout(ctx, UINT_MAX);
+		ret = iio_context_set_timeout(ctx, IIO_TIMEOUT_INFINITE);
 		thread_err(id, ret, "iio_context_set_timeout failed");
 
 		dev = get_device(ctx, info->argv[info->arg_index + 1]);


### PR DESCRIPTION
## PR Description

### Problem

The libiio timeout API has inconsistencies and limited expressiveness:
- `iio_context_params.timeout_ms` is `int` but `iio_context_set_timeout()` and backend ops take `unsigned int`
- No way to express "use backend default" after context creation
- No explicit non-blocking mode
- The conversion from user-facing to internal values only happens at context creation, not in `iio_context_set_timeout()`

### Solution

Introduce well-defined timeout semantics with named constants:

| Constant | Value | Meaning |
|----------|-------|---------|
| `IIO_TIMEOUT_BACKEND` | `0` | Use backend default timeout |
| `IIO_TIMEOUT_INFINITE` | `-1` | Wait indefinitely |
| `IIO_TIMEOUT_NONBLOCK` | `INT_MIN` | Non-blocking |
| *(positive)* | | Timeout in milliseconds |
| *(other negative)* | | Returns `-EINVAL` |

### Architecture

**4 boundaries** enforce the new semantics:

1. **Context creation** (`context.c`) — resolves user values before `backend->ops->create()`
2. **`iio_context_set_timeout()`** (`context.c`) — resolves before `backend->ops->set_timeout()`
3. **Scan** (`scan.c`) — resolves before `backend->ops->scan()`
4. **Backend API contract** (`iio-backend.h`) — backends always receive resolved poll()-ready values (`-1`/`0`/positive), never raw user-facing constants

A shared `iio_resolve_timeout()` function handles the translation at all three call sites. A `default_timeout_ms` field is added to `struct iio_context` so that `iio_context_set_timeout(ctx, IIO_TIMEOUT_BACKEND)` can resolve the backend default at any time, not just during creation.

The internal convention matches `poll()` semantics throughout the entire stack, including the lock/task primitives (`iio_cond_wait`, `iio_task_sync`): `-1` = infinite, `0` = nonblock, positive = milliseconds.

### Compatibility

The 0.x compatibility layer (`compat.c`) preserves the old `unsigned int` signature and translates the old semantic (`0` = wait forever) to the new one (`-1` = wait forever) so existing client code continues to work correctly.

### Notes
This PR builds on the discussions from PR: https://github.com/analogdevicesinc/libiio/pull/1391.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
