### PR TITLE
io_common: fix params forwarding for local backend, remove dead prefix code

### DIFF
--- a/utils/iio_common.c
+++ b/utils/iio_common.c
@@ -368,7 +368,7 @@ struct iio_context * handle_common_opts(char * name, int argc,
 	else if (backend == IIO_URI)
 		ctx = iio_create_context(&params, arg);
 	else
-		ctx = iio_create_context(NULL, NULL);
+		ctx = iio_create_context(&params, NULL);
 
 	err = iio_err(ctx);
 	if (err && !do_scan && !detect_context) {

--- a/utils/iio_common.c
+++ b/utils/iio_common.c
@@ -262,7 +262,7 @@ struct iio_context * handle_common_opts(char * name, int argc,
 	if (default_params)
 		params = *default_params;
 	enum backend backend = IIO_LOCAL;
-	const char *arg = NULL, *prefix = NULL;
+	const char *arg = NULL;
 	bool do_scan = false, detect_context = false;
 	char buf[1024];
 	struct option *opts;
@@ -355,14 +355,6 @@ struct iio_context * handle_common_opts(char * name, int argc,
 		return NULL;
 	} else if (detect_context || backend == IIO_AUTO) {
 		ctx = autodetect_context(true, name, arg);
-	} else if (prefix) {
-		err = iio_snprintf(buf, sizeof(buf), "%s:%s", prefix, arg);
-		if (err < 0)
-			ctx = iio_ptr(err);
-		else if ((size_t)err >= sizeof(buf))
-			ctx = iio_ptr(-EINVAL);
-		else
-			ctx = iio_create_context(NULL, buf);
 	} else if (!arg && backend != IIO_LOCAL)
 		fprintf(stderr, "argument parsing error\n");
 	else if (backend == IIO_URI)


### PR DESCRIPTION
## PR Description

Fix `iio_genxml -e` not including attribute values in the generated XML when using the local backend. The `-e` flag sets `IIO_CTX_XML_INCLUDE_VALUES` in `iio_context_params. This fix ensures that flag reaches the context for all backends.
### Changes

- Pass `&params` instead of `NULL` to `iio_create_context()` for the local backend path in `handle_common_opts()` in `utils/iio_common.c`
- Remove dead prefix variable and unreachable else if (prefix) block in handle_common_opts() — prefix was never assigned after f1b6706d removed `--ip/--xml`
### Backwards Compatibility

All other utilities (`iio_info`, `iio_attr`, `iio_rwdev`, `iio_reg`, `iio_event`) pass `NULL` as `default_params`, so `params` stays NULL in `handle_common_opts()`.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
