### PR TITLE
bindings: expose iio_buffer_get_scan_element APIs in Python, C++ and C#

### DIFF
--- a/bindings/cpp/iio.hpp
+++ b/bindings/cpp/iio.hpp
@@ -520,6 +520,8 @@ public:
     bool is_output() const {return iio_buffer_is_output(p);}
     void set_data(void * data){iio_buffer_set_data(p, data);}
     void * data() {return iio_buffer_get_data(p);}
+    unsigned int scan_elements_count() const {return iio_buffer_get_scan_elements_count(p);}
+    optional<Channel> get_scan_element(unsigned int index) const {return impl::maybe<Channel>(const_cast<iio_channel *>(iio_buffer_get_scan_element(p, index)));}
     BufferStreamPtr open(iio_channels_mask const * mask) { return BufferStreamPtr{impl::check(iio_buffer_open(p, mask), "iio_buffer_open")}; }
     StreamPtr create_stream(size_t nb_blocks, size_t sample_count, iio_channels_mask * mask) { return StreamPtr{impl::check(iio_buffer_create_stream(p, nb_blocks, sample_count, mask), "iio_buffer_create_stream")}; }
 };

--- a/bindings/csharp/IOBuffer.cs
+++ b/bindings/csharp/IOBuffer.cs
@@ -26,6 +26,12 @@ namespace iio
         [return: MarshalAs(UnmanagedType.I1)]
         private static extern bool iio_buffer_is_output(IntPtr buf);
 
+        [DllImport(IioLib.dllname, CallingConvention = CallingConvention.Cdecl)]
+        private static extern uint iio_buffer_get_scan_elements_count(IntPtr buf);
+
+        [DllImport(IioLib.dllname, CallingConvention = CallingConvention.Cdecl)]
+        private static extern IntPtr iio_buffer_get_scan_element(IntPtr buf, uint index);
+
         /// <summary>The associated <see cref="iio.Device"/> object.</summary>
         public readonly Device dev;
 
@@ -51,6 +57,23 @@ namespace iio
         public bool output
         {
             get { return iio_buffer_is_output(buf); }
+        }
+
+        /// <summary>Returns the list of scan elements associated with this buffer.</summary>
+        public List<Channel> scan_elements
+        {
+            get
+            {
+                var list = new List<Channel>();
+                uint count = iio_buffer_get_scan_elements_count(buf);
+                for (uint i = 0; i < count; i++)
+                {
+                    IntPtr chn = iio_buffer_get_scan_element(buf, i);
+                    if (chn != IntPtr.Zero)
+                        list.Add(new Channel(dev, chn));
+                }
+                return list;
+            }
         }
 
         /// <summary>Open this buffer for data streaming.</summary>

--- a/bindings/python/iio/__init__.py
+++ b/bindings/python/iio/__init__.py
@@ -522,6 +522,14 @@ _b_get_attr.restype = _AttrPtr
 _b_get_attr.argtypes = (_BufferPtr, c_uint)
 _b_get_attr.errcheck = _check_null
 
+_b_scan_elements_count = _lib.iio_buffer_get_scan_elements_count
+_b_scan_elements_count.restype = c_uint
+_b_scan_elements_count.argtypes = (_BufferPtr,)
+
+_b_get_scan_element = _lib.iio_buffer_get_scan_element
+_b_get_scan_element.restype = _ChannelPtr
+_b_get_scan_element.argtypes = (_BufferPtr, c_uint)
+
 _d_get_context = _lib.iio_device_get_context
 _d_get_context.restype = _ContextPtr
 _d_get_context.argtypes = (_DevicePtr,)
@@ -1167,6 +1175,16 @@ class Buffer(_IIO_Object):
         None,
         None,
         "List of attributes for this buffer.\n\ttype=dict of iio.Attr",
+    )
+
+    scan_elements = property(
+        lambda self: [
+            Channel(self._parent, _b_get_scan_element(self._buffer, x))
+            for x in range(0, _b_scan_elements_count(self._buffer))
+        ],
+        None,
+        None,
+        "List of scan elements (channels) associated with this buffer.\n\ttype=list of iio.Channel",
     )
 
 


### PR DESCRIPTION
## PR Description
This PR exposes `iio_buffer_get_scan_elements_count()` and `iio_buffer_get_scan_element()` in the Python, C++, and C# bindings. All Python, C++, C# bindings were tested against a Pluto.


### Changes
- Python: ctypes bindings + `Buffer.scan_elements` property
- C++: `Buffer::scan_elements_count()` and `Buffer::get_scan_element()` in `iio.hpp`
- C#: P/Invoke declarations + `IOBuffer.scan_elements` property


### Testing

All three bindings tested against a Pluto through iiod. All returned identical results: 2 scan elements on the RX buffer (output=False) and 2 on the TX buffer (output=True)

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
