### PR TITLE
emu: use device names for buffer filenames

### DIFF
--- a/emu.c
+++ b/emu.c
@@ -935,7 +935,7 @@ static void emu_shutdown(struct iio_context *ctx)
  * Returns NULL on allocation failure.
  * Cross-platform: handles both '/' and '\\' directory separators. */
 static char *emu_make_data_path(const char *xml_path,
-				const char *dev_id,
+				const struct iio_device *dev,
 				unsigned int idx)
 {
 	const char *sep = strrchr(xml_path, '/');
@@ -945,16 +945,28 @@ static char *emu_make_data_path(const char *xml_path,
 		sep = sep_win;
 #endif
 	size_t dir_len = sep ? (size_t)(sep - xml_path + 1) : 0;
-	size_t path_len = dir_len + MAX_DEV_ID + 32; /* _buf{idx}.bin + margin */
+
+	/* Use device name if available, fallback to device ID */
+	const char *name = iio_device_get_name(dev);
+	const char *identifier = name ? name : iio_device_get_id(dev);
+
+	size_t identifier_len = strnlen(identifier, MAX_DEV_ID);
+	size_t path_len = dir_len + identifier_len + 32; /* _buf{idx}.bin + margin */
 	char *path = malloc(path_len);
 
 	if (!path)
 		return NULL;
 
 	if (dir_len)
-		iio_snprintf(path, path_len, "%.*s%s_buf%u.bin", (int)dir_len, xml_path, dev_id, idx);
+		iio_snprintf(path, path_len, "%.*s%s_buf%u.bin", (int)dir_len, xml_path, identifier, idx);
 	else
-		iio_snprintf(path, path_len, "%s_buf%u.bin", dev_id, idx);
+		iio_snprintf(path, path_len, "%s_buf%u.bin", identifier, idx);
+
+	/* Colons are invalid in filenames on Windows */
+	for (char *p = path + dir_len; *p; p++) {
+		if (*p == ':')
+			*p = '_';
+	}
 
 	return path;
 }
@@ -1028,7 +1040,7 @@ static int emu_enable_buffer(struct iio_buffer_pdata *pdata,
 
 	ctx_pdata = iio_context_get_pdata(pdata->dev->ctx);
 	path = emu_make_data_path(ctx_pdata->xml_path,
-				  iio_device_get_id(pdata->dev),
+				  pdata->dev,
 				  pdata->idx);
 	if (!path) {
 		iio_mutex_unlock(pdata->file_lock);


### PR DESCRIPTION
## PR Description

This PR fixes the emu backend buffer data file naming so it works on Windows.  The fix sanitizes the filename by replacing `:` with `_` and additionally prefers the device name (e.g. `cf-ad9361-lpc`) over the device ID when one is available.
- The path is assembled as <xml_dir>/<identifier>_buf<idx>.bin, where identifier is the device name if available, otherwise the sanitized device ID.

## Changes
- Add a colon-to-underscore sanitization pass over the filename portion of the generated path
- Change `emu_make_data_path()` signature from `const char *dev_id` to `const struct iio_device *dev`
## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
