### PR TITLE
bindings/csharp: use Dictionary for attrs and cache scan_elements

### DIFF
--- a/bindings/csharp/Channel.cs
+++ b/bindings/csharp/Channel.cs
@@ -252,11 +252,11 @@ namespace iio
         /// and use it for I/O operations.</remarks>
         public readonly bool scan_element;
 
-        /// <summary>A <c>list</c> of all the attributes that this channel has.</summary>
-        public readonly List<Attr> attrs;
+        /// <summary>A <c>Dictionary</c> of all the attributes that this channel has. Key is the attribute name.</summary>
+        public readonly IReadOnlyDictionary<string, Attr> attrs;
 
-        /// <summary>A <c>list</c> of all the event attributes that this channel has.</summary>
-        public readonly List<Attr> event_attrs;
+        /// <summary>A <c>Dictionary</c> of all the event attributes that this channel has. Key is the attribute name.</summary>
+        public readonly IReadOnlyDictionary<string, Attr> event_attrs;
 
         /// <summary>The modifier of this channel.</summary>
         public ChannelModifier modifier { get; private set; }
@@ -275,21 +275,25 @@ namespace iio
 
             this.dev = dev;
             this.chn = chn;
-            attrs = new List<Attr>();
-            event_attrs = new List<Attr>();
             modifier = (ChannelModifier) iio_channel_get_modifier(chn);
             type = (ChannelType) iio_channel_get_type(chn);
             format = (DataFormat)Marshal.PtrToStructure(fmt_struct, typeof(DataFormat));
 
+            var attrsDict = new Dictionary<string, Attr>();
             for (uint i = 0; i < nb_attrs; i++)
             {
-                attrs.Add(new Attr(iio_channel_get_attr(chn, i)));
+                Attr a = new Attr(iio_channel_get_attr(chn, i));
+                attrsDict[a.name] = a;
             }
+            attrs = attrsDict;
 
+            var eventAttrsDict = new Dictionary<string, Attr>();
             for (uint i = 0; i < nb_event_attrs; i++)
             {
-                event_attrs.Add(new Attr(iio_channel_get_event_attr(chn, i)));
+                Attr a = new Attr(iio_channel_get_event_attr(chn, i));
+                eventAttrsDict[a.name] = a;
             }
+            event_attrs = eventAttrsDict;
 
             IntPtr name_ptr = iio_channel_get_name(this.chn);
             if (name_ptr == IntPtr.Zero)

--- a/bindings/csharp/Context.cs
+++ b/bindings/csharp/Context.cs
@@ -209,14 +209,15 @@ namespace iio
         }
 
         /// <summary>Get the <see cref="iio.Device"/> object of the specified name.</summary>
-        /// <param name="name">Name or ID of the device to look for</param>
+        /// <param name="name">Name, ID, or label of the device to look for</param>
         /// <exception cref="IioLib.IIOException">The IIO device with the specified
-        /// name or ID could not be found in the current context.</exception>
+        /// name, ID, or label could not be found in the current context.</exception>
         public Device get_device(string name)
         {
             foreach (Device each in devices) {
                 if (each.name.CompareTo(name) == 0 ||
-                            each.id.CompareTo(name) == 0)
+                            each.id.CompareTo(name) == 0 ||
+                            each.label.CompareTo(name) == 0)
                 {
                     return each;
                 }

--- a/bindings/csharp/Context.cs
+++ b/bindings/csharp/Context.cs
@@ -107,7 +107,7 @@ namespace iio
         public readonly Version backend_version;
 
         /// <summary>A <c>List</c> of all the IIO devices present on the current context.</summary>
-        public readonly List<Device> devices;
+        public readonly IReadOnlyList<Device> devices;
 
         /// <summary>A <c>Dictionary</c> of all the attributes of the current context. (key, value) = (name, value)</summary>
         public Dictionary<string, string> attrs { get; private set; }
@@ -167,19 +167,20 @@ namespace iio
 
             uint nb_devices = iio_context_get_devices_count(hdl);
 
-            devices = new List<Device>();
+            var devicesList = new List<Device>();
             for (uint i = 0; i < nb_devices; i++)
             {
                 IntPtr dev = iio_context_get_device(hdl, i);
                 if (iio_device_is_trigger(dev))
                 {
-                    devices.Add(new Trigger(this, dev));
+                    devicesList.Add(new Trigger(this, dev));
                 }
                 else
                 {
-                    devices.Add(new Device(this, dev));
+                    devicesList.Add(new Device(this, dev));
                 }
             }
+            devices = devicesList;
 
             IIOPtr xml_hdl = iio_context_get_xml(hdl);
             if (!xml_hdl)

--- a/bindings/csharp/Context.cs
+++ b/bindings/csharp/Context.cs
@@ -109,7 +109,7 @@ namespace iio
         /// <summary>A <c>List</c> of all the IIO devices present on the current context.</summary>
         public readonly List<Device> devices;
 
-        /// <summary>A <c>Dictionary</c> of all the attributes of the current channel. (key, value) = (name, value)</summary>
+        /// <summary>A <c>Dictionary</c> of all the attributes of the current context. (key, value) = (name, value)</summary>
         public Dictionary<string, string> attrs { get; private set; }
 
         /// <summary>

--- a/bindings/csharp/Device.cs
+++ b/bindings/csharp/Device.cs
@@ -175,16 +175,17 @@ namespace iio
         }
 
         /// <summary>Get the <see cref="iio.Channel"/> object of the specified name.</summary>
-        /// <param name="name">Name or ID of the channel to look for</param>
+        /// <param name="name">Name, ID, or label of the channel to look for</param>
         /// <param name="output">true if you are looking for an output channel, otherwise false.</param>
-        /// <exception cref="IioLib.IIOException">The IIO device with the specified
-        /// name or ID could not be found in the current context.</exception>
+        /// <exception cref="IioLib.IIOException">The IIO channel with the specified
+        /// name, ID, or label could not be found in the current device.</exception>
         public Channel get_channel(string name, bool output = false)
         {
             foreach (Channel each in channels)
             {
                 if ((each.name.CompareTo(name) == 0 ||
-                            each.id.CompareTo(name) == 0) && each.output == output)
+                            each.id.CompareTo(name) == 0 ||
+                            each.label.CompareTo(name) == 0) && each.output == output)
                 {
                     return each;
                 }

--- a/bindings/csharp/Device.cs
+++ b/bindings/csharp/Device.cs
@@ -91,30 +91,25 @@ namespace iio
         /// <summary>True if the device is a hardware monitoring device, False if it is a IIO device.</summary>
         public bool hwmon { get; private set; }
 
-        /// <summary>A <c>list</c> of all the attributes that this device has.</summary>
-        public readonly List<Attr> attrs;
+        /// <summary>A <c>Dictionary</c> of all the attributes that this device has. Key is the attribute name.</summary>
+        public readonly IReadOnlyDictionary<string, Attr> attrs;
 
-        /// <summary>A <c>list</c> of all the debug attributes that this device has.</summary>
-        public readonly List<Attr> debug_attrs;
+        /// <summary>A <c>Dictionary</c> of all the debug attributes that this device has. Key is the attribute name.</summary>
+        public readonly IReadOnlyDictionary<string, Attr> debug_attrs;
 
-        /// <summary>A <c>list</c> of all the event attributes that this device has.</summary>
-        public readonly List<Attr> event_attrs;
+        /// <summary>A <c>Dictionary</c> of all the event attributes that this device has. Key is the attribute name.</summary>
+        public readonly IReadOnlyDictionary<string, Attr> event_attrs;
 
         /// <summary>A <c>list</c> of all the <see cref="iio.Channel"/> objects that this device possesses.</summary>
-        public readonly List<Channel> channels;
+        public readonly IReadOnlyList<Channel> channels;
 
         /// <summary>A <c>list</c> of all the <see cref="iio.IOBuffer"/> objects that this device possesses.</summary>
-        public readonly List<IOBuffer> buffers;
+        public readonly IReadOnlyList<IOBuffer> buffers;
 
         internal Device(Context ctx, IntPtr dev)
         {
             this.ctx = ctx;
             this.dev = dev;
-            channels = new List<Channel>();
-            attrs = new List<Attr>();
-            debug_attrs = new List<Attr>();
-            event_attrs = new List<Attr>();
-            buffers = new List<IOBuffer>();
 
             uint nb_channels = iio_device_get_channels_count(dev);
             uint nb_attrs = iio_device_get_attrs_count(dev);
@@ -122,32 +117,46 @@ namespace iio
             uint nb_event_attrs = iio_device_get_event_attrs_count(dev);
             uint nb_buffers = iio_device_get_buffers_count(dev);
 
+            var channelsList = new List<Channel>();
             for (uint i = 0; i < nb_channels; i++)
             {
-                channels.Add(new Channel(this, iio_device_get_channel(dev, i)));
+                channelsList.Add(new Channel(this, iio_device_get_channel(dev, i)));
             }
 
+            var attrsDict = new Dictionary<string, Attr>();
             for (uint i = 0; i < nb_attrs; i++)
             {
-                attrs.Add(new Attr(iio_device_get_attr(dev, i)));
+                Attr a = new Attr(iio_device_get_attr(dev, i));
+                attrsDict[a.name] = a;
             }
 
+            var debugAttrsDict = new Dictionary<string, Attr>();
             for (uint i = 0; i < nb_debug_attrs; i++)
             {
-                debug_attrs.Add(new Attr(iio_device_get_debug_attr(dev, i)));
+                Attr a = new Attr(iio_device_get_debug_attr(dev, i));
+                debugAttrsDict[a.name] = a;
             }
 
+            var eventAttrsDict = new Dictionary<string, Attr>();
             for (uint i = 0; i < nb_event_attrs; i++)
             {
-                event_attrs.Add(new Attr(iio_device_get_event_attr(dev, i)));
+                Attr a = new Attr(iio_device_get_event_attr(dev, i));
+                eventAttrsDict[a.name] = a;
             }
 
             id = Marshal.PtrToStringAnsi(iio_device_get_id(dev)); // Device IDs are ASCII (kernel-defined)
 
+            var buffersList = new List<IOBuffer>();
             for (uint i = 0; i < nb_buffers; i++)
             {
-                buffers.Add(new IOBuffer(this, iio_device_get_buffer(dev, i)));
+                buffersList.Add(new IOBuffer(this, iio_device_get_buffer(dev, i)));
             }
+
+            channels = channelsList;
+            attrs = attrsDict;
+            debug_attrs = debugAttrsDict;
+            event_attrs = eventAttrsDict;
+            buffers = buffersList;
 
             IntPtr name_ptr = iio_device_get_name(dev);
             if (name_ptr == IntPtr.Zero)

--- a/bindings/csharp/IOBuffer.cs
+++ b/bindings/csharp/IOBuffer.cs
@@ -35,8 +35,8 @@ namespace iio
         /// <summary>The associated <see cref="iio.Device"/> object.</summary>
         public readonly Device dev;
 
-        /// <summary>A <c>list</c> of all the attributes that this buffer has.</summary>
-        public readonly List<Attr> attrs;
+        /// <summary>A <c>Dictionary</c> of all the attributes that this buffer has. Key is the attribute name.</summary>
+        public readonly IReadOnlyDictionary<string, Attr> attrs;
 
         internal IntPtr buf;
 
@@ -45,12 +45,14 @@ namespace iio
             this.dev = dev;
             this.buf = buffer;
 
-            attrs = new List<Attr>();
+            var attrsDict = new Dictionary<string, Attr>();
             uint nb_buffer_attrs = iio_buffer_get_attrs_count(buf);
             for (uint i = 0; i < nb_buffer_attrs; i++)
             {
-                attrs.Add(new Attr(iio_buffer_get_attr(buf, i)));
+                Attr a = new Attr(iio_buffer_get_attr(buf, i));
+                attrsDict[a.name] = a;
             }
+            attrs = attrsDict;
         }
 
         /// <summary>Returns true if the buffer is an output (TX) buffer.</summary>

--- a/bindings/csharp/IOBuffer.cs
+++ b/bindings/csharp/IOBuffer.cs
@@ -38,6 +38,9 @@ namespace iio
         /// <summary>A <c>Dictionary</c> of all the attributes that this buffer has. Key is the attribute name.</summary>
         public readonly IReadOnlyDictionary<string, Attr> attrs;
 
+        /// <summary>A <c>list</c> of all scan elements associated with this buffer.</summary>
+        public readonly IReadOnlyList<Channel> scan_elements;
+
         internal IntPtr buf;
 
         internal IOBuffer(Device dev, IntPtr buffer)
@@ -53,29 +56,22 @@ namespace iio
                 attrsDict[a.name] = a;
             }
             attrs = attrsDict;
+
+            var scanElements = new List<Channel>();
+            uint nb_scan_elements = iio_buffer_get_scan_elements_count(buf);
+            for (uint i = 0; i < nb_scan_elements; i++)
+            {
+                IntPtr chn = iio_buffer_get_scan_element(buf, i);
+                if (chn != IntPtr.Zero)
+                    scanElements.Add(new Channel(dev, chn));
+            }
+            scan_elements = scanElements;
         }
 
         /// <summary>Returns true if the buffer is an output (TX) buffer.</summary>
         public bool output
         {
             get { return iio_buffer_is_output(buf); }
-        }
-
-        /// <summary>Returns the list of scan elements associated with this buffer.</summary>
-        public List<Channel> scan_elements
-        {
-            get
-            {
-                var list = new List<Channel>();
-                uint count = iio_buffer_get_scan_elements_count(buf);
-                for (uint i = 0; i < count; i++)
-                {
-                    IntPtr chn = iio_buffer_get_scan_element(buf, i);
-                    if (chn != IntPtr.Zero)
-                        list.Add(new Channel(dev, chn));
-                }
-                return list;
-            }
         }
 
         /// <summary>Open this buffer for data streaming.</summary>

--- a/bindings/csharp/Scan.cs
+++ b/bindings/csharp/Scan.cs
@@ -48,7 +48,7 @@ namespace iio
         public readonly uint nb_results;
 
         /// <summary>A <see cref="Dictionary{String, String}"/> containing each context's uri as key and its description as value.</summary>
-        public readonly Dictionary<string, string> results;
+        public readonly IReadOnlyDictionary<string, string> results;
 
         public Scan(string backends = null)
         {
@@ -61,14 +61,15 @@ namespace iio
             hdl = ptr.ptr;
             nb_results = iio_scan_get_results_count(hdl);
 
-            results = new Dictionary<string, string>();
+            var resultsDict = new Dictionary<string, string>();
 
             for (uint i = 0; i < nb_results; i++) {
                 string uri = Marshal.PtrToStringAnsi(iio_scan_get_uri(hdl, i)); // URIs are ASCII (RFC-compliant)
                 string dsc = UTF8Marshaler.PtrToStringUTF8(iio_scan_get_description(hdl, i));
 
-                results[uri] = dsc;
+                resultsDict[uri] = dsc;
             }
+            results = resultsDict;
         }
 
         protected override void Destroy()

--- a/bindings/csharp/Trigger.cs
+++ b/bindings/csharp/Trigger.cs
@@ -25,7 +25,7 @@ namespace iio
         /// <exception cref="IioLib.IIOException">The new frequency could not be set.</exception>
         public void set_rate(ulong rate)
         {
-            foreach (Attr each in attrs)
+            foreach (Attr each in attrs.Values)
             {
                 if (each.name.Equals("frequency"))
                 {
@@ -40,7 +40,7 @@ namespace iio
         /// <exception cref="IioLib.IIOException">The configured frequency could not be obtained.</exception>
         public ulong get_rate()
         {
-            foreach (Attr each in attrs)
+            foreach (Attr each in attrs.Values)
             {
                 if (each.name.Equals("frequency"))
                 {

--- a/bindings/csharp/Trigger.cs
+++ b/bindings/csharp/Trigger.cs
@@ -19,35 +19,26 @@ namespace iio
     /// Contains the representation of an IIO device that can act as a trigger.</summary>
     public class Trigger : Device
     {
+        private const string FrequencyAttr = "frequency";
+
         internal Trigger(Context ctx, IntPtr ptr) : base(ctx, ptr) { }
 
         /// <summary>Configure a new frequency for this trigger.</summary>
         /// <exception cref="IioLib.IIOException">The new frequency could not be set.</exception>
         public void set_rate(ulong rate)
         {
-            foreach (Attr each in attrs.Values)
-            {
-                if (each.name.Equals("frequency"))
-                {
-                    each.write((long) rate);
-                    return;
-                }
-            }
-            throw new IIOException("Trigger has no frequency?");
+            if (!attrs.ContainsKey(FrequencyAttr))
+                throw new IIOException("Trigger has no frequency?");
+            attrs[FrequencyAttr].write((long) rate);
         }
 
         /// <summary>Get the currently configured frequency of this trigger.</summary>
         /// <exception cref="IioLib.IIOException">The configured frequency could not be obtained.</exception>
         public ulong get_rate()
         {
-            foreach (Attr each in attrs.Values)
-            {
-                if (each.name.Equals("frequency"))
-                {
-                    return (ulong) each.read_long();
-                }
-            }
-            throw new IIOException("Trigger has no frequency?");
+            if (!attrs.ContainsKey(FrequencyAttr))
+                throw new IIOException("Trigger has no frequency?");
+            return (ulong) attrs[FrequencyAttr].read_long();
         }
 
         /// <summary>Set Trigger.</summary>

--- a/bindings/csharp/examples/ExampleProgram.cs
+++ b/bindings/csharp/examples/ExampleProgram.cs
@@ -141,7 +141,7 @@ namespace IIOCSharp
                 }
 
                 Console.WriteLine("\n\t\t" + dev.attrs.Count + " device-specific attributes found:");
-                foreach (Attr attr in dev.attrs)
+                foreach (Attr attr in dev.attrs.Values)
                 {
                     Console.WriteLine("\t\t\t" + attr.name);
                 }

--- a/bindings/csharp/examples/ExampleProgram.cs
+++ b/bindings/csharp/examples/ExampleProgram.cs
@@ -118,7 +118,7 @@ namespace IIOCSharp
                     Console.WriteLine("* Sample size is " + sampleSize + "\n");
 
                     Console.WriteLine("\t\t\t" + buf.attrs.Count + " buffer-specific attributes found:");
-                    foreach (Attr attr in buf.attrs)
+                    foreach (Attr attr in buf.attrs.Values)
                     {
                         Console.WriteLine("\t\t\t\t" + attr.name + " " + attr.read());
                     }

--- a/bindings/csharp/examples/ExampleProgram.cs
+++ b/bindings/csharp/examples/ExampleProgram.cs
@@ -80,7 +80,7 @@ namespace IIOCSharp
                     }
 
                     Console.WriteLine("\t\t\t" + chn.attrs.Count + " channel-specific attributes found:");
-                    foreach (Attr attr in chn.attrs)
+                    foreach (Attr attr in chn.attrs.Values)
                     {
                         string attr_name = "\t\t\t\t" + attr.name;
                         string attr_val = "";

--- a/bindings/csharp/tests/IntegrationTests.cs
+++ b/bindings/csharp/tests/IntegrationTests.cs
@@ -176,7 +176,7 @@ namespace LibiioTests
                 int attrCount = dev.attrs.Count;
                 Console.WriteLine("  INFO: Device has " + attrCount + " attributes");
 
-                foreach (Attr attr in dev.attrs)
+                foreach (Attr attr in dev.attrs.Values)
                 {
                     string name = attr.name;
 

--- a/bindings/csharp/tests/IntegrationTests.cs
+++ b/bindings/csharp/tests/IntegrationTests.cs
@@ -222,7 +222,7 @@ namespace LibiioTests
                     int attrCount = chn.attrs.Count;
                     Console.WriteLine("  INFO: Channel '" + chn.id + "' has " + attrCount + " attributes");
 
-                    foreach (Attr attr in chn.attrs)
+                    foreach (Attr attr in chn.attrs.Values)
                     {
                         string name = attr.name;
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -140,8 +140,10 @@ import logging as py_logging
 
 # Patterns for C# xref warnings to suppress (unavoidable .NET system types)
 csharp_xref_suppress_patterns = [
-    re.compile(r"Failed to find xref for: IntPtr"),  # .NET system type
-    re.compile(r"Failed to find xref for: >"),        # Generic type parsing artifact
+    re.compile(r"Failed to find xref for: IntPtr"),              # .NET system type
+    re.compile(r"Failed to find xref for: IReadOnlyDictionary"), # .NET system type
+    re.compile(r"Failed to find xref for: IReadOnlyList"),       # .NET system type
+    re.compile(r"Failed to find xref for: >"),                   # Generic type parsing artifact
 ]
 
 class CSharpXrefWarningFilter(py_logging.Filter):


### PR DESCRIPTION
# PR: bindings/csharp: API review and consistency improvements

## PR Description

These commits improve the C# bindings API by making attribute access consistent across all classes and fixing a performance issue with `IOBuffer.scan_elements`. `Device`, `Channel`, and `IOBuffer` now expose attrs as `IReadOnlyDictionary<string, Attr>` instead of `List<Attr>`, matching the pattern already used by `Context` and `Scan`, and restoring the named attribute lookup capability that was available in the v0 bindings.

### Benefits

- Enables O(1) attribute lookup by name via `attrs["attribute_name"]` on `Device`, `Channel`, and `IOBuffer`, previously required a linear search with `attrs.Find()`
- Makes the API consistent across all classes: `Context`, `Scan`, `Device`, `Channel`, and `IOBuffer` all now use dictionary-based attribute access
- `IOBuffer.scan_elements` is now cached at construction time instead of allocating a new list and creating new `Channel` objects on every access
- Fixes an incorrect doc comment in `Context.cs` that referred to "channel" instead of "context"

### Changes

- `Device.attrs` and `Device.debug_attrs`: `List<Attr>` to `IReadOnlyDictionary<string, Attr>`
- `Channel.attrs`: `List<Attr>` to`IReadOnlyDictionary<string, Attr>`
- `IOBuffer.attrs`: `List<Attr>` to `IReadOnlyDictionary<string, Attr>`
- `IOBuffer.scan_elements`: changed from a computed property (new list on each access) to a `readonly` field populated once in the constructor
- `Trigger.set_rate()` / `Trigger.get_rate()`: rewritten to use `attrs["frequency"]` directly instead of iterating the attribute list
- `Context.cs`: fixed doc comment on `attrs`, was "current channel", now "current context"
- Updated all call sites in `Trigger.cs`, `ExampleProgram.cs`, and `IntegrationTests.cs` to use `.Values` where iteration is needed


### Usage

```csharp
// Before (v0-style linear search)
chn.attrs.Find(a => a.name == "sampling_frequency").write(3000000);

// After (direct dictionary access)
chn.attrs["sampling_frequency"].write(3000000);

// Iteration still works via .Values
foreach (Attr attr in dev.attrs.Values)
    Console.WriteLine(attr.name + " = " + attr.read());
```

## PR Type

- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist

- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
