### PR TITLE
ci: fix tags.json generation script and reduce deployment noise

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -118,11 +118,26 @@ jobs:
             echo "$remote_v0_tags" | grep -qxF "$dir" && echo "$dir"
           done | sort -Vr)
 
-          { echo "$sphinx_paths" | grep -v '^main$'; echo "$v0_entries" | grep .; echo "main"; } | \
-            jq -R . | jq -s . > tags-update/tags.json
+          { [ -n "$sphinx_paths" ] && echo "$sphinx_paths"; \
+            [ -n "$v0_entries" ] && echo "$v0_entries"; } | \
+            jq -R . | jq -s '. - ["main"] + ["main"]' > tags-update/tags.json
+
+          # Check if tags.json actually changed
+          if [ -f gh-pages-content/tags.json ]; then
+            if diff -q gh-pages-content/tags.json tags-update/tags.json >/dev/null 2>&1; then
+              echo "tags.json unchanged, skipping deployment"
+              echo "TAGS_CHANGED=false" >> $GITHUB_ENV
+            else
+              echo "tags.json changed, will deploy"
+              echo "TAGS_CHANGED=true" >> $GITHUB_ENV
+            fi
+          else
+            echo "tags.json doesn't exist, will deploy"
+            echo "TAGS_CHANGED=true" >> $GITHUB_ENV
+          fi
 
       - name: Deploy tags.json to gh-pages
-        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.event_name == 'push'
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.event_name == 'push' && env.TAGS_CHANGED == 'true'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## PR Description

This PR fixes the documentation CI's tags.json generation script that was producing empty version lists and creating unnecessary deployment noise. The fix ensures version dropdowns in GitHub Pages documentation display correctly and reduces gh-pages commit frequency by only deploying when content actually changes.

### Benefits

- Fixes broken version dropdowns that showed no available documentation versions
- Reduces gh-pages repository noise by skipping unnecessary deployments
- Preserves proper version ordering with main branch appearing last in dropdown lists

### Changes

- Replace problematic `grep -v '^main$'` pipeline with conditional echo statements and jq filtering
- Add diff comparison logic to detect when tags.json content has actually changed
- Add `TAGS_CHANGED` environment variable to control deployment step execution
- Modify deployment step condition to include `env.TAGS_CHANGED == 'true'` requirement

### How it works

1. The script generates tags.json by scanning gh-pages for Sphinx documentation directories and validating v0.x directories against remote git tags
2. Instead of using `grep` commands that can fail with exit code 1, the script uses conditional echo statements and lets jq handle the filtering logic with `. - ["main"] + ["main"]`
3. Before deployment, the script compares the newly generated tags.json against the existing version using `diff -q`
4. If files are identical, `TAGS_CHANGED=false` is set, causing the deployment step to be skipped
5. If files differ or no existing tags.json exists, `TAGS_CHANGED=true` enables deployment


## PR Type

- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist

- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)