### PR TITLE
emu: fix sscanf MSVC build warning

### DIFF
--- a/emu.c
+++ b/emu.c
@@ -688,7 +688,7 @@ static int validate_against_available(const struct iio_attr *attr, const char *s
 	ret = iio_attr_get_range(attr, &min, &step, &max);
 	if (ret == 0) {
 		double value, steps_from_min;
-		if (step == 0 || sscanf(src, "%lf", &value) != 1 ||
+		if (step == 0 || iio_sscanf(src, "%lf", &value) != 1 ||
 		    value < min || value > max)
 			return -EINVAL;
 		steps_from_min = (value - min) / step;


### PR DESCRIPTION

## PR Description

MSVC treats `sscanf` as an unsafe function (C4996) and with warnings-as-errors enabled this broke the Windows MSVC build.  Replace it with `iio_sscanf` - consistent with the rest of the file.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
