### PR TITLE
zephyr: iiod: Remove double ctx create in uart.c

### DIFF
--- a/zephyr/iiod/uart.c
+++ b/zephyr/iiod/uart.c
@@ -125,7 +125,6 @@ static void iiod_uart_thread(void *p1, void *p2, void *p3)
 	uart_irq_callback_user_data_set(dev, iiod_uart_irq, NULL);
 	uart_irq_rx_enable(dev);
 
-	ctx = iio_create_context(&ctx_params, "zephyr:");
 
 	/* Initialize tinyiiod global resources */
 	LOG_DBG("Initializing tinyiiod resources...");


### PR DESCRIPTION
Remove of the double context create function in uart.c.

Signed-off-by: Dimitrije Lilic <dimitrije.lilic@orioninc.com>

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
