### PR TITLE
zephyr: Extend iiod sample to support eval_adxl362_ardz and frdm_k64f sensors

### DIFF
--- a/zephyr/samples/iiod/CMakeLists.txt
+++ b/zephyr/samples/iiod/CMakeLists.txt
@@ -7,6 +7,11 @@ if(eval_ad4052_ardz IN_LIST SHIELD)
   list(APPEND EXTRA_DTC_OVERLAY_FILE eval_ad4052_ardz.overlay)
 endif()
 
+if(eval_adxl362_ardz IN_LIST SHIELD)
+  list(APPEND EXTRA_DTC_OVERLAY_FILE eval_adxl362_ardz.overlay)
+  list(APPEND EXTRA_CONF_FILE eval_adxl362_ardz.conf)
+endif()
+
 if(pmod_acl IN_LIST SHIELD)
   list(APPEND EXTRA_DTC_OVERLAY_FILE pmod_acl.overlay)
   list(APPEND EXTRA_CONF_FILE pmod_acl.conf)

--- a/zephyr/samples/iiod/boards/frdm_k64f_mk64f12.conf
+++ b/zephyr/samples/iiod/boards/frdm_k64f_mk64f12.conf
@@ -1,0 +1,5 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+CONFIG_SENSOR=y
+CONFIG_FXOS8700_TEMP=y

--- a/zephyr/samples/iiod/boards/frdm_k64f_mk64f12.overlay
+++ b/zephyr/samples/iiod/boards/frdm_k64f_mk64f12.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/iio/sensor-channels.h>
+
+/ {
+	iio-context {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		iio-device@3 {
+			compatible = "iio,sensor";
+			reg = <3>;
+			sensor-device = <&fxos8700>;
+			sensor-channels = <IIO_SENSOR_CHAN_ACCEL_X
+					   IIO_SENSOR_CHAN_ACCEL_Y
+					   IIO_SENSOR_CHAN_ACCEL_Z
+					   IIO_SENSOR_CHAN_MAGN_X
+					   IIO_SENSOR_CHAN_MAGN_Y
+					   IIO_SENSOR_CHAN_MAGN_Z
+					   IIO_SENSOR_CHAN_DIE_TEMP>;
+			buffer-name = "buffer0";
+			io-name = "fxos8700";
+		};
+	};
+};

--- a/zephyr/samples/iiod/eval_adxl362_ardz.conf
+++ b/zephyr/samples/iiod/eval_adxl362_ardz.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+CONFIG_SENSOR=y

--- a/zephyr/samples/iiod/eval_adxl362_ardz.overlay
+++ b/zephyr/samples/iiod/eval_adxl362_ardz.overlay
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <dt-bindings/iio/sensor-channels.h>
+
+/ {
+	iio-context {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		iio-device@4 {
+			compatible = "iio,sensor";
+			reg = <4>;
+			sensor-device = <&adxl362_eval_adxl362_ardz>;
+			sensor-channels = <IIO_SENSOR_CHAN_ACCEL_X
+					   IIO_SENSOR_CHAN_ACCEL_Y
+					   IIO_SENSOR_CHAN_ACCEL_Z>;
+			buffer-name = "buffer0";
+			io-name = "adxl362";
+		};
+	};
+};

--- a/zephyr/samples/iiod/sample.yaml
+++ b/zephyr/samples/iiod/sample.yaml
@@ -56,6 +56,14 @@ tests:
     platform_allow:
       - apard32690/max32690/m4
 
+  sample.iiod.console.eval_adxl362_ardz:
+    extra_args:
+      - SNIPPET=iiod-console
+      - SHIELD=eval_adxl362_ardz
+    platform_allow:
+      - apard32690/max32690/m4
+      - frdm_k64f
+
   sample.iiod.console.pmod_acl:
     extra_args:
       - SNIPPET=iiod-console


### PR DESCRIPTION
## PR Description
Adds devicetree and Kconfig overlays for the eval_adxl362_ardz shield and frdm_k64f boards, which contain an adxl362 accelerometer and fxos8700 accelerometer/magnetometer respectively.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
