### PR TITLE
zephyr: Refactor devicetree properties into a shared base binding

### DIFF
--- a/zephyr/drivers/iio_device/io_channels.c
+++ b/zephyr/drivers/iio_device/io_channels.c
@@ -780,7 +780,7 @@ static const struct iio_device_io_channels_config iio_device_io_channel_config_#
 	.num_channels = ARRAY_SIZE(iio_device_io_channels_##inst),				\
 };												\
 												\
-IIO_DEVICE_DT_INST_DEFINE(inst, DT_INST_PROP_OR(inst, io_name, NULL),				\
+IIO_DEVICE_DT_INST_DEFINE(inst,									\
 	iio_device_io_channels_init, NULL,							\
 	&iio_device_io_channel_data_##inst, &iio_device_io_channel_config_##inst,		\
 	POST_KERNEL, CONFIG_LIBIIO_IIO_DEVICE_IO_CHANNELS_INIT_PRIORITY,			\

--- a/zephyr/drivers/iio_device/sensor.c
+++ b/zephyr/drivers/iio_device/sensor.c
@@ -64,7 +64,6 @@ static const struct sensor_channel_map channel_map[] = {
 };
 
 struct iio_device_sensor_config {
-	const char *name;
 	const struct device *sensor_dev;
 	const enum sensor_channel *channels;
 	size_t num_channels;
@@ -351,13 +350,12 @@ static struct iio_device_sensor_data iio_device_sensor_data_##inst = {		\
 										\
 static const struct iio_device_sensor_config				\
 		iio_device_sensor_config_##inst = {				\
-	.name        = DT_INST_PROP_OR(inst, io_name, NULL),			\
 	.sensor_dev  = DEVICE_DT_GET(DT_INST_PHANDLE(inst, sensor_device)),	\
 	.channels    = iio_device_sensor_channels_##inst,			\
 	.num_channels = ARRAY_SIZE(iio_device_sensor_channels_##inst),		\
 };										\
 										\
-IIO_DEVICE_DT_INST_DEFINE(inst, DT_INST_PROP_OR(inst, io_name, NULL),		\
+IIO_DEVICE_DT_INST_DEFINE(inst,							\
 	iio_device_sensor_init, NULL,						\
 	&iio_device_sensor_data_##inst,						\
 	&iio_device_sensor_config_##inst,					\

--- a/zephyr/dts/bindings/iio/iio,iio-device.yaml
+++ b/zephyr/dts/bindings/iio/iio,iio-device.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+include: base.yaml
+
+properties:
+  reg:
+    required: true
+
+  io-name:
+    type: string
+    description: |
+      The device name for use within IIOD. If not set, the device's node will be used
+      as a fallback.

--- a/zephyr/dts/bindings/iio/iio,io-channels.yaml
+++ b/zephyr/dts/bindings/iio/iio,io-channels.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) 2025 Analog Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-include: base.yaml
+include: iio,iio-device.yaml
 
 description: IIO ADC/DAC io-channels
 
@@ -12,10 +12,3 @@ properties:
     required: true
   io-channel-names:
     required: true
-  reg:
-    required: true
-  io-name:
-    type: string
-    description: |
-      The device name for use within IIOD. If not set, the device's node will be used
-      as a fallback.

--- a/zephyr/dts/bindings/iio/iio,sensor.yaml
+++ b/zephyr/dts/bindings/iio/iio,sensor.yaml
@@ -1,16 +1,13 @@
 # Copyright (c) 2025 Analog Devices, Inc.
 # SPDX-License-Identifier: MIT
 
-include: base.yaml
+include: iio,iio-device.yaml
 
 description: IIO sensor
 
 compatible: "iio,sensor"
 
 properties:
-  reg:
-    required: true
-
   sensor-device:
     type: phandle
     required: true

--- a/zephyr/include/iio_device.h
+++ b/zephyr/include/iio_device.h
@@ -34,18 +34,19 @@ struct iio_device_info {
 #define IIO_DEVICE_INFO_DT_NAME(node_id)					\
 	_CONCAT(__iio_device_info, DEVICE_DT_NAME_GET(node_id))
 
-#define IIO_DEVICE_INFO_DT_DEFINE(node_id, name)				\
+#define IIO_DEVICE_INFO_DT_DEFINE(node_id)					\
 	IIO_DEVICE_INFO_DEFINE(IIO_DEVICE_INFO_DT_NAME(node_id),		\
-			       DEVICE_DT_GET(node_id), name)
+			       DEVICE_DT_GET(node_id),				\
+			       DT_PROP_OR(node_id, io_name, NULL))
 
-#define IIO_DEVICE_DT_DEFINE(node_id, name, init_fn, pm_device,			\
+#define IIO_DEVICE_DT_DEFINE(node_id, init_fn, pm_device,			\
 			     data_ptr, cfg_ptr, level, prio,			\
 			     api_ptr, ...)					\
 	DEVICE_DT_DEFINE(node_id, init_fn, pm_device,				\
 			 data_ptr, cfg_ptr, level, prio,			\
 			 api_ptr, __VA_ARGS__);					\
 										\
-	IIO_DEVICE_INFO_DT_DEFINE(node_id, name);
+	IIO_DEVICE_INFO_DT_DEFINE(node_id);
 
 
 #define IIO_DEVICE_DT_INST_DEFINE(inst, ...)					\

--- a/zephyr/samples/iiod/adc-emul.overlay
+++ b/zephyr/samples/iiod/adc-emul.overlay
@@ -14,6 +14,7 @@
 			reg = <1>;
 			io-channels = <&adc_emul 0>, <&adc_emul 1>;
 			io-channel-names = "adc_emul_in_ch0", "adc_emul_in_ch1";
+			io-name = "adc-emul";
 		};
 	};
 

--- a/zephyr/samples/iiod/adc-max32.overlay
+++ b/zephyr/samples/iiod/adc-max32.overlay
@@ -14,6 +14,7 @@
 			reg = <0>;
 			io-channels = <&adc 0>;
 			io-channel-names = "adc_in_ch0";
+			io-name = "max32-adc";
 		};
 	};
 };

--- a/zephyr/samples/iiod/adxl345.overlay
+++ b/zephyr/samples/iiod/adxl345.overlay
@@ -57,6 +57,7 @@
 				IIO_SENSOR_CHAN_ACCEL_Z
 			>;
 			buffer-name = "buffer0";
+			io-name = "adxl345";
 		};
 	};
 };

--- a/zephyr/samples/iiod/eval_ad4052_ardz.overlay
+++ b/zephyr/samples/iiod/eval_ad4052_ardz.overlay
@@ -14,6 +14,7 @@
 			reg = <0>;
 			io-channels = <&adc4052_eval_ad4052_ardz 0>;
 			io-channel-names = "adc_in_ch0";
+			io-name = "ad4052";
 		};
 	};
 };

--- a/zephyr/samples/iiod/pmod_acl.overlay
+++ b/zephyr/samples/iiod/pmod_acl.overlay
@@ -19,6 +19,7 @@
 					   IIO_SENSOR_CHAN_ACCEL_Y
 					   IIO_SENSOR_CHAN_ACCEL_Z>;
 			buffer-name = "buffer0";
+			io-name = "adxl345";
 		};
 	};
 };

--- a/zephyr/samples/iiod/sensor-emul.overlay
+++ b/zephyr/samples/iiod/sensor-emul.overlay
@@ -26,6 +26,7 @@
 				IIO_SENSOR_CHAN_AMBIENT_TEMP
 			>;
 			buffer-name = "buffer0";
+			io-name = "ltc2990";
 		};
 	};
 


### PR DESCRIPTION
## PR Description
Extracts `reg` and `io-name` properties into a new base binding (iio,iio-device.yaml) to eliminate duplication across io-channels and sensor bindings. Updates device macros to retrieve io-name from devicetree rather than requiring it as a parameter.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
