### PR TITLE
context: sort scan elements by hardware index on init

### DIFF
--- a/context.c
+++ b/context.c
@@ -598,10 +598,14 @@ static void reorder_channels(struct iio_device *dev)
 
 int iio_context_init(struct iio_context *ctx)
 {
-	unsigned int i;
+	unsigned int i, j;
 
-	for (i = 0; i < ctx->nb_devices; i++)
+	for (i = 0; i < ctx->nb_devices; i++) {
 		reorder_channels(ctx->devices[i]);
+
+		for (j = 0; j < ctx->devices[i]->nb_buffers; j++)
+			iio_sort_scan_elements(ctx->devices[i]->buffers[j]);
+	}
 
 	return 0;
 }

--- a/sort.c
+++ b/sort.c
@@ -61,6 +61,24 @@ static int iio_attr_compare(const void *p1, const void *p2)
 	return strcmp(attr1->name, attr2->name);
 }
 
+static int iio_scan_elements_compare(const void *p1, const void *p2)
+{
+	const struct iio_scan_element *se1 = *(struct iio_scan_element **)p1;
+	const struct iio_scan_element *se2 = *(struct iio_scan_element **)p2;
+	long idx1 = iio_channel_get_index(se1->chn);
+	long idx2 = iio_channel_get_index(se2->chn);
+
+	if (idx1 == idx2 && idx1 >= 0) {
+		idx1 = iio_channel_get_data_format(se1->chn)->shift;
+		idx2 = iio_channel_get_data_format(se2->chn)->shift;
+	}
+
+	if (idx2 >= 0 && (idx1 > idx2 || idx1 < 0))
+		return 1;
+
+	return -1;
+}
+
 void iio_sort_attrs(struct iio_attr_list *attrs)
 {
 	if (attrs && attrs->num > 1) {
@@ -80,4 +98,10 @@ void iio_sort_channels(struct iio_device *dev)
 	if (dev->channels && dev->nb_channels > 1) {
 		qsort(dev->channels, dev->nb_channels, sizeof(*dev->channels), iio_channel_compare);
 	}
+}
+
+void iio_sort_scan_elements(struct iio_buffer *buf)
+{
+	if (buf->scans && buf->nb_scans > 1)
+		qsort(buf->scans, buf->nb_scans, sizeof(*buf->scans), iio_scan_elements_compare);
 }

--- a/sort.h
+++ b/sort.h
@@ -10,11 +10,13 @@
 #define __IIO_QSORT_H__
 
 struct iio_attr_list;
+struct iio_buffer;
 struct iio_context;
 struct iio_device;
 
 void iio_sort_attrs(struct iio_attr_list *attrs);
 void iio_sort_devices(struct iio_context *ctx);
 void iio_sort_channels(struct iio_device *dev);
+void iio_sort_scan_elements(struct iio_buffer *buf);
 
 #endif /* __IIO_QSORT_H__ */


### PR DESCRIPTION
## PR Description

This PR fixes the ordering of scan elements within each buffer's `scans[]` array. Scan elements are now sorted by hardware index on context initialization, consistent with how `iio_context_init()` already sorts channels via `reorder_channels()`.

### Benefits
- Scan elements are returned in chan->index order, consistent with the existing channel ordering

### Changes
- Add `iio_scan_elements_compare()` in `sort.c`, sorts by `chn->index`, with `shift` as tiebreaker for channels packed into the same data word (same as channel compare)
- Add `iio_sort_scan_elements(struct iio_buffer *buf)` in `sort.c`
- Declare `iio_sort_scan_elements()` and `struct iio_buffer` in `sort.h`
- Call `iio_sort_scan_elements()` for each buffer of each device in `iio_context_init()` in `context.c`, alongside the existing `reorder_channels()` call

### How it works

1. During local context creation, `foreach_in_dir()` iterates the `scan_elements/` directory and appends channels to `buf->scans[]` via `iio_buffer_add_scan_element()` in `readdir()` order , not hardware index order.
2. By the time `iio_context_init()` runs at the end of context creation, all `chn->index` fields are fully populated from the `_index` sysfs files.
3. `iio_context_init()` calls `iio_sort_scan_elements()` for each buffer of each device, which `qsort`s `buf->scans[]` using `iio_scan_elements_compare()`.

### Example
Before:
```c
			buffer0: (input)
			4 scan elements found:
				Scan element 0: voltage1 (input)
				Scan element 1: voltage3 (input)
				Scan element 2: voltage0 (input)
				Scan element 3: voltage2 (input)
```
After:
```c
			buffer0: (input)
			4 scan elements found:
 				Scan element 0: voltage0 (input)
 				Scan element 1: voltage1 (input)
 				Scan element 2: voltage2 (input)
 				Scan element 3: voltage3 (input)
```

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
