### PR TITLE
ci: zephyr: Upgrade to action-zephyr-setup v1.0.14

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -28,7 +28,7 @@ jobs:
           python-version: 3.12
 
       - name: Setup Zephyr project
-        uses: zephyrproject-rtos/action-zephyr-setup@360ff9b36e58499d9eb28015cdcde7ca03a5b04d # v1.0.12
+        uses: zephyrproject-rtos/action-zephyr-setup@5ec39f5cba83346d83a836dfed1524270c660e28 # v1.0.14
         with:
           app-path: libiio
           toolchains: arm-zephyr-eabi


### PR DESCRIPTION
Upgrades to the latest version of
zephyrproject-rtos/action-zephyr-setup, which picks up a newer version of actions/cache. This should resolve the warning:

"Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected:
actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830."

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
