### PR TITLE
Add iio_fopen() cross-platform wrapper

### DIFF
--- a/emu.c
+++ b/emu.c
@@ -1035,11 +1035,7 @@ static int emu_enable_buffer(struct iio_buffer_pdata *pdata,
 		return -ENOMEM;
 	}
 
-#ifdef _MSC_BUILD
-	fopen_s(&pdata->file, path, is_output ? "wb" : "rb");
-#else
-	pdata->file = fopen(path, is_output ? "wb" : "rb");
-#endif
+	pdata->file = iio_fopen(path, is_output ? "wb" : "rb");
 	if (!pdata->file) {
 		if(!is_output)
 			dev_err(pdata->dev, "Rx data file not found, expected at %s\n", path);

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -235,6 +235,7 @@ __api __iio_printf ssize_t
 iio_snprintf(char *buf, size_t len, const char *fmt, ...);
 __api char *iio_strdup(const char *str);
 __api size_t iio_strlcpy(char * __restrict dst, const char * __restrict src, size_t dsize);
+__api FILE *iio_fopen(const char *path, const char *mode);
 
 __api struct iio_context *
 iio_create_context_from_xml(const struct iio_context_params *params,

--- a/utilities.c
+++ b/utilities.c
@@ -226,6 +226,20 @@ void iio_strerror(int err, char *buf, size_t len)
 	}
 }
 
+FILE *iio_fopen(const char *path, const char *mode)
+{
+#ifdef _MSC_BUILD
+	FILE *f;
+	int ret = fopen_s(&f, path, mode);
+	if (ret) {
+		return NULL;
+	}
+	return f;
+#else
+	return fopen(path, mode);
+#endif
+}
+
 char *iio_strtok_r(char *str, const char *delim, char **saveptr)
 {
 #if defined(_WIN32)

--- a/utils/gen_code.c
+++ b/utils/gen_code.c
@@ -23,27 +23,11 @@ static enum languages {
 	UNSUPPORTED_LANG,
 } lang = UNSUPPORTED_LANG;
 
-static int gen_fopen(FILE** pFile, const char *filename, const char *mode)
-{
-	int ret = 0;
-
-
-#ifdef _MSC_BUILD
-	ret = fopen_s(pFile, filename, mode);
-#else
-	*pFile = fopen(filename, mode);
-	if (!*pFile)
-		ret = -errno;
-#endif
-
-	return ret;
-}
 
 bool gen_test_path(const char *gen_file)
 {
 	FILE *test;
 	char *last;
-	int ret;
 
 	if (!gen_file)
 		return false;
@@ -65,8 +49,8 @@ bool gen_test_path(const char *gen_file)
 		return false;
 	}
 
-	ret = gen_fopen(&test, gen_file, "w");
-	if (ret)
+	test = iio_fopen(gen_file, "w");
+	if (!test)
 		return false;
 	fclose(test);
 
@@ -75,18 +59,16 @@ bool gen_test_path(const char *gen_file)
 
 void gen_start(const char *gen_file)
 {
-	int ret;
-
 	if (!gen_file)
 		return;
 
 	if (lang == UNSUPPORTED_LANG)
 		return;
 
-	ret = gen_fopen(&fd, gen_file, "w");
-	if (ret) {
+	fd = iio_fopen(gen_file, "w");
+	if (!fd) {
 		char buf[1024];
-		iio_strerror(-ret, buf, sizeof(buf));
+		iio_strerror(errno, buf, sizeof(buf));
 		fprintf(stderr, "Error '%s' opening file: %s\n", buf, gen_file);
 		return;
 	}

--- a/utils/iio_attr.c
+++ b/utils/iio_attr.c
@@ -98,15 +98,9 @@ static unsigned char *read_input_file(const char *path, size_t *len)
 	unsigned char *buf;
 	int err = 0;
 
-#ifdef _MSC_BUILD
-	err = fopen_s(&f, path, "rb");
-	if (err)
-		f = NULL;
-#else
-	f = fopen(path, "rb"); /* Flawfinder: ignore */
+	f = iio_fopen(path, "rb"); /* Flawfinder: ignore */
 	if (!f)
 		err = errno;
-#endif
 	if (!f) {
 		char errbuf[256];
 		iio_strerror(err, errbuf, sizeof(errbuf));


### PR DESCRIPTION
## PR Description
Adds `iio_fopen()` to `utilities.c` as a cross-platform `fopen` wrapper, following the pattern of `iio_strdup()` and `iio_strtok_r()`. Declared in `iio-backend.h` and used treewide to replace `#ifdef _MSC_BUILD` blocks, including the removal of the local `gen_fopen()` helper in `gen_code.c`.

Closes [1434](https://github.com/analogdevicesinc/libiio/issues/1434)
  
  ### Changes
  - Add `iio_fopen()` to `utilities.c`, declared in `iio-backend.h`
  - Replace inline `#ifdef _MSC_BUILD` fopen blocks in `emu.c` and `iio_attr.c`
  - Remove local `gen_fopen()` from `gen_code.c` and switch to `iio_fopen()`
## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
