### PR TITLE
emu: parse context metadata from XML attributes

### DIFF
--- a/emu.c
+++ b/emu.c
@@ -617,6 +617,10 @@ emu_create_context(const struct iio_context_params *params, const char *args)
 	struct iio_context_pdata *pdata;
 	xmlDoc *doc;
 	xmlNode *root, *node;
+	xmlAttr *attr;
+	const char *description = NULL, *git_tag = NULL, *content;
+	char *end;
+	long major = 0, minor = 0;
 	int ret;
 
 	if (!args || !*args) {
@@ -639,8 +643,36 @@ emu_create_context(const struct iio_context_params *params, const char *args)
 		return iio_ptr(-EINVAL);
 	}
 
+	for (attr = root->properties; attr; attr = attr->next) {
+		content = (const char *) attr->children->content;
+
+		if (!strcmp((char *) attr->name, "description")) {
+			description = content;
+		} else if (!strcmp((char *) attr->name, "version-major")) {
+			errno = 0;
+			major = strtol(content, &end, 10);
+			if (*end != '\0' ||  errno == ERANGE)
+				prm_warn(params, "invalid format for major version\n");
+		} else if (!strcmp((char *) attr->name, "version-minor")) {
+			errno = 0;
+			minor = strtol(content, &end, 10);
+			if (*end != '\0' || errno == ERANGE)
+				prm_warn(params, "invalid format for minor version\n");
+		} else if (!strcmp((char *) attr->name, "version-git")) {
+			git_tag = content;
+		} else if (strcmp((char *) attr->name, "name")) {
+			prm_dbg(params, "Unknown parameter \'%s\' in <context>\n",
+				content);
+		}
+	}
+
+	if (!description)
+		description = "Emulated IIO Context";
+	if (!git_tag)
+		git_tag = "emu-v1";
+
 	ctx = iio_context_create_from_backend(params, &iio_emu_backend,
-										"Emulated IIO Context", 0, 1, "emu-v1");
+										description, major, minor, git_tag);
 
 	ret = iio_err(ctx);
 	if (ret) {


### PR DESCRIPTION
## PR Description
This PR enhances the EMU backend to parse context metadata from XML attributes instead of using hardcoded values. The EMU backend now extracts version information and description from XML files, similar to the XML backend.

### Benefits
- EMU contexts now report correct version numbers from XML files
- Device descriptions reflect hardware
- Realistic context information

### Changes
- Add XML attribute parsing loop to `emu_create_context()`
- Extract `version-major`, `version-minor`, `version-git`, and `description` from context element
- Replace hardcoded context creation parameters with parsed values
- Add fallback defaults when XML attributes are missing

### How it works
1. `emu_create_context()` parses the XML root element's properties after validation
2. The function extracts `description`, `version-major`, `version-minor`, and `version-git` attributes using `strtol()` for numeric conversion
3. Missing attributes fall back to defaults ("Emulated IIO Context" and "emu-v1")
4. `iio_context_create_from_backend()` receives the parsed values instead of hardcoded ones

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)