### PR TITLE
iio.h: remove __pure from iio_attr_get_range, _available, and _available_buf

### DIFF
--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -476,7 +476,7 @@ iio_attr_get_static_value(const struct iio_attr *attr);
  * @return On error, a negative errno code is returned. For attributes without the
  * '_available' suffix, -ENXIO is returned. For attributes whose values do not follow
  * the [min step max] format, -EOPNOTSUPP is returned. */
-__api __pure int
+__api int
 iio_attr_get_range(const struct iio_attr *attr, double *min, double *step, double *max);
 
 /** @brief Extract the list of elements from an attribute with suffix '_available'
@@ -490,7 +490,7 @@ iio_attr_get_range(const struct iio_attr *attr, double *min, double *step, doubl
  * @return On error, a negative errno code is returned. For attributes without the
  * '_available' suffix, -ENXIO is returned. For attributes whose values are in a range
  * format, -EOPNOTSUPP is returned. */
-__api __pure int
+__api int
 iio_attr_get_available(const struct iio_attr *attr, char ***list, size_t *count);
 
  /** @brief A variant of iio_attr_get_available() that uses a caller-supplied,
@@ -515,7 +515,7 @@ iio_attr_get_available(const struct iio_attr *attr, char ***list, size_t *count)
  * the '_available' suffix, -ENXIO is returned. For attributes whose values are
  * in a range format, -EOPNOTSUPP is returned. If not enough space is available in
  * list[], the function returns -ENOSPC*/
-__api __pure int
+__api int
 iio_attr_get_available_buf(const struct iio_attr *attr, char *buf,
 		size_t buflen, char **list, size_t *count);
 


### PR DESCRIPTION
## PR Description

`iio_attr_get_range()`, `iio_attr_get_available()`, and `iio_attr_get_available_buf()` all write results back through pointer out-parameters, but all three were declared with `__pure`. `__pure` tells GCC the function has no observable effects beyond its return value, and writing through pointers doesn't fit that contract. The GCC docs define it as [gcc-pure]:

> "The pure attribute prohibits a function from modifying the state of the program that is observable by means other than inspecting the function's return value."

With the annotation in place, GCC is free to optimize calls away, meaning the output variables may never actually get written. This PR removes `__pure` from all three.

[gcc-pure]: https://gcc.gnu.org/onlinedocs/gcc-12.3.0/gcc/Common-Function-Attributes.html#pure

### Example

This came up in the EMU backend, where `iio_attr_get_range()` was used to validate writes against an attribute's available range. The output variables `min`, `step`, and `max` were initialized to zero and GCC, relying on `__pure`, was free to assume they stayed that way. The validation that followed saw `step == 0` and returned `-EINVAL`, rejecting writes that were perfectly valid. The same can happen with `iio_attr_get_available()` and `iio_attr_get_available_buf()`, where `list` and `count` may similarly remain at their initial values.

### Changes
- Remove `__pure` from `iio_attr_get_range()` in `include/iio/iio.h`
- Remove `__pure` from `iio_attr_get_available()` in `include/iio/iio.h`
- Remove `__pure` from `iio_attr_get_available_buf()` in `include/iio/iio.h`

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
