### PR TITLE
 add iio_context_ping() API and iio_ping utility

### DIFF
--- a/bindings/cpp/iio.hpp
+++ b/bindings/cpp/iio.hpp
@@ -683,6 +683,7 @@ public:
     optional<Device> device(unsigned int idx) const { return impl::maybe<Device>(iio_context_get_device(p, idx)); }
     optional<Device> find_device(cstr name) const {return impl::maybe<Device>(iio_context_find_device(p, name));}
     void set_timeout(int timeout_ms){impl::check(iio_context_set_timeout(p, timeout_ms), "iio_context_set_timeout");}
+    void ping(){impl::check(iio_context_ping(p), "iio_context_ping");}
     iio_context_params const * params() const {return iio_context_get_params(p);}
     void set_data(void * data){iio_context_set_data(p, data);}
     void * data() const {return iio_context_get_data(p);}

--- a/bindings/csharp/Context.cs
+++ b/bindings/csharp/Context.cs
@@ -85,6 +85,9 @@ namespace iio
         private static extern int iio_context_set_timeout(IntPtr ctx, int timeout_ms);
 
         [DllImport(IioLib.dllname, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int iio_context_ping(IntPtr ctx);
+
+        [DllImport(IioLib.dllname, CallingConvention = CallingConvention.Cdecl)]
         private static extern uint iio_context_get_attrs_count(IntPtr ctx);
 
         [DllImport(IioLib.dllname, CallingConvention = CallingConvention.Cdecl)]
@@ -236,6 +239,15 @@ namespace iio
             int ret = iio_context_set_timeout(hdl, timeout);
             if (ret < 0)
                 throw new IIOException("Unable to set timeout", ret);
+        }
+
+        /// <summary>Ping the IIO context to check if it is still responsive.</summary>
+        /// <exception cref="IioLib.IIOException">The context did not respond.</exception>
+        public void ping()
+        {
+            int ret = iio_context_ping(hdl);
+            if (ret < 0)
+                throw new IIOException("Ping failed", ret);
         }
 
         /// <summary>

--- a/bindings/python/iio/__init__.py
+++ b/bindings/python/iio/__init__.py
@@ -446,6 +446,11 @@ _set_timeout.argtypes = (
 )
 _set_timeout.errcheck = _check_negative
 
+_ping = _lib.iio_context_ping
+_ping.restype = c_int
+_ping.argtypes = (_ContextPtr,)
+_ping.errcheck = _check_negative
+
 _a_get_name = _lib.iio_attr_get_name
 _a_get_name.restype = c_char_p
 _a_get_name.argtypes = (_AttrPtr,)
@@ -1654,6 +1659,10 @@ class Context(_IIO_Object):
             The timeout value, in milliseconds
         """
         _set_timeout(self._context, timeout)
+
+    def ping(self):
+        """Ping the IIO context to check if it is still responsive."""
+        _ping(self._context)
 
     def find_device(self, name_or_id_or_label):
         """

--- a/context.c
+++ b/context.c
@@ -667,6 +667,14 @@ int iio_context_set_timeout(struct iio_context *ctx, int timeout)
 	return 0;
 }
 
+int iio_context_ping(struct iio_context *ctx)
+{
+	if (!ctx->ops->ping)
+		return -ENOTSUP;
+
+	return ctx->ops->ping(ctx);
+}
+
 const struct iio_backend *const iio_backends[] = {
 	IIO_IF_ENABLED(WITH_LOCAL_BACKEND, &iio_local_backend),
 	IIO_IF_ENABLED(WITH_NETWORK_BACKEND && !WITH_NETWORK_BACKEND_DYNAMIC, &iio_ip_backend),

--- a/emu.c
+++ b/emu.c
@@ -1403,6 +1403,11 @@ static int emu_dequeue_block(struct iio_block_pdata *pdata, bool nonblock)
 	return 0;
 }
 
+static int emu_ping(struct iio_context *ctx)
+{
+	return 0;
+}
+
 static const struct iio_backend_ops emu_ops = {
 	.create = emu_create_context,
 	.read_attr = emu_read_attr,
@@ -1421,6 +1426,7 @@ static const struct iio_backend_ops emu_ops = {
 
 	.reg_read = emu_reg_read,
 	.reg_write = emu_reg_write,
+	.ping = emu_ping,
 };
 
 const struct iio_backend iio_emu_backend = {

--- a/iiod-client.c
+++ b/iiod-client.c
@@ -1947,3 +1947,19 @@ int iiod_client_reg_write(struct iiod_client *client, const struct iio_device *d
 
 	return iiod_io_wait_for_command_done(io);
 }
+
+int iiod_client_nop(struct iiod_client *client)
+{
+	struct iiod_command cmd;
+	struct iiod_io *io;
+
+	if (!iiod_client_uses_binary_interface(client))
+		return -ENOTSUP;
+
+	cmd.op = IIOD_OP_NOP;
+	cmd.dev = 0;
+	cmd.code = 0;
+
+	io = iiod_responder_get_default_io(client->responder);
+	return iiod_io_exec_simple_command(io, &cmd);
+}

--- a/iiod-responder.h
+++ b/iiod-responder.h
@@ -62,6 +62,8 @@ enum iiod_opcode {
 	IIOD_OP_REG_READ,
 	IIOD_OP_REG_WRITE,
 
+	IIOD_OP_NOP,
+
 	IIOD_NB_OPCODES,
 };
 

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -106,6 +106,15 @@ static void handle_timeout(struct parser_pdata *pdata, const struct iiod_command
 	iiod_io_send_response_code(io, ret);
 }
 
+static void handle_nop(struct parser_pdata *pdata, const struct iiod_command *cmd,
+		struct iiod_command_data *cmd_data)
+{
+	struct iiod_io *io = iiod_command_get_default_io(cmd_data);
+
+	/* Simply return success - this is a no-op */
+	iiod_io_send_response_code(io, 0);
+}
+
 static struct buffer_entry *get_iio_buffer_entry_unlocked(
 		struct parser_pdata *pdata, const struct iiod_command *cmd)
 {
@@ -1182,6 +1191,8 @@ static const iiod_opcode_fn iiod_op_functions[] = {
 
 	[IIOD_OP_REG_READ] = handle_reg_read,
 	[IIOD_OP_REG_WRITE] = handle_reg_write,
+
+	[IIOD_OP_NOP] = handle_nop,
 };
 
 static int iiod_cmd(const struct iiod_command *cmd, struct iiod_command_data *data, void *d)

--- a/include/iio/iio-backend.h
+++ b/include/iio/iio-backend.h
@@ -137,6 +137,9 @@ struct iio_backend_ops {
 	/* Atomic register operations */
 	int (*reg_read)(const struct iio_device *dev, uint32_t address, uint32_t *value);
 	int (*reg_write)(const struct iio_device *dev, uint32_t address, uint32_t value);
+
+	/* Connection liveness test */
+	int (*ping)(struct iio_context *ctx);
 };
 
 /**

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -795,6 +795,17 @@ __api void iio_context_set_data(struct iio_context *ctx, void *data);
  * @return The pointer previously associated if present, or NULL */
 __api void *iio_context_get_data(const struct iio_context *ctx);
 
+/** @brief Ping the IIO context to check if it is still responsive
+ * @param ctx A pointer to an iio_context structure
+ * @return On success, 0 is returned
+ * @return On error, a negative errno code is returned
+ *
+ * <b>NOTE:</b> This performs a lightweight round-trip operation to verify
+ * the connection is still alive. It does not access hardware or change any
+ * device state. This operation is only meaningful for remote contexts
+ * (network, USB, serial). For local contexts, it always succeeds. */
+__api __check_ret int iio_context_ping(struct iio_context *ctx);
+
 /** @} */ /* ------------------------------------------------------------------*/
 /* ------------------------- Device functions --------------------------------*/
 /** @defgroup Device Device

--- a/include/iio/iiod-client.h
+++ b/include/iio/iiod-client.h
@@ -84,6 +84,8 @@ __api int iiod_client_reg_read(struct iiod_client *client, const struct iio_devi
 __api int iiod_client_reg_write(struct iiod_client *client, const struct iio_device *dev,
 		uint32_t address, uint32_t value);
 
+__api __check_ret int iiod_client_nop(struct iiod_client *client);
+
 #undef __api
 
 #endif /* _IIOD_CLIENT_H */

--- a/local.c
+++ b/local.c
@@ -674,6 +674,11 @@ unlock:
 	return ret;
 }
 
+static int local_ping(struct iio_context *ctx)
+{
+	return 0;
+}
+
 static int local_reg_write(const struct iio_device *dev, uint32_t address, uint32_t value)
 {
 	char buf[1024];
@@ -1915,6 +1920,7 @@ static const struct iio_backend_ops local_ops = {
 	.disable_cpu_access = local_disable_cpu_access,
 	.reg_read = local_reg_read,
 	.reg_write = local_reg_write,
+	.ping = local_ping,
 };
 
 const struct iio_backend iio_local_backend = {

--- a/man/iio_ping.1.in
+++ b/man/iio_ping.1.in
@@ -1,0 +1,69 @@
+.\" Copyright (c) 2026 Analog Devices Inc.
+.\"
+.\" %%%LICENSE_START(GPLv2+_DOC_FULL)
+.\" This is free documentation; you can redistribute it and/or
+.\" modify it under the terms of the GNU General Public License as
+.\" published by the Free Software Foundation; either version 2 of
+.\" the License, or (at your option) any later version.
+.\"
+.\" The GNU General Public License's references to "object code"
+.\" and "executables" are to be interpreted as the output of any
+.\" document formatting or typesetting system, including
+.\" intermediate and printed output.
+.\"
+.\" This manual is distributed in the hope that it will be useful,
+.\" but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.\" GNU General Public License for more details.
+.\"
+.\" You should have received a copy of the GNU General Public
+.\" License along with this manual; if not, see
+.\" <http://www.gnu.org/licenses/>.
+.\" %%%LICENSE_END
+.\"
+.TH iio_ping 1 "@CMAKE_DATE@" "libiio-@LIBIIO_VERSION_MAJOR@.@LIBIIO_VERSION_MINOR@" "LibIIO Utilities"
+.IX iio_ping
+.SH NAME
+iio_ping \- Test the responsiveness of a remote IIO context
+.SH SYNOPSIS
+.B iio_ping
+[
+.I options
+]
+
+.SH DESCRIPTION
+.B iio_ping
+sends a no-operation command to a remote IIO context and measures
+the round-trip time. It can be used to verify that a connection to
+a remote IIO daemon (iiod) is alive and responsive, without accessing
+any hardware or changing any device state.
+.PP
+This is only meaningful for remote contexts (network, USB, serial).
+For local contexts, the command always succeeds immediately.
+
+.SH OPTIONS
+##COMMON_COMMANDS_START##
+##COMMON_COMMANDS_STOP##
+##COMMON_OPTION_START##
+##COMMON_OPTION_STOP##
+.TP
+.B \-c, \-\-count <count>
+Number of ping requests to send (default: 4).
+.TP
+.B \-i, \-\-interval <interval_ms>
+Interval between ping requests in milliseconds (default: 1000).
+
+.SH RETURN VALUE
+Returns 0 if all pings succeeded, or a non-zero exit code if any
+ping failed.
+
+.SH ERRORS
+.TP
+.B EPIPE
+The connection was broken (e.g. USB unplugged, network down).
+.TP
+.B ETIMEDOUT
+The server did not respond within the configured timeout.
+.TP
+.B ENOTSUP
+The backend or protocol does not support the ping operation (e.g. ASCII IIOD).

--- a/network.c
+++ b/network.c
@@ -520,6 +520,13 @@ static int network_reg_write(const struct iio_device *dev, uint32_t address, uin
 	return iiod_client_reg_write(client, dev, address, value);
 }
 
+static int network_ping(struct iio_context *ctx)
+{
+	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
+
+	return iiod_client_nop(pdata->iiod_client);
+}
+
 static const struct iio_backend_ops network_ops = {
 	.scan = IIO_IF_ENABLED(HAVE_DNS_SD, dnssd_context_scan),
 	.create = network_create_context,
@@ -549,6 +556,8 @@ static const struct iio_backend_ops network_ops = {
 
 	.reg_read = network_reg_read,
 	.reg_write = network_reg_write,
+
+	.ping = network_ping,
 };
 
 __api_export_if(WITH_NETWORK_BACKEND_DYNAMIC) const struct iio_backend iio_ip_backend = {

--- a/serial.c
+++ b/serial.c
@@ -306,6 +306,13 @@ static int serial_reg_write(const struct iio_device *dev, uint32_t address, uint
 	return iiod_client_reg_write(client, dev, address, value);
 }
 
+static int serial_ping(struct iio_context *ctx)
+{
+	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
+
+	return iiod_client_nop(pdata->iiod_client);
+}
+
 static const struct iio_backend_ops serial_ops = {
 	.create = serial_create_context_from_args,
 	.read_attr = serial_read_attr,
@@ -332,6 +339,8 @@ static const struct iio_backend_ops serial_ops = {
 
 	.reg_read = serial_reg_read,
 	.reg_write = serial_reg_write,
+
+	.ping = serial_ping,
 };
 
 __api_export_if(WITH_SERIAL_BACKEND_DYNAMIC) const struct iio_backend iio_serial_backend = {

--- a/usb.c
+++ b/usb.c
@@ -288,6 +288,13 @@ static int usb_reg_write(const struct iio_device *dev, uint32_t address, uint32_
 	return iiod_client_reg_write(client, dev, address, value);
 }
 
+static int usb_ping(struct iio_context *ctx)
+{
+	struct iio_context_pdata *pdata = iio_context_get_pdata(ctx);
+
+	return iiod_client_nop(pdata->io_ctx.iiod_client);
+}
+
 static const struct iio_device *usb_get_trigger(const struct iio_device *dev)
 {
 	const struct iio_context *ctx = iio_device_get_context(dev);
@@ -541,6 +548,8 @@ static const struct iio_backend_ops usb_ops = {
 
 	.reg_read = usb_reg_read,
 	.reg_write = usb_reg_write,
+
+	.ping = usb_ping,
 };
 
 __api_export_if(WITH_USB_BACKEND_DYNAMIC) const struct iio_backend iio_usb_backend = {

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 
-set(IIO_UTILS_TARGETS iio_genxml iio_info iio_attr iio_rwdev iio_reg iio_event)
+set(IIO_UTILS_TARGETS iio_genxml iio_info iio_attr iio_rwdev iio_reg iio_event iio_ping)
 if (PTHREAD_LIBRARIES OR ANDROID)
     list(APPEND IIO_UTILS_TARGETS iio_stresstest)
 endif ()

--- a/utils/iio_ping.c
+++ b/utils/iio_ping.c
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * iio_ping - Part of the industrial I/O (IIO) utilities
+ *
+ * Copyright (C) 2026 Analog Devices, Inc.
+ * Author: Marius Lucacel <marius.lucacel@analog.com>
+ */
+
+#include <errno.h>
+#include <getopt.h>
+#include <iio/iio.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#define msleep(ms) Sleep(ms)
+#else
+#include <time.h>
+static void msleep(unsigned int ms)
+{
+	struct timespec ts = { .tv_sec = ms / 1000,
+			       .tv_nsec = (ms % 1000) * 1000000L };
+	nanosleep(&ts, NULL);
+}
+#endif
+
+#include "iio_common.h"
+
+#define MY_NAME "iio_ping"
+#define MY_OPTS "c:i:"
+
+static const struct option options[] = {
+	{ "count", required_argument, NULL, 'c' },
+	{ "interval", required_argument, NULL, 'i' },
+	{ 0, 0, 0, 0 },
+};
+
+static const char *options_descriptions[] = {
+	"\t\t[-c <count>] [-i <interval_ms>]",
+	"Number of pings to send (default: 4).",
+	"Interval between pings in milliseconds (default: 1000).",
+};
+
+int main(int argc, char **argv)
+{
+	char **argw;
+	struct iio_context *ctx;
+	struct option *opts;
+	unsigned int i, count = 4, interval_ms = 1000;
+	unsigned int sent = 0, received = 0;
+	uint64_t start_us, elapsed_us;
+	const char *name;
+	int c, ret = EXIT_FAILURE;
+
+	argw = dup_argv(MY_NAME, argc, argv);
+
+	ctx = handle_common_opts(MY_NAME, argc, argw, MY_OPTS,
+				 options, options_descriptions, NULL, &ret);
+	opts = add_common_options(options);
+	if (!opts) {
+		fprintf(stderr, "Failed to add common options\n");
+		return EXIT_FAILURE;
+	}
+
+	while ((c = getopt_long(argc, argw, "+" COMMON_OPTIONS MY_OPTS, /* Flawfinder: ignore */
+				opts, NULL)) != -1) {
+		switch (c) {
+		case 'h':
+		case 'V':
+		case 'u':
+		case 'T':
+			break;
+		case 'S':
+		case 'a':
+			if (!optarg && argc > optind && argw[optind] != NULL &&
+					argw[optind][0] != '-')
+				optind++;
+			break;
+		case 'c':
+			count = sanitize_clamp("count", optarg, 1, UINT32_MAX);
+			break;
+		case 'i':
+			interval_ms = sanitize_clamp("interval", optarg, 1, UINT32_MAX);
+			break;
+		case '?':
+			printf("Unknown argument '%c'\n", c);
+			return EXIT_FAILURE;
+		}
+	}
+	free(opts);
+
+	if (optind != argc) {
+		fprintf(stderr, "Incorrect number of arguments.\n\n");
+		usage(MY_NAME, options, options_descriptions);
+		return EXIT_FAILURE;
+	}
+
+	if (!ctx)
+		return ret;
+
+	name = iio_context_get_name(ctx);
+	printf("PING %s backend (%s)\n", name, iio_context_get_description(ctx));
+
+	for (i = 0; i < count; i++) {
+		start_us = get_time_us();
+		ret = iio_context_ping(ctx);
+		elapsed_us = get_time_us() - start_us;
+
+		sent++;
+
+		if (ret == 0) {
+			printf("Reply from %s: seq=%u time=%llu.%03llu ms\n",
+			       name, i,
+			       (unsigned long long)(elapsed_us / 1000),
+			       (unsigned long long)(elapsed_us % 1000));
+			received++;
+		} else {
+			char err_str[256];
+
+			iio_strerror(-ret, err_str, sizeof(err_str));
+			printf("No reply from %s: seq=%u error=%d (%s)\n",
+			       name, i, ret, err_str);
+		}
+
+		if (i < count - 1)
+			msleep(interval_ms);
+	}
+
+	printf("\n--- %s ping statistics ---\n", name);
+	printf("%u requests sent, %u received, %.1f%% loss\n",
+	       sent, received,
+	       sent ? ((sent - received) * 100.0) / sent : 0.0);
+
+	iio_context_destroy(ctx);
+	free_argw(argc, argw);
+	return received == sent ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## PR Description

This PR adds `IIOD_OP_NOP` (opcode 27), a new no-operation command to the IIOD binary protocol, along with a public `iio_context_ping()` API and an `iio_ping` command-line utility. It gives applications a way to verify that a remote IIO context (network, USB, serial) is still alive and responsive , without touching any hardware or changing device state.

### Benefits
- Enables connection checks without reading attributes or changing state
- Works across all remote backends (network, USB, serial) through a single API call
- Includes `iio_ping` utility for  connection testing

### Changes
  - Add IIOD_OP_NOP (opcode 27) to iiod-responder.h, handle_nop() to iiod/responder.c, and iiod_client_nop()
  to iiod-client.c
  - Add .ping to iio_backend_ops and implement iio_context_ping() in context.c with -EINVAL fallback to
  iio_context_set_timeout()
  - Add network_ping(), usb_ping(), serial_ping(), local_ping(), emu_ping() to their respective backends
  - Add iio_ping utility with -c and -i options, and man page

### How it works

1. The caller invokes `iio_context_ping(ctx)`.
2. `iio_context_ping()` calls `ctx->ops->ping(ctx)` for example `network_ping()` for a network context.
3. `network_ping()` calls `iiod_client_nop(pdata->iiod_client)`.
4. `iiod_client_nop()`  builds an `iiod_command` with `op = IIOD_OP_NOP` and sends it via `iiod_io_exec_simple_command()`. 
5. The reader thread dispatches opcode 27 to `handle_nop()`, which calls `iiod_io_send_response_code(io, 0)` and the client returns 0.

### Usage

```c
/* API */
struct iio_context *ctx = iio_create_context(NULL, "ip:192.168.1.10");

if (iio_context_ping(ctx) < 0) {
    iio_context_destroy(ctx);
    ctx = iio_create_context(NULL, "ip:192.168.1.10");
}
```

```sh
# CLI
iio_ping -u ip:192.168.0.2 -c 4 -i 1000
PING ip backend (Linux pi5 6.12.62+rpt-rpi-2712 #1 SMP PREEMPT Debian 1:6.12.62-1+rpt1 (2025-12-18) aarch64 192.168.0.2)
Reply from ip: seq=0 time=1.616 ms
Reply from ip: seq=1 time=2.038 ms
Reply from ip: seq=2 time=2.732 ms
Reply from ip: seq=3 time=1.983 ms

--- ip ping statistics ---
4 requests sent, 4 received, 0.0% loss
```

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
