### PR TITLE
lock-windows: Close thread handle after join

### DIFF
--- a/lock-windows.c
+++ b/lock-windows.c
@@ -134,6 +134,7 @@ int iio_thrd_join_and_destroy(struct iio_thrd *thrd)
 
 	WaitForSingleObject(thrd->thid, INFINITE);
 	GetExitCodeThread(thrd->thid, &ret);
+	CloseHandle(thrd->thid);
 	free(thrd);
 
 	return (int)ret;


### PR DESCRIPTION
`CreateThread()` returns a handle that must be closed once it is no longer needed. `iio_thrd_join_and_destroy()` waits for the thread and reads its exit code, but only frees the wrapper structure, leaking the underlying Windows handle.

Close the thread handle before freeing the wrapper.