### PR TITLE
ci/zephyr: run libiio regression tests against native_sim IIOD backend

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -61,3 +61,67 @@ jobs:
             EXTRA_TWISTER_FLAGS="--short-build-path -O/tmp/twister-out"
           fi
           west twister -T samples -v --force-color --inline-logs --integration $EXTRA_TWISTER_FLAGS
+
+  regression-tests:
+    name: Regression tests against Zephyr IIOD backend
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: libiio
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: 3.12
+
+      - name: Setup Zephyr project
+        uses: zephyrproject-rtos/action-zephyr-setup@5ec39f5cba83346d83a836dfed1524270c660e28 # v1.0.14
+        with:
+          app-path: libiio
+          toolchains: arm-zephyr-eabi
+          ccache-cache-key: regression-ubuntu-22.04
+
+      - name: Install libiio build dependencies
+        run: sudo apt-get install -y libxml2-dev
+
+      - name: Build libiio C library and test suite
+        working-directory: libiio
+        run: |
+          mkdir build && cd build
+          cmake -DWITH_NETWORK_BACKEND=ON -DWITH_ZSTD=ON ../
+          make -j$(nproc)
+          sudo make install
+          sudo ldconfig
+
+      - name: Build native_sim IIOD sample
+        working-directory: libiio/zephyr
+        run: |
+          west build -p -b native_sim samples/iiod/ -S iiod-network \
+            -d build-iiod-regression \
+            -- -DCONFIG_LIBIIO_IIOD_ADC_EMUL=y -DCONFIG_LIBIIO_IIOD_SENSOR_EMUL=y
+
+      - name: Start IIOD server (native_sim)
+        working-directory: libiio/zephyr
+        run: |
+          ./build-iiod-regression/zephyr/zephyr.exe &
+          echo $! > /tmp/zephyr_pid
+          # Wait until the server is accepting connections
+          for i in $(seq 1 30); do
+            if nc -z 127.0.0.1 30431 2>/dev/null; then
+              echo "IIOD server is up"
+              break
+            fi
+            sleep 0.5
+          done
+
+      - name: Run regression tests against Zephyr IIOD backend
+        working-directory: libiio/build
+        run: |
+          TESTS_API_URI=ip:127.0.0.1 ctest -L api --output-on-failure -j1
+
+      - name: Stop IIOD server
+        if: always()
+        run: kill $(cat /tmp/zephyr_pid) 2>/dev/null || true

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -91,7 +91,7 @@ jobs:
         working-directory: libiio
         run: |
           mkdir build && cd build
-          cmake -DWITH_TESTS=OFF -DWITH_USB_BACKEND=OFF -DHAVE_DNS_SD=OFF -DWITH_AIO=OFF ..
+          cmake -DWITH_TESTS=ON -DWITH_USB_BACKEND=OFF -DHAVE_DNS_SD=OFF -DWITH_AIO=OFF ..
           make -j$(nproc)
           sudo make install
           sudo ldconfig

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -91,7 +91,7 @@ jobs:
         working-directory: libiio
         run: |
           mkdir build && cd build
-          cmake -DWITH_NETWORK_BACKEND=ON -DWITH_ZSTD=ON ../
+          cmake -DWITH_TESTS=OFF -DWITH_USB_BACKEND=OFF -DHAVE_DNS_SD=OFF -DWITH_AIO=OFF ..
           make -j$(nproc)
           sudo make install
           sudo ldconfig

--- a/tests/api/test_context.c
+++ b/tests/api/test_context.c
@@ -343,9 +343,19 @@ TEST_FUNCTION(context_timeout_measurement)
 	DEBUG_PRINT("  INFO: 1000ms timeout: error=%d, elapsed=%ld ms\n", err, elapsed_ms);
 	TEST_ASSERT(iio_err(ctx), "Connection to unreachable host should fail");
 
-	/* Allow ±500ms tolerance (some overhead for DNS, connection setup, etc.) */
-	TEST_ASSERT_DURATION_RANGE(elapsed_ms, 500, 2000,
-			"1000ms timeout should complete within expected range");
+	/*
+	 * Only check duration when the error is ETIMEDOUT. If the host returns
+	 * EHOSTUNREACH (e.g. due to routing), the timeout parameter isn't the
+	 * limiting factor and the duration check is not meaningful.
+	 */
+	if (err == -ETIMEDOUT) {
+		/* Allow ±500ms tolerance (some overhead for DNS, connection setup, etc.) */
+		TEST_ASSERT_DURATION_RANGE(elapsed_ms, 500, 2000,
+				"1000ms timeout should complete within expected range");
+	} else {
+		DEBUG_PRINT("  SKIP: Duration check skipped for 1000ms test (error %d, not a timeout)\n",
+				err);
+	}
 
 	/* Test 2: 4000ms timeout */
 	DEBUG_PRINT("  INFO: Testing 4000ms timeout...\n");
@@ -361,9 +371,18 @@ TEST_FUNCTION(context_timeout_measurement)
 	DEBUG_PRINT("  INFO: 4000ms timeout: error=%d, elapsed=%ld ms\n", err, elapsed_ms);
 	TEST_ASSERT(iio_err(ctx), "Connection to unreachable host should fail");
 
-	/* Allow ±1000ms tolerance */
-	TEST_ASSERT_DURATION_RANGE(elapsed_ms, 3000, 5500,
-			"4000ms timeout should complete within expected range");
+	/*
+	 * Only check duration when the error is ETIMEDOUT. EHOSTUNREACH or other
+	 * routing errors can occur before the timeout and are still valid failures.
+	 */
+	if (err == -ETIMEDOUT) {
+		/* Allow ±1000ms tolerance */
+		TEST_ASSERT_DURATION_RANGE(elapsed_ms, 3000, 5500,
+				"4000ms timeout should complete within expected range");
+	} else {
+		DEBUG_PRINT("  SKIP: Duration check skipped for 4000ms test (error %d, not a timeout)\n",
+				err);
+	}
 
 	/* Test 3: Non-blocking mode */
 	DEBUG_PRINT("  INFO: Testing non-blocking mode...\n");

--- a/zephyr/samples/iiod/adc-emul.overlay
+++ b/zephyr/samples/iiod/adc-emul.overlay
@@ -13,7 +13,7 @@
 			compatible = "iio,io-channels";
 			reg = <1>;
 			io-channels = <&adc_emul 0>, <&adc_emul 1>;
-			io-channel-names = "adc_emul_in_ch0", "adc_emul_in_ch1";
+			io-channel-names = "voltage0", "voltage1";
 			io-name = "adc-emul";
 		};
 	};

--- a/zephyr/samples/iiod/pytest/conftest.py
+++ b/zephyr/samples/iiod/pytest/conftest.py
@@ -29,11 +29,20 @@ def iiod_context(dut: DeviceAdapter, request):
 
 
 def _network_context(dut: DeviceAdapter):
-    # Wait until the server has built the IIO context XML and is about to enter
-    # the accept() loop.  This fires before any client has connected, so it is
-    # a reliable "server is ready" signal that works for both the first and any
-    # subsequent test session restarts.
-    dut.readlines_until(regex=r'.*XML ready.*')
+    # Poll port 30431 directly until the IIOD server is accepting connections.
+    # Waiting for a specific DUT log line is unreliable: the startup messages
+    # are emitted in ~20 ms and the server then blocks in accept(), so if pytest
+    # starts scanning after that point it will never see them.
+    deadline = time.monotonic() + 30.0
+    while time.monotonic() < deadline:
+        try:
+            s = socket.create_connection(('127.0.0.1', 30431), timeout=1.0)
+            s.close()
+            break
+        except OSError:
+            time.sleep(0.1)
+    else:
+        raise TimeoutError('IIOD network server did not start within 30 seconds')
     ctx = iio.Context('ip:127.0.0.1')
     yield ctx
     del ctx  # close TCP connection before DUT teardown

--- a/zephyr/samples/iiod/pytest/conftest.py
+++ b/zephyr/samples/iiod/pytest/conftest.py
@@ -19,7 +19,7 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='function')
 def iiod_context(dut: DeviceAdapter, request):
     transport = request.config.getoption('--iiod-transport')
     if transport == 'uart':

--- a/zephyr/samples/iiod/pytest/conftest.py
+++ b/zephyr/samples/iiod/pytest/conftest.py
@@ -19,7 +19,7 @@ def pytest_addoption(parser):
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='session')
 def iiod_context(dut: DeviceAdapter, request):
     transport = request.config.getoption('--iiod-transport')
     if transport == 'uart':
@@ -29,7 +29,11 @@ def iiod_context(dut: DeviceAdapter, request):
 
 
 def _network_context(dut: DeviceAdapter):
-    dut.readlines_until(regex=r'.*Calling accept.*')
+    # Wait until the server has built the IIO context XML and is about to enter
+    # the accept() loop.  This fires before any client has connected, so it is
+    # a reliable "server is ready" signal that works for both the first and any
+    # subsequent test session restarts.
+    dut.readlines_until(regex=r'.*XML ready.*')
     ctx = iio.Context('ip:127.0.0.1')
     yield ctx
     del ctx  # close TCP connection before DUT teardown

--- a/zephyr/samples/iiod/sample.yaml
+++ b/zephyr/samples/iiod/sample.yaml
@@ -28,6 +28,7 @@ tests:
     integration_platforms:
       - native_sim
     harness: pytest
+    timeout: 120
     harness_config:
       pytest_dut_scope: session
       pytest_args:


### PR DESCRIPTION
## PR Description
zephyr: iiod: fix ADC channel naming and pytest fixture scope

- adc-emul.overlay: rename io-channel-names from 'adc_emul_in_ch0/1'
  to 'voltage0/1' so libiio derives the correct IIO_CHAN_TYPE_VOLTAGE
  channel type from the name prefix
- pytest/conftest.py: change iiod_context fixture from session to
  function scope to match the twister_harness dut fixture scope,
  fixing a ScopeMismatch error

tests: api: skip duration check when connection fails before timeout

context_timeout_measurement connects to 192.0.2.1 (RFC 5737 TEST-NET)
to verify that iio_create_context respects timeout_ms. On some hosts
(e.g. CI) the kernel returns EHOSTUNREACH immediately via routing
instead of timing out, so the elapsed time is unrelated to the
configured timeout.

Only assert the duration range when err == -ETIMEDOUT. For any other
error (EHOSTUNREACH, ENETUNREACH, etc.) skip the timing assertion
while still verifying that the connection correctly fails.

ci: zephyr: add regression tests job against native_sim IIOD backend

Add a new 'regression-tests' CI job that:
- builds the libiio C library and test suite (WITH_TESTS=ON)
- builds the iiod sample for native_sim with the iiod-network snippet
  and ADC/sensor emulators enabled
- starts the native_sim zephyr.exe and waits for port 30431
- runs 'ctest -L api' with TESTS_API_URI=ip:127.0.0.1 against the
  live Zephyr IIOD backend

This exercises the binary IIOD protocol implementation end-to-end
on every push and pull request.

Signed-off-by: Dimitrije Lilic <dimitrije.lilic@orioninc.com>
- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
