### PR TITLE
iio_reg: fix context leak on successful register access

### DIFF
--- a/utils/iio_reg.c
+++ b/utils/iio_reg.c
@@ -119,15 +119,15 @@ int main(int argc, char **argv)
 	addr = sanitize_clamp("register address", argw[optind + 1], 0, UINT32_MAX);
 
 	if ((argc - optind) == 2) {
-		return read_reg(dev, addr);
+		ret = read_reg(dev, addr);
 	} else {
 		uint32_t val = sanitize_clamp("register value", argw[optind + 2], 0, UINT32_MAX);
-		return write_reg(dev, addr, val);
+		ret = write_reg(dev, addr, val);
 	}
 
 err_destroy_context:
 	free(name);
 	iio_context_destroy(ctx);
 	free_argw(argc, argw);
-	return EXIT_SUCCESS;
+	return ret;
 }


### PR DESCRIPTION
## PR Description
`read_reg()` and `write_reg()` returned directly from `main()`, bypassing `err_destroy_context` and leaking the entire IIO context on every successful invocation. Caught with Valgrind during testing.
Store the return value and fall through to the common cleanup block instead. This also fixes `err_destroy_context` incorrectly returning `EXIT_SUCCESS` when device lookup fails.

### Changes
- Store result of `read_reg()`/`write_reg()` in `ret` instead of returning directly
- Return `ret` instead of hardcoded `EXIT_SUCCESS` at cleanup label

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
