### PR TITLE
CMakeLists: allow compat layer enablement on MacOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,16 +73,19 @@ if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang|MSVC")
 		add_library(iio-compat compat.c)
 		if (WIN32)
 			target_sources(iio-compat PRIVATE dynamic-windows.c)
-			target_compile_definitions(iio-compat PRIVATE
-				LIBIIO1_NAME="iio${PROJECT_VERSION_MAJOR}.dll"
-			)
+			set(LIBIIO1_NAME "iio${PROJECT_VERSION_MAJOR}.dll")
 		else()
 			target_sources(iio-compat PRIVATE dynamic-unix.c)
 			target_link_libraries(iio-compat PRIVATE dl)
-			target_compile_definitions(iio-compat PRIVATE
-				LIBIIO1_NAME="libiio.so.${PROJECT_VERSION_MAJOR}"
-			)
+			if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+				set(LIBIIO1_NAME "iio.framework/Versions/${PROJECT_VERSION}/iio")
+			else()
+				set(LIBIIO1_NAME "libiio.so.${PROJECT_VERSION_MAJOR}")
+			endif()
 		endif()
+		target_compile_definitions(iio-compat PRIVATE
+			LIBIIO1_NAME="${LIBIIO1_NAME}"
+		)
 
 		target_include_directories(iio-compat PUBLIC ${CMAKE_BINARY_DIR} include)
 		target_compile_definitions(iio-compat PRIVATE LIBIIO_COMPAT_EXPORTS)


### PR DESCRIPTION
## PR Description

Compat layer was not supported on MacOS due to a dlopen(libiio.so.1) call. 
Handle the libiio v1 binary name properly for MacOS alongside Windows or Linux.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
