### PR TITLE
CI: Temporarly disable license check for Windows builds

### DIFF
--- a/CI/build_win_msvc.ps1
+++ b/CI/build_win_msvc.ps1
@@ -25,7 +25,8 @@ cmake -G "$Env:COMPILER" -DCMAKE_SYSTEM_PREFIX_PATH="C:" `
 -DLIBUSB_LIBRARIES="$Env:BUILD_SOURCESDIRECTORY\deps\libusb\$USB_VS_version\MS64\dll\libusb-1.0.lib" -DLIBUSB_INCLUDE_DIR="$Env:BUILD_SOURCESDIRECTORY\deps\libusb\include" `
 -DLIBSERIALPORT_LIBRARIES="$Env:BUILD_SOURCESDIRECTORY\deps\libserialport\x64\Release\libserialport.lib" -DLIBSERIALPORT_INCLUDE_DIR="$Env:BUILD_SOURCESDIRECTORY\deps\libserialport" `
 -DLIBZSTD_LIBRARIES="$Env:BUILD_SOURCESDIRECTORY\deps\zstd\build\VS2010\bin\x64_Release\libzstd.lib" -DLIBZSTD_INCLUDE_DIR="$Env:BUILD_SOURCESDIRECTORY\deps\zstd\lib" `
--DWITH_EXAMPLES=ON -DLICENSE_CHECK=ON ..
+-DWITH_EXAMPLES=ON `
+-DLICENSE_CHECK=OFF ..  # To re-enable this once script is fixed
 
 # Build each configuration
 foreach ($config in $buildConfigs) {


### PR DESCRIPTION
## PR Description
To be re-enabled once the cmake license check script gets fixed.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
