### PR TITLE
Iio channels and adc emul fix

### DIFF
--- a/zephyr/drivers/iio_device/io_channels.c
+++ b/zephyr/drivers/iio_device/io_channels.c
@@ -403,7 +403,7 @@ static int iio_device_io_channels_write_channel_raw(const struct device *dev,
 
 static int iio_device_io_channels_parse_gain(const char *src, size_t len, enum adc_gain *gain_out)
 {
-	for (uint8_t i = 0; i < ARRAY_SIZE(gain_values); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(gain_values); i++) {
 		const char *compare_gain = gain_values[i];
 
 		if (compare_gain == NULL) {
@@ -545,7 +545,7 @@ static int iio_device_io_channels_read_channel_reference(const struct device *de
 
 static int iio_device_io_channels_parse_reference(const char *src, size_t len, enum adc_reference *reference_out)
 {
-	for (uint8_t i = 0; i < ARRAY_SIZE(reference_values); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(reference_values); i++) {
 		const char *compare_reference = reference_values[i];
 
 		if (compare_reference == NULL) {

--- a/zephyr/samples/iiod/adc-emul.overlay
+++ b/zephyr/samples/iiod/adc-emul.overlay
@@ -10,7 +10,7 @@
 		#size-cells = <0>;
 
 		iio-device@1 {
-			compatible = "iio,adc";
+			compatible = "iio,io-channels";
 			reg = <1>;
 			io-channels = <&adc_emul 0>, <&adc_emul 1>;
 			io-channel-names = "adc_emul_in_ch0", "adc_emul_in_ch1";


### PR DESCRIPTION
## PR Description

Fix adc-emul compatible to align to iio-channels.

Fixed ARRAY_SIZE CI/CD issue for iio-channels.

Signed-off-by: Dimitrije Lilic <dimitrije.lilic@orioninc.com>

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
