### PR TITLE
zephyr: Handle reads for larger LIBIIO_IIOD_UART_RX_BUF_SIZE values

### DIFF
--- a/zephyr/iiod/uart.c
+++ b/zephyr/iiod/uart.c
@@ -26,11 +26,14 @@ static ssize_t iiod_uart_read(struct iiod_pdata *pdata, void *buf, size_t size)
 
 	LOG_DBG("start read %d bytes", size);
 
-	k_sem_take(&rx_sem, K_FOREVER);
 	rx_len = ring_buf_get(&rx_buf, buf, size);
 
-	LOG_DBG("rx buffer get %d bytes", rx_len);
-	LOG_DBG("done read %d bytes", size);
+	while (!rx_len) {
+		k_sem_take(&rx_sem, K_FOREVER);
+		rx_len = ring_buf_get(&rx_buf, buf, size);
+	}
+
+	LOG_DBG("tried to read %d bytes, got %d", size, rx_len);
 
 	return rx_len;
 }


### PR DESCRIPTION
## PR Description

When LIBIIO_IIOD_UART_RX_BUF_SIZE is increase to buffer more input, a smaller read that does not fully empty the ring buffer will lead to blocking subsequent reads when the semaphore is not given again but more details remains unread. Fix this by attempting reads-the-sem-take in a loop until the ring buffer returns data.

## PR Type
- [X] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [X] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
