### PR TITLE
Grant write permissions for GitHub Pages deployment

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -3,7 +3,7 @@ name: Documentation Tests
 on: [push, pull_request]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   CheckDocs:


### PR DESCRIPTION
## PR Description

The CI job that creates the documentation can't deploy it as it has read-only permissions.
Error:
remote: Permission to analogdevicesinc/libiio.git denied to github-actions[bot].
  fatal: unable to access 'https://github.com/analogdevicesinc/libiio.git/': The requested URL returned error: 403
  Error: Action failed with "The process '/usr/bin/git' failed with exit code 128"

Grant write permissions to fix this.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
