### PR TITLE
emu: fix MSVC build warnings

### DIFF
--- a/emu.c
+++ b/emu.c
@@ -13,7 +13,9 @@
 #include <errno.h>
 #include <string.h>
 #include <stdio.h>
-#ifndef _WIN32
+#ifdef _WIN32
+#include <io.h>
+#else
 #include <unistd.h>
 #endif
 #include <iio/iio-backend.h>
@@ -1001,7 +1003,11 @@ static int emu_enable_buffer(struct iio_buffer_pdata *pdata,
 		return -ENOMEM;
 	}
 
+#ifdef _MSC_BUILD
+	fopen_s(&pdata->file, path, is_output ? "wb" : "rb");
+#else
 	pdata->file = fopen(path, is_output ? "wb" : "rb");
+#endif
 	if (!pdata->file) {
 		if(!is_output)
 			dev_err(pdata->dev, "Rx data file not found, expected at %s\n", path);

--- a/emu.c
+++ b/emu.c
@@ -1117,7 +1117,7 @@ static int emu_dequeue_block(struct iio_block_pdata *pdata, bool nonblock)
 			fseek(file, 0, SEEK_SET);
 			n2 = fread((char*)pdata->data + n, 1, bytes_used - n, file);
 			if (n2 == 0)
-				return -ENODATA;
+				return -EIO;
 		}
 	}
 


### PR DESCRIPTION
## PR Description
 This PR fixes build issues in the emu backend for two platforms:

 ### Changes
 - **MSVC:** Add missing <io.h> include and replace fopen() with fopen_s() under _MSC_BUILD
  - **FreeBSD:** Replace ENODATA with EIO, which is standard POSIX - ENODATA is not available on FreeBSD


## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
