### PR TITLE
device: fall back to attr method if backend reg op returns -ENOSYS

### DIFF
--- a/device.c
+++ b/device.c
@@ -417,7 +417,9 @@ int iio_device_reg_write(struct iio_device *dev,
 
 	/* Use atomic backend operation if available */
 	if (ops && ops->reg_write) {
-		return ops->reg_write(dev, address, value);
+		int ret = ops->reg_write(dev, address, value);
+		if (ret != -ENOSYS)
+			return ret;
 	}
 
 	/* Fallback to the original attribute-based implementation.
@@ -446,7 +448,9 @@ int iio_device_reg_read(struct iio_device *dev,
 
 	/* Use atomic backend operation if available */
 	if (ops && ops->reg_read) {
-		return ops->reg_read(dev, address, value);
+		int ret = ops->reg_read(dev, address, value);
+		if (ret != -ENOSYS)
+			return ret;
 	}
 
 	/* Fallback to the original attribute-based implementation. */


### PR DESCRIPTION
## PR Description

`iio_device_reg_write()` and `iio_device_reg_read()` now work correctly when a v1 client connects to a v0 (ASCII protocol) server over the network. Previously both functions returned `-ENOSYS` in that scenario, making register access completely broken against legacy servers.

### Changes
- `iio_device_reg_write()` in `device.c`: treat `-ENOSYS` as not supported on the legacy version and fall through to the `direct_reg_access` attribute method
- `iio_device_reg_read()` in `device.c`: same fix

### Testing

Tested against a v0 IIOD server (AD9361 platform) using `iio_device_reg_write` and `iio_device_reg_read` on the `cf-ad9361-dds-core-lpc` device. A full write -> read round-trip  returned the expected value (`0xA5A5A5A5`). Before the fix both functions returned `-38` (`-ENOSYS`).
## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
