### PR TITLE
zephyr: logging: Zephyr-specific implementation of iio_prm_printf.

### DIFF
--- a/utilities.c
+++ b/utilities.c
@@ -386,6 +386,7 @@ ssize_t __iio_printf iio_snprintf(char *buf, size_t len, const char *fmt, ...)
 	return (ssize_t)ret;
 }
 
+#ifndef __ZEPHYR__
 void iio_prm_printf(const struct iio_context_params *params, enum iio_log_level msg_level,
 		const char *fmt, ...)
 {
@@ -417,6 +418,7 @@ void iio_prm_printf(const struct iio_context_params *params, enum iio_log_level 
 
 	va_end(ap);
 }
+#endif /* !__ZEPHYR__ */
 
 uint64_t iio_read_counter_us(void)
 {

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -27,6 +27,7 @@ if(CONFIG_LIBIIO)
     ${ZEPHYR_LIBIIO_MODULE_DIR}/iiod-responder.c
     ${ZEPHYR_LIBIIO_MODULE_DIR}/iiod/rw.c
     ${ZEPHYR_LIBIIO_MODULE_DIR}/zephyr/backend.c
+    ${ZEPHYR_LIBIIO_MODULE_DIR}/zephyr/libiio_log.c
   )
 
   zephyr_include_directories(

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -36,6 +36,9 @@ if(CONFIG_LIBIIO)
     ${ZEPHYR_LIBIIO_MODULE_DIR}
   )
 
+  # zephyr log levels (0-4) are offset by 1 from libiio levels (1-5)
+  math(EXPR default_log_level "${CONFIG_LIBIIO_LOG_LEVEL} + 1")
+
   zephyr_library_compile_definitions(
     LIBIIO_STATIC=1
     NO_THREADS=1
@@ -56,7 +59,7 @@ if(CONFIG_LIBIIO)
     WITH_EMU_BACKEND_DYNAMIC=0
     HAVE_DNS_SD=0
     WITH_MODULES=0
-    DEFAULT_LOG_LEVEL=4
+    DEFAULT_LOG_LEVEL=${default_log_level}
     LIBIIO_VERSION_MAJOR=1
     LIBIIO_VERSION_MINOR=0
     LIBIIO_VERSION_GIT=\"v1.0\"

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -13,6 +13,15 @@ module = LIBIIO
 module-str = libiio
 source "subsys/logging/Kconfig.template.log_config"
 
+config LIBIIO_LOG_MSG_SIZE
+	int "Maximum length of a single libiio log message (bytes)"
+	default 128
+	help
+	  Each call to zephyr iio_prm_printf() formats the message into a stack-
+	  allocated buffer of this size before handing it to the Zephyr
+	  logging subsystem. Increase this value if libiio log messages are
+	  being truncated.
+
 rsource "drivers/Kconfig"
 rsource "iiod/Kconfig"
 

--- a/zephyr/iiod/network.c
+++ b/zephyr/iiod/network.c
@@ -16,7 +16,7 @@
 #include <zephyr/net/conn_mgr_monitor.h>
 #endif
 
-LOG_MODULE_REGISTER(libiio, CONFIG_LIBIIO_LOG_LEVEL);
+LOG_MODULE_REGISTER(iiod_network, CONFIG_LIBIIO_LOG_LEVEL);
 
 #define MAX_CONNECTIONS	5
 

--- a/zephyr/libiio_log.c
+++ b/zephyr/libiio_log.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zephyr/logging/log.h>
+#include <iio/iio-debug.h>
+
+#include <stdarg.h>
+#include <stdio.h>
+
+LOG_MODULE_REGISTER(libiio, CONFIG_LIBIIO_LOG_LEVEL);
+
+void iio_prm_printf(const struct iio_context_params *params,
+		    enum iio_log_level msg_level,
+		    const char *fmt, ...)
+{
+	char buf[CONFIG_LIBIIO_LOG_MSG_SIZE];
+	va_list ap;
+	int len;
+
+	/*
+	 * Filters everything above the configured level.
+	 * When params is NULL we fall through to the Zephyr log level, which
+	 * is already enforced at compile-time by LOG_MODULE_REGISTER above.
+	 */
+	if (params && msg_level > params->log_level)
+		return;
+
+	va_start(ap, fmt);
+	len = vsnprintf(buf, sizeof(buf), fmt, ap);
+	va_end(ap);
+
+	/*
+	 * libiio format strings typically end with '\n'.  Zephyr's logging
+	 * back-end appends its own newline, so strip the trailing one to
+	 * avoid a blank line after every message.
+	 */
+	if (len > 0 && len < (int)sizeof(buf) && buf[len - 1] == '\n')
+		buf[len - 1] = '\0';
+
+	switch (msg_level) {
+	case LEVEL_ERROR:
+		LOG_ERR("%s", buf);
+		break;
+	case LEVEL_WARNING:
+		LOG_WRN("%s", buf);
+		break;
+	case LEVEL_INFO:
+		LOG_INF("%s", buf);
+		break;
+	case LEVEL_DEBUG:
+	default:
+		LOG_DBG("%s", buf);
+		break;
+	}
+}

--- a/zephyr/libiio_log.c
+++ b/zephyr/libiio_log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Analog Devices, Inc.
+ * Copyright (c) 2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: MIT
  */
@@ -16,6 +16,7 @@ void iio_prm_printf(const struct iio_context_params *params,
 		    enum iio_log_level msg_level,
 		    const char *fmt, ...)
 {
+#ifdef CONFIG_LOG
 	char buf[CONFIG_LIBIIO_LOG_MSG_SIZE];
 	va_list ap;
 	int len;
@@ -26,6 +27,17 @@ void iio_prm_printf(const struct iio_context_params *params,
 	 * is already enforced at compile-time by LOG_MODULE_REGISTER above.
 	 */
 	if (params && msg_level > params->log_level)
+		return;
+
+	/*
+	 * Gate the vsnprintf on the compile-time Zephyr log level for this
+	 * module. libiio levels (LEVEL_ERROR=2 .. LEVEL_DEBUG=5) are offset
+	 * by 1 relative to Zephyr's (LOG_LEVEL_ERR=1 .. LOG_LEVEL_DBG=4), so
+	 * the equivalent Zephyr level is (msg_level - 1).  If that exceeds
+	 * CONFIG_LIBIIO_LOG_LEVEL the message will be filtered by LOG_* anyway,
+	 * so skip the formatting work entirely.
+	 */
+	if ((int)msg_level - 1 > CONFIG_LIBIIO_LOG_LEVEL)
 		return;
 
 	va_start(ap, fmt);
@@ -55,4 +67,9 @@ void iio_prm_printf(const struct iio_context_params *params,
 		LOG_DBG("%s", buf);
 		break;
 	}
+#else
+	ARG_UNUSED(params);
+	ARG_UNUSED(msg_level);
+	ARG_UNUSED(fmt);
+#endif /* CONFIG_LOG */
 }


### PR DESCRIPTION
## PR Description

Libiio core components route all log output through the single function iio_prm_printf() (see utilities.c). On Zephyr the stdio-based version is excluded via #ifndef ZEPHYR and this file (libiio_log.c) provides the replacement, forwarding every message to the Zephyr logging subsystem so that libiio messages participate in the same runtime log filtering and back-end as the rest of the application.

The log level used for the module is CONFIG_LIBIIO_LOG_LEVEL, which is generated by the "Kconfig.template.log_config" template already present in zephyr/Kconfig and follows the standard Zephyr convention: 0 = none, 1 = error, 2 = warning, 3 = info, 4 = debug.

To test:
Add in prj.conf:
CONFIG_LOG=y
CONFIG_LIBIIO_LOG_LEVEL_DBG=y (can be also INF, etc)
OR with compile flags:
-DCONFIG_LOG=y -DCONFIG_LIBIIO_LOG_LEVEL_DBG=y (can be also INF, etc)

Signed-off-by: Dimitrije Lilic [dimitrije.lilic@orioninc.com](mailto:dimitrije.lilic@orioninc.com)Libiio core components route all log output through the single function iio_prm_printf() (see utilities.c). On Zephyr the stdio-based version is excluded via #ifndef ZEPHYR and this file (libiio_log.c) provides the replacement, forwarding every message to the Zephyr logging subsystem so that libiio messages participate in the same runtime log filtering and back-end as the rest of the application.

The log level used for the module is CONFIG_LIBIIO_LOG_LEVEL, which is generated by the "Kconfig.template.log_config" template already present in zephyr/Kconfig and follows the standard Zephyr convention: 0 = none, 1 = error, 2 = warning, 3 = info, 4 = debug.

To test:
Add in prj.conf:
CONFIG_LOG=y
CONFIG_LIBIIO_LOG_LEVEL_DBG=y (can be also INF, etc)
OR with compile flags:
-DCONFIG_LOG=y -DCONFIG_LIBIIO_LOG_LEVEL_DBG=y (can be also INF, etc)

Signed-off-by: Dimitrije Lilic <dimitrije.lilic@orioninc.com>

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
