### PR TITLE
utils: iio_attr: Support multiple buffers

### DIFF
--- a/man/iio_attr.1.in
+++ b/man/iio_attr.1.in
@@ -55,7 +55,7 @@ iio_attr \- list IIO devices, and read/write device attributes
 [
 .I options
 ]
--f -d|-c|-B|-D [device] [channel] [attr] [path]
+-f -d|-c|-B[-b buffer_index]|-D [device] [channel] [attr] [path]
 .br
 .B iio_attr
 -S <arg>
@@ -111,6 +111,10 @@ When pattern matching devices, channels or attributes, ignore case
 .TP
 .B \-g, \-\-generate-code <arg>
 Generate small C or python snippets that emulate what you are doing on the command line. Argument is a file name 'foo.c' or 'foo.py'
+.TP
+.B \-b, \-\-buffer-index <arg>
+When reading or writing buffer attributes (\-B), select the buffer at this index.
+When not specified, \-B shows attribute counts for all buffers on the device.
 .TP
 .B \-f, \-\-input-file
 Treat the trailing [value] argument as a path to a file. The file's raw bytes are written to the attribute via the _raw API variant, instead of writing [value] as a string. Cannot be combined with

--- a/utils/gen_code.c
+++ b/utils/gen_code.c
@@ -206,14 +206,18 @@ void gen_dev(const struct iio_device *dev)
 	}
 }
 
-void gen_buf(const struct iio_buffer *buffer)
+void gen_buf(unsigned int buffer_index)
 {
 	if (!fd)
 		return;
 
 	if (lang == C_LANG) {
 		fprintf(fd, "\t/* Get pre-allocated buffer for device */\n");
-		fprintf(fd, "\tIIO_ASSERT(buffer = iio_device_get_buffer(dev, 0));\n\n");
+		fprintf(fd, "\tIIO_ASSERT(buffer = iio_device_get_buffer(dev, %u));\n\n",
+			buffer_index);
+	} else if (lang == PYTHON_LANG) {
+		fprintf(fd, "    # Get pre-allocated buffer for device\n");
+		fprintf(fd, "    buffer = dev.get_buffer(%u)\n\n", buffer_index);
 	}
 }
 
@@ -298,6 +302,9 @@ void gen_function(const char* prefix, const char* target,
 				fprintf(fd, "    %s.%s[\"%s\"].value = str(\"%s\")\n", target,
 					attr->type == IIO_ATTR_TYPE_DEBUG ? "debug_attrs" : "attrs",
 					iio_attr_get_name(attr), wbuf);
+			} else if (strncmp(prefix, "buffer", 6) == 0) {
+				fprintf(fd, "    %s.attrs[\"%s\"].value = str(\"%s\")\n", target,
+					iio_attr_get_name(attr), wbuf);
 			} else {
 				fprintf(fd, "    # Write for %s / %s not implemented yet\n", prefix, target);
 			}
@@ -310,6 +317,9 @@ void gen_function(const char* prefix, const char* target,
 						iio_attr_get_name(attr), target,
 						attr->type == IIO_ATTR_TYPE_DEBUG ? "debug_attrs" : "attrs",
 						iio_attr_get_name(attr));
+			} else if (strncmp(prefix, "buffer", 6) == 0) {
+				fprintf(fd, "    print(\"%s : \" + %s.attrs[\"%s\"].value)\n",
+						iio_attr_get_name(attr), target, iio_attr_get_name(attr));
 			} else {
 				fprintf(fd, "    # Read for %s / %s not implemented yet\n", prefix, target);
 			}

--- a/utils/gen_code.h
+++ b/utils/gen_code.h
@@ -18,7 +18,7 @@ void gen_context (const char *uri);
 void gen_context_destroy(void);
 void gen_context_attr(const char *key);
 void gen_dev(const struct iio_device *dev);
-void gen_buf(const struct iio_buffer *buffer);
+void gen_buf(unsigned int buffer_index);
 void gen_ch(const struct iio_channel *ch);
 void gen_function(const char* prefix, const char* target,
 		  const struct iio_attr *attr, const char *wbuf);

--- a/utils/iio_attr.c
+++ b/utils/iio_attr.c
@@ -26,6 +26,8 @@
 #define snprintf sprintf_s
 #endif
 
+#define IIO_BUFFER_INDEX_UNSPECIFIED UINT_MAX
+
 #define IIO_ERR(...) prm_err(NULL, MY_NAME ": " __VA_ARGS__)
 #define IIO_PERROR(err, ...) prm_perror(NULL, err, MY_NAME ": " __VA_ARGS__)
 
@@ -320,6 +322,52 @@ static int dump_channel_attributes(const struct iio_device *dev,
 	return (int)ret;
 }
 
+static int dump_buffer_attributes(const struct iio_device *dev,
+				  const struct iio_buffer *buffer,
+				  unsigned int buffer_index,
+				  const struct iio_attr *attr,
+				  const char *wbuf, const unsigned char *wraw,
+				  size_t wraw_len, bool write_only,
+				  enum verbosity quiet)
+{
+	ssize_t ret = 0;
+	bool writing = wbuf || wraw;
+
+	if (!writing || quiet == ATTR_VERBOSE) {
+		gen_function("buffer", "buffer", attr, NULL);
+		if (quiet == ATTR_VERBOSE) {
+			printf("%s ", iio_device_is_trigger(dev) ? "trig" : "dev");
+			printf("'%s'", get_label_or_name_or_id(dev));
+			printf(", buffer (index %u), ", buffer_index);
+			printf("attr '%s', ", iio_attr_get_name(attr));
+		}
+
+		print_attribute_value(dev, attr, "", quiet);
+	}
+	if (writing) {
+		if (wraw) {
+			ret = iio_attr_write_raw(attr, (const void *)wraw, wraw_len);
+		} else {
+			gen_function("buffer", "buffer", attr, wbuf);
+			ret = iio_attr_write_string(attr, wbuf);
+		}
+		if (ret > 0) {
+			if (quiet == ATTR_VERBOSE)
+				printf("wrote %li bytes to %s\n", (long)ret,
+				       iio_attr_get_name(attr));
+			if (wraw && (size_t)ret < wraw_len)
+				fprintf(stderr, "WARNING: short write on '%s': %li of %zu bytes accepted\n",
+						iio_attr_get_name(attr), (long)ret, wraw_len);
+			if (!write_only)
+				dump_buffer_attributes(dev, buffer, buffer_index, attr,
+						       NULL, NULL, 0, false, quiet);
+		} else {
+			IIO_PERROR((int)ret, "Unable to write buffer attribute");
+		}
+	}
+	return (int)ret;
+}
+
 static const struct option options[] = {
 	{"ignore-case", no_argument, 0, 'I'},
 	{"write-only", no_argument, 0, 'w'},
@@ -336,6 +384,7 @@ static const struct option options[] = {
 	{"channel-attr", no_argument, 0, 'c'},
 	{"context-attr", no_argument, 0, 'C'},
 	{"buffer-attr", no_argument, 0, 'B'},
+	{"buffer-index", required_argument, 0, 'b'},
 	{"debug-attr", no_argument, 0, 'D'},
 	{0, 0, 0, 0},
 };
@@ -363,16 +412,18 @@ static const char *options_descriptions[] = {
 	"Read/Write channel attributes.",
 	"Read IIO context attributes.",
 	"Read/Write buffer attributes.",
+	"Buffer index to use.",
 	"Read/Write debug attributes.",
 };
 
-#define MY_OPTS "CdcBDiosIwqvg:f"
+#define MY_OPTS "CdcBDiosIwqvg:fb:"
 int main(int argc, char **argv)
 {
 	char **argw;
 	struct iio_context *ctx;
 	int c, argd = argc;
 	int device_index = 0, channel_index = 0, attr_index = 0;
+	unsigned int buffer_index = IIO_BUFFER_INDEX_UNSPECIFIED;
 	const char *gen_file = NULL;
 	bool search_device = false, ignore_case = false,
 		search_channel = false, search_buffer = false, search_debug = false,
@@ -437,6 +488,13 @@ int main(int argc, char **argv)
 			break;
 		case 'B':
 			search_buffer = true;
+			break;
+		case 'b':
+			if (!optarg) {
+				fprintf(stderr, "Buffer index requires an argument\n");
+				return EXIT_FAILURE;
+			}
+			buffer_index = sanitize_clamp("buffer index", optarg, 0, UINT_MAX);
 			break;
 		case 'D':
 			search_debug = true;
@@ -691,7 +749,8 @@ int main(int argc, char **argv)
 			const char *ch_name, *ch_label;
 			struct iio_buffer *buffer;
 			struct iio_channels_mask *mask;
-			unsigned int nb_attrs, nb_channels, j;
+			unsigned int nb_attrs, nb_channels, nb_buffers, buf_idx, j;
+			char buf_type[32];
 
 			if (device_index && !str_match(dev_id, argw[device_index], ignore_case)
 					&& !str_match(label, argw[device_index], ignore_case)
@@ -896,43 +955,61 @@ int main(int argc, char **argv)
 				}
 			}
 
-			buffer = iio_device_get_buffer(dev, 0);
-			if (buffer) {
-				nb_attrs = iio_buffer_get_attrs_count(buffer);
+			nb_buffers = iio_device_get_buffers_count(dev);
 
-				if (search_buffer && !device_index)
-					printf("found %u buffer attributes\n", nb_attrs);
-
-				if (search_buffer && device_index && !attr_index && !nb_attrs) {
-					printf("%s: Found %s device, but it has %u buffer attributes\n",
-					       MY_NAME, label_or_name_or_id, nb_attrs);
-					if (!attr_found)
+			if (search_buffer && !device_index) {
+				printf("found %u buffer%s\n", nb_buffers,
+				       nb_buffers != 1 ? "s" : "");
+			} else if (search_buffer && device_index) {
+				if (!attr_index && buffer_index == IIO_BUFFER_INDEX_UNSPECIFIED) {
+					for (buf_idx = 0; buf_idx < nb_buffers; buf_idx++) {
+						buffer = iio_device_get_buffer(dev, buf_idx);
+						if (!buffer)
+							continue;
+						nb_attrs = iio_buffer_get_attrs_count(buffer);
+						printf("dev '%s', buffer (index %u), found %u buffer-specific attributes\n",
+						       label_or_name_or_id, buf_idx, nb_attrs);
+						attr_found = true;
+					}
+					if (!attr_found) {
+						printf("%s: Found %s device, but it has no buffers\n",
+						       MY_NAME, label_or_name_or_id);
 						found_err = true;
-				}
-
-				if (search_buffer && device_index && nb_attrs) {
-					gen_dev(dev);
-					gen_buf(buffer);
-					for (j = 0; j < nb_attrs; j++) {
-						attr = iio_buffer_get_attr(buffer, j);
-
-						if ((attr_index && str_match(iio_attr_get_name(attr),
-									     argw[attr_index],
-									     ignore_case))
-						    || !attr_index) {
-							found_err = false;
-							attr_found = true;
-							ret = dump_device_attributes(dev, attr, "buffer",
-										     "buffer", wbuf,
-										     wraw, wraw_len, write_only,
-										     attr_index ? quiet : ATTR_VERBOSE);
-							if ((wbuf || wraw) && ret < 0)
-								write_err = true;
-							else if (ret < 0 && attr_index)
-								read_err = true;
+					}
+				} else {
+					buffer = iio_device_get_buffer(dev, buffer_index);
+					snprintf(buf_type, sizeof(buf_type), "buffer%u", buffer_index);
+					if (!buffer) {
+						printf("%s: Found %s device, but has no buffer at index %u\n",
+						       MY_NAME, label_or_name_or_id, buffer_index);
+						found_err = true;
+					} else {
+						nb_attrs = iio_buffer_get_attrs_count(buffer);
+						if (!nb_attrs) {
+							printf("%s: Found %s device, but %s has %u buffer attributes\n",
+							       MY_NAME, label_or_name_or_id, buf_type, nb_attrs);
+							if (!attr_found)
+								found_err = true;
+						} else {
+							gen_dev(dev);
+							gen_buf(buffer);
+							for (j = 0; j < nb_attrs; j++) {
+								attr = iio_buffer_get_attr(buffer, j);
+								if (!attr_index || str_match(iio_attr_get_name(attr),
+									      argw[attr_index], ignore_case)) {
+									found_err = false;
+									attr_found = true;
+									ret = dump_buffer_attributes(dev, buffer, buffer_index, attr,
+												      wbuf, wraw, wraw_len, write_only,
+												      attr_index ? quiet : ATTR_VERBOSE);
+									if ((wbuf || wraw) && ret < 0)
+										write_err = true;
+									else if (ret < 0)
+										read_err = true;
+								}
+							}
 						}
 					}
-
 				}
 			}
 

--- a/utils/iio_attr.c
+++ b/utils/iio_attr.c
@@ -158,8 +158,7 @@ static inline const char *get_label_or_name_or_id(const struct iio_device *dev)
 	return iio_device_get_id(dev);
 }
 
-static void print_attribute_value(const struct iio_device *dev,
-                                  const struct iio_attr *attr,
+static void print_attribute_value(const struct iio_attr *attr,
                                   const char *prefix,
                                   enum verbosity quiet)
 {
@@ -233,7 +232,7 @@ static int dump_device_attributes(const struct iio_device *dev,
                               iio_attr_get_name(attr));
 		}
 		gen_function(type, var, attr, NULL);
-		print_attribute_value(dev, attr, "", quiet);
+		print_attribute_value(attr, "", quiet);
 	}
 	if (writing) {
 		if (wraw) {
@@ -295,7 +294,7 @@ static int dump_channel_attributes(const struct iio_device *dev,
 		if (quiet == ATTR_VERBOSE)
 			printf("attr '%s', ", iio_attr_get_name(attr));
 
-		print_attribute_value(dev, attr, "", quiet);
+		print_attribute_value(attr, "", quiet);
 	}
 	if (writing) {
 		if (wraw) {
@@ -342,7 +341,7 @@ static int dump_buffer_attributes(const struct iio_device *dev,
 			printf("attr '%s', ", iio_attr_get_name(attr));
 		}
 
-		print_attribute_value(dev, attr, "", quiet);
+		print_attribute_value(attr, "", quiet);
 	}
 	if (writing) {
 		if (wraw) {

--- a/utils/iio_attr.c
+++ b/utils/iio_attr.c
@@ -210,6 +210,7 @@ static void print_attribute_value(const struct iio_attr *attr,
 		printf("\n");
 		IIO_PERROR((int)ret, "Unable to read attribute");
 	}
+	free(buf);
 }
 
 static int dump_device_attributes(const struct iio_device *dev,
@@ -220,7 +221,6 @@ static int dump_device_attributes(const struct iio_device *dev,
 				  enum verbosity quiet)
 {
 	ssize_t ret = 0;
-	char *buf = xmalloc(BUF_SIZE, MY_NAME);
 	bool writing = wbuf || wraw;
 
 	if (!writing || quiet == ATTR_VERBOSE) {
@@ -255,8 +255,6 @@ static int dump_device_attributes(const struct iio_device *dev,
 			IIO_PERROR((int)ret, "Unable to write attribute");
 		}
 	}
-	free(buf);
-
 	return (int)ret;
 }
 
@@ -268,7 +266,6 @@ static int dump_channel_attributes(const struct iio_device *dev,
 				   enum verbosity quiet)
 {
 	ssize_t ret = 0;
-	char *buf = xmalloc(BUF_SIZE, MY_NAME);
 	const char *type_name;
 	bool writing = wbuf || wraw;
 
@@ -317,7 +314,6 @@ static int dump_channel_attributes(const struct iio_device *dev,
 			IIO_PERROR((int)ret, "Unable to write channel attribute");
 		}
 	}
-	free(buf);
 	return (int)ret;
 }
 

--- a/utils/iio_attr.c
+++ b/utils/iio_attr.c
@@ -992,7 +992,7 @@ int main(int argc, char **argv)
 								found_err = true;
 						} else {
 							gen_dev(dev);
-							gen_buf(buffer);
+							gen_buf(buffer_index);
 							for (j = 0; j < nb_attrs; j++) {
 								attr = iio_buffer_get_attr(buffer, j);
 								if (!attr_index || str_match(iio_attr_get_name(attr),


### PR DESCRIPTION
## PR Description
This PR adds multi-buffer support to the `iio_attr` utility and code generation functionality. Users can now select specific buffer indices when reading or writing buffer attributes, and the code generation feature produces correct buffer access code for multi-buffer devices.

Also this fixes #1418 

### Benefits
- Enables buffer attribute access on multi-buffer devices
- Improves code quality by removing unused allocations and parameters

### Changes
- Add `-b/--buffer-index` option to `iio_attr` utility for buffer index selection
- Add `dump_buffer_attributes()` helper function with buffer index display
- Update `gen_buf()` signature to accept `buffer_index` parameter instead of hardcoding 0
- Add buffer attribute support for Python code generation
- Remove unused `dev` parameter from `print_attribute_value()` function
- Remove unused buffer allocations from attribute dump functions

### How it works
1. When `-B` is used without `-b`, `iio_attr` iterates through all buffers on the device and shows the attribute count for each buffer index.
2. When `-b idx` is specified with `-B`, the tool calls `iio_device_get_buffer(dev, idx)` to access the specific buffer and displays each individual attribute of that buffer with their names and values
3. The updated `gen_buf()` function receives the buffer index and generates `iio_device_get_buffer(dev, idx)` with the correct index in generated code
4. Generated code (both C and Python) uses the proper buffer index that matches the runtime selection made with `-b`

### Backwards Compatibility
The behavior changes when no `-b` flag is specified with -B. Previously, buffer operations accessed buffer 0 directly. Now they provide a discovery view showing attribute counts for all buffers. Additionally, when `-B` is used without a device name, the behavior changes from showing device buffer attribute counts to showing buffer counts per device
### Usage

#### Basic Buffer Discovery
```bash
# List all buffers on a multi-buffer device
$ iio_attr -u ip:192.168.2.1 -B cf-ad9361-lpc
dev 'cf-ad9361-lpc', buffer (index 0), found 3 buffer-specific attributes

# List all devices and their buffer counts
$ iio_attr -u ip:192.168.2.1 -B
IIO context has 5 devices:
        iio:device0, adm1177-iio: found 0 buffers
        iio:device1, ad9361-phy: found 0 buffers
        iio:device2, xadc: found 0 buffers
        iio:device3, cf-ad9361-dds-core-lpc: found 1 buffer
        iio:device4, cf-ad9361-lpc: found 1 buffer

# List all attriutes for a specified buffer index
$ iio_attr -u ip:192.168.2.1 -B cf-ad9361-lpc -b 0
dev 'cf-ad9361-lpc', buffer (index 0), attr 'data_available', value '0'
dev 'cf-ad9361-lpc', buffer (index 0), attr 'direction', value 'in'
dev 'cf-ad9361-lpc', buffer (index 0), attr 'length_align_bytes', value '8'

```

#### Reading Buffer Attributes
```bash
# Read from buffer 0
$ iio_attr -u ip:192.168.2.1 -B cf-ad9361-lpc -b 0 data_available
0

# Verbose output shows buffer index clearly
$ iio_attr -u ip:192.168.2.1 -B cf-ad9361-lpc -b 0 data_available -v
dev 'cf-ad9361-lpc', buffer (index 0), attr 'data_available', value '0'
```

#### Code Generation Examples
```bash
# Generate C code for buffer 0 access
$ iio_attr -u ip:192.168.2.1 -B cf-ad9361-lpc -b 0 data_available -g ../../temp/code_gen/test_buf0.c

# Generate Python code for buffer 0 access
$ iio_attr -u ip:192.168.2.1 -B cf-ad9361-lpc -b 0  data_available -g ../../temp/code_gen/test_buf0.py

```

#### Error Handling
```bash
# Non-existent buffer index fails gracefully
$ iio_attr -u ip:192.168.2.1 -b 99 -B cf-ad9361-lpc data_available
iio_attr: Found cf-ad9361-lpc device, but has no buffer at index 99
```
All usage examples shown above have been tested and verified, including the code generation that produces working C and Python code.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [x] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)