### PR TITLE
Fix buflist_lock deadlock and simplify close path

### DIFF
--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -377,7 +377,7 @@ static void handle_open_buffer(struct parser_pdata *pdata,
 	if (!dev)
 		goto err_send_response;
 
-	entry = get_iio_buffer_entry_unblocked(pdata, cmd);
+	entry = get_iio_buffer_entry(pdata, cmd);
 	if (!iio_err(entry)) {
 		/* No error? This buffer already exists, so return
 		 * -EEXIST. */
@@ -416,8 +416,6 @@ static void handle_open_buffer(struct parser_pdata *pdata,
 		ret = -ENOMEM;
 		goto err_free_words;
 	}
-
-	iio_mutex_lock(buflist_lock);
 
 	entry->dev = dev;
 	entry->idx = (uint16_t) cmd->code;
@@ -479,6 +477,7 @@ static void handle_open_buffer(struct parser_pdata *pdata,
 	entry->buf_stream = buf_stream;
 	entry->pdata = pdata;
 
+	iio_mutex_lock(buflist_lock);
 	SLIST_INSERT_HEAD(&bufferlist, entry, entry);
 	iio_mutex_unlock(buflist_lock);
 

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -110,8 +110,8 @@ static void handle_timeout(struct parser_pdata *pdata,
 	iiod_io_send_response_code(io, ret);
 }
 
-static struct buffer_entry * get_iio_buffer_entry_unblocked(struct parser_pdata *pdata,
-							    const struct iiod_command *cmd)
+static struct buffer_entry * get_iio_buffer_entry_unlocked(struct parser_pdata *pdata,
+							   const struct iiod_command *cmd)
 {
 	const struct iio_device *dev;
 	struct buffer_entry *entry;
@@ -515,7 +515,7 @@ static struct buffer_entry * get_iio_buffer_entry(struct parser_pdata *pdata,
 
 
 	iio_mutex_lock(buflist_lock);
-	entry = get_iio_buffer_entry_unblocked(pdata, cmd);
+	entry = get_iio_buffer_entry_unlocked(pdata, cmd);
 	iio_mutex_unlock(buflist_lock);
 
 	return entry;
@@ -560,29 +560,22 @@ static void handle_close_buffer(struct parser_pdata *pdata,
 			       struct iiod_command_data *cmd_data)
 {
 	struct iiod_io *io = iiod_command_get_default_io(cmd_data);
-	struct buffer_entry *entry, *buf_entry;
+	struct buffer_entry *entry;
 	int ret = -ENODEV;
-
-	buf_entry = get_iio_buffer_entry(pdata, cmd);
-	ret = iio_err(buf_entry);
-	if (ret)
-		goto out_send_response;
-
-	ret = -EBADF;
 
 	iio_mutex_lock(buflist_lock);
 
-	SLIST_FOREACH(entry, &bufferlist, entry) {
-		if (entry != buf_entry)
-			continue;
-
-		SLIST_REMOVE(&bufferlist, entry, buffer_entry, entry);
-		free_buffer_entry(entry);
-		ret = 0;
-		break;
+	entry = get_iio_buffer_entry_unlocked(pdata, cmd);
+	ret = iio_err(entry);
+	if (ret) {
+		iio_mutex_unlock(buflist_lock);
+		goto out_send_response;
 	}
 
+	SLIST_REMOVE(&bufferlist, entry, buffer_entry, entry);
 	iio_mutex_unlock(buflist_lock);
+	free_buffer_entry(entry);
+	ret = 0;
 
 	IIO_DEBUG("Buffer %u freed.\n", cmd->code);
 


### PR DESCRIPTION
## PR Description

Fix a deadlock in handle_open_buffer() where buflist_lock was acquired  early but never released on error paths. While at it, simplify handle_close_buffer() which was doing a redundant double traversal of the buffer list with a TOCTOU race in between.

 - Patch 1 fixes the deadlock by deferring the lock to just before the list insertion, and switches to get_iio_buffer_entry() for the initial lookup.
 - Patch 2 reworks the close path to hold the lock across lookup and removal in a single critical section.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
