### PR TITLE
network: Fix pipe2() fallback handling

### DIFF
--- a/network-unix.c
+++ b/network-unix.c
@@ -53,7 +53,9 @@ static int create_cancel_fd(struct iiod_client_pdata *io_ctx)
 
 #ifdef HAS_PIPE2
 	ret = pipe2(io_ctx->cancel_fd, O_CLOEXEC | O_NONBLOCK);
-	if (ret < 0 && errno != ENOSYS) /* If ENOSYS try pipe() */
+	if (!ret)
+		return 0;
+	if (errno != ENOSYS) /* If ENOSYS try pipe() */
 		return -errno;
 #endif
 	ret = pipe(io_ctx->cancel_fd);


### PR DESCRIPTION
When `pipe2()` succeeds, `create_cancel_fd()` still falls through to `pipe()`. This overwrites the stored cancel pipe file descriptors and leaks the descriptors returned by `pipe2()`.

Return immediately after a successful `pipe2()` call so `pipe()` is only used for the intended `ENOSYS` fallback case.

Fixes: d2ca7db254bd ("network: Add cancellation support")