### PR TITLE
iiod/stresstest: fix buffer open race and network backend hang

### DIFF
--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -451,6 +451,14 @@ static void handle_open_buffer(struct parser_pdata *pdata, const struct iiod_com
 	if (ret)
 		goto err_destroy_dequeue_task;
 
+	iio_mutex_lock(buflist_lock);
+	if (!iio_err(get_iio_buffer_entry_unlocked(pdata, cmd))) {
+		iio_mutex_unlock(buflist_lock);
+		ret = -EEXIST;
+		goto err_destroy_lock;
+	}
+	iio_mutex_unlock(buflist_lock);
+
 	buf = iio_device_get_buffer(dev, entry->idx);
 	if (!buf) {
 		ret = -ENODEV;

--- a/utils/iio_stresstest.c
+++ b/utils/iio_stresstest.c
@@ -273,8 +273,6 @@ static void *client_thread(void *data)
 		/* started another context */
 		info->starts[id]++;
 
-		ret = iio_context_set_timeout(ctx, IIO_TIMEOUT_INFINITE);
-		thread_err(id, ret, "iio_context_set_timeout failed");
 
 		dev = get_device(ctx, info->argv[info->arg_index + 1]);
 		if (!dev) {
@@ -312,7 +310,7 @@ static void *client_thread(void *data)
 			printf("%2d: Running\n", id);
 
 		i = 0;
-		while (threads_running || i == 0) {
+		while (app_running && (threads_running || i == 0)) {
 			info->buffers[id]++;
 
 			stream = iio_buffer_create_stream(buffer, 4, info->buffer_size, mask);
@@ -327,7 +325,7 @@ static void *client_thread(void *data)
 				continue;
 			}
 
-			while (threads_running || i == 0) {
+			while (app_running && (threads_running || i == 0)) {
 				block = iio_stream_get_next_block(stream);
 				ret = iio_err(block);
 				if (ret) {


### PR DESCRIPTION
## PR Description

Two bug fixes found by running `iio_stresstest` against iiod, initially with iio-emu and then confirmed on a real fmcomms2 board over TCP.

**iiod race:** Found with iio-emu. Two clients racing to open the same buffer could both pass the existing-entry check in `handle_open_buffer` and both insert a `buffer_entry`, causing one client to silently own the other's entry. Fixed by re-checking under `buflist_lock` immediately before inserting. This alone was enough for stresstest to exit cleanly for emu backend over iiod. But not enough for real hardware over iiod.

**iio_stresstest hang:** `IIO_TIMEOUT_INFINITE` caused `iio_block_dequeue` to wait forever when iiod is stuck waiting for samples. Removing it restores the backend default (5s). `app_running` is also added to the inner loops so threads blocked on EEXIST contention exit on SIGINT without waiting on the `i == 0` guard.
### Benefits

- Eliminates the race in `handle_open_buffer` where concurrent clients could corrupt each other's buffer ownership
- `iio_stresstest` no longer hangs on Ctrl-C when streaming against a network backend

### Changes

- `iiod/responder.c`: re-check `get_iio_buffer_entry_unlocked()` under `buflist_lock` before inserting a new `buffer_entry`, return `-EEXIST` if one already exists
- `utils/iio_stresstest.c`: remove `iio_context_set_timeout(ctx, IIO_TIMEOUT_INFINITE)`
- `utils/iio_stresstest.c`: add `app_running` to inner streaming loop conditions

### Usage

```bash
./iio_stresstest -u ip:<board-ip>:30434 -t 10 cf-ad9361-lpc

 0: Ran : 2 times, opening 32 buffers, doing 12 refills
 1: Ran : 2 times, opening 36 buffers, doing 2 refills
 2: Ran : 2 times, opening 34 buffers, doing 2 refills
 3: Ran : 2 times, opening 34 buffers, doing 4 refills
 4: Ran : 2 times, opening 35 buffers, doing 2 refills
 5: Ran : 2 times, opening 35 buffers, doing 7 refills
 6: Ran : 2 times, opening 41 buffers, doing 1 refills
 7: Ran : 2 times, opening 44 buffers, doing 6 refills
 8: Ran : 2 times, opening 38 buffers, doing 2 refills
 9: Ran : 2 times, opening 40 buffers, doing 6 refills
total: 21s Context : 20 (0.92/s), buffers: 369 (17.00/s), refills : 44 (2.03/s)
    0        :       0 ( 0.00%)
  1 - 9   μs :       0 ( 0.00%)
 10 - 99  μs :       1 ( 5.56%)
100 - 999 μs :       7 (38.89%)
  1 - 9.9 ms :       4 (22.22%)
 10 - 99  ms :       6 (33.33%)
100 - 999 ms :       0 ( 0.00%)
over 1 s     :       0 ( 0.00%)
```

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
