### PR TITLE
cmake: add emu backend to feature summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -824,6 +824,7 @@ configure_file(iio-config.h.cmakein ${CMAKE_CURRENT_BINARY_DIR}/iio-config.h @ON
 
 toggle_iio_feature("${LIBIIO_COMPAT}" compat)
 toggle_iio_feature("${WITH_XML_BACKEND}" xml)
+toggle_iio_feature("${WITH_EMU_BACKEND}" emu)
 toggle_iio_feature("${WITH_ZSTD}" zstd)
 toggle_iio_feature("${WITH_NETWORK_BACKEND}" network)
 toggle_iio_feature("${HAVE_DNS_SD}" dns-sd)


### PR DESCRIPTION
## PR Description
The emu backend was missing from the toggle_iio_feature list, so it never appeared in the CMake configuration summary output.

 ### Changes
  - Add `toggle_iio_feature("${WITH_EMU_BACKEND}" emu)` to `CMakeLists.txt`

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
