### PR TITLE
iiod-client: null-terminate XML string in non-ZSTD path

### DIFF
--- a/iiod-client.c
+++ b/iiod-client.c
@@ -948,7 +948,7 @@ iiod_client_create_context_private_new(struct iiod_client *client,
 	bool is_zstd;
 	int ret;
 
-	xml = malloc(xml_len + uri_len);
+	xml = malloc(xml_len + uri_len + 1);
 	if (!xml)
 		return iio_ptr(-ENOMEM);
 
@@ -962,6 +962,9 @@ iiod_client_create_context_private_new(struct iiod_client *client,
 	}
 
 	xml_len = ret;
+
+	/* Null-terminate the XML data */
+	xml[uri_len + xml_len] = '\0';
 
 	is_zstd = strncmp(xml, "xml:<?xml", sizeof("xml:<?xml") - 1) != 0;
 	if (is_zstd)


### PR DESCRIPTION
## PR Description

In iiod_client_create_context_private_new(), the XML string received from iiod via the PRINT command is not null-terminated in the non-ZSTD code path. The buffer is then passed to iio_create_context_from_xml(), which eventually calls xmlReadMemory() with strlen(arg) to determine the length. Since the buffer is not null-terminated, strlen() reads past the XML data into uninitialized heap memory, causing intermittent XML parse errors ('Extra content at the end of the document').

The ZSTD code path correctly null-terminates the decompressed data, but the uncompressed path was missing this step.

Fix by allocating one extra byte and writing a null terminator after receiving the XML data.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
