### PR TITLE
ci: add weekly scheduled build for libiio-v0 branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,14 @@ pr:
     - 20*
     - libiio-v0
 
+schedules:
+- cron: "0 6 * * 6"
+  displayName: Weekly libiio-v0 build
+  branches:
+    include:
+    - libiio-v0
+  always: true
+
 stages:
 - stage: Builds
   #############################################


### PR DESCRIPTION
Ensures the legacy v0 branch is built every Saturday at 06:00 UTC, even in the absence of new commits, catching CI image and dependency drift early.

Signed-off-by: Ioana Chelaru <ioana-gabriela.chelaru@analog.com>