### PR TITLE
zephyr: Upgrade to zephyr v4.4.1

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, macos-15-intel, windows-2022]
+        os: [ubuntu-22.04, macos-14, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/west.yml
+++ b/west.yml
@@ -9,7 +9,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: v4.3.0
+      revision: v4.4.1
       clone-depth: 1
       import:
         name-allowlist:


### PR DESCRIPTION
Upgrades to the latest zephyr release, published on Jun 10 2026.

Tested sample.iiod.network and sample.iiod.console.adc_max32 configurations.

A fix for the zephyr build failures on the `adi_sdp_k1` board with USB is proposed in zephyrproject-rtos/zephyr#107517. Will try to backport to zephyr v4.4.1.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
