### PR TITLE
zephyr: samples/iiod: fix native_sim network test races

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -60,7 +60,7 @@ jobs:
           if [ "${{ runner.os }}" = "Windows" ]; then
             EXTRA_TWISTER_FLAGS="--short-build-path -O/tmp/twister-out"
           fi
-          west twister -T samples -v --force-color --inline-logs --integration --fixture iiod_tcp_30431 $EXTRA_TWISTER_FLAGS
+          west twister -T samples -v --force-color --inline-logs --integration $EXTRA_TWISTER_FLAGS
 
   regression-tests:
     name: Regression tests against Zephyr IIOD backend

--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -60,7 +60,7 @@ jobs:
           if [ "${{ runner.os }}" = "Windows" ]; then
             EXTRA_TWISTER_FLAGS="--short-build-path -O/tmp/twister-out"
           fi
-          west twister -T samples -v --force-color --inline-logs --integration $EXTRA_TWISTER_FLAGS
+          west twister -T samples -v --force-color --inline-logs --integration --fixture iiod_tcp_30431 $EXTRA_TWISTER_FLAGS
 
   regression-tests:
     name: Regression tests against Zephyr IIOD backend

--- a/zephyr/samples/iiod/pytest/conftest.py
+++ b/zephyr/samples/iiod/pytest/conftest.py
@@ -43,7 +43,23 @@ def _network_context(dut: DeviceAdapter):
             time.sleep(0.1)
     else:
         raise TimeoutError('IIOD network server did not start within 30 seconds')
-    ctx = iio.Context('ip:127.0.0.1')
+    # The listen socket is opened BEFORE the shared IIO context is populated,
+    # so an immediate iio.Context() may hit the accept() with 0 devices.
+    # Retry the context until we see devices or timeout.
+    deadline = time.monotonic() + 10.0
+    ctx = None
+    while time.monotonic() < deadline:
+        try:
+            ctx = iio.Context('ip:127.0.0.1')
+            if len(list(ctx.devices)) > 0:
+                break
+            del ctx
+            ctx = None
+        except OSError:
+            pass
+        time.sleep(0.1)
+    if ctx is None:
+        raise TimeoutError('IIOD server never advertised any devices')
     yield ctx
     del ctx  # close TCP connection before DUT teardown
     dut.base_timeout = 2.0

--- a/zephyr/samples/iiod/sample.yaml
+++ b/zephyr/samples/iiod/sample.yaml
@@ -9,20 +9,6 @@ common:
     regex:
       - "Booting Zephyr OS"
 tests:
-  sample.iiod.network:
-    extra_args:
-      - SNIPPET=iiod-network
-    extra_configs:
-      - CONFIG_LIBIIO_IIOD_ADC_EMUL=y
-      - CONFIG_LIBIIO_IIOD_SENSOR_EMUL=y
-    platform_allow:
-      - native_sim
-    harness_config:
-      type: one_line
-      regex:
-        - "Booting Zephyr OS"
-      fixture: iiod_tcp_30431
-
   sample.iiod.network.pytest:
     extra_args:
       - SNIPPET=iiod-network
@@ -36,7 +22,6 @@ tests:
     timeout: 120
     harness_config:
       pytest_dut_scope: session
-      fixture: iiod_tcp_30431
       pytest_args:
         - --iiod-transport=network
 

--- a/zephyr/samples/iiod/sample.yaml
+++ b/zephyr/samples/iiod/sample.yaml
@@ -17,6 +17,11 @@ tests:
       - CONFIG_LIBIIO_IIOD_SENSOR_EMUL=y
     platform_allow:
       - native_sim
+    harness_config:
+      type: one_line
+      regex:
+        - "Booting Zephyr OS"
+      fixture: iiod_tcp_30431
 
   sample.iiod.network.pytest:
     extra_args:
@@ -31,6 +36,7 @@ tests:
     timeout: 120
     harness_config:
       pytest_dut_scope: session
+      fixture: iiod_tcp_30431
       pytest_args:
         - --iiod-transport=network
 


### PR DESCRIPTION
## PR Description

Two independent races made the pytest sample fail intermittently on the
Zephyr CI ubuntu-22.04 runner:

  1. Port collision. sample.iiod.network (console harness) and
     sample.iiod.network.pytest (pytest harness) built two separate
     native_sim zephyr.exe images that both bind TCP port 30431. Twister
     runs native_sim tests in parallel, so whichever DUT lost the bind()
     race got errno 112 (EADDRINUSE) and never advertised its IIO
     context:

         <err> libiio: Failed to bind socket: -1 (errno: 112)
         <err> libiio: Failed to create test server

     sample.iiod.network only checked that the DUT prints "Booting Zephyr
     OS", which is a strict subset of what the pytest variant already
     verifies (it also boots the DUT and then talks the full IIOD
     protocol to it). Drop the redundant console-harness test so nothing
     else contends for port 30431.

  2. Client-side race. The IIOD server thread opens its listen socket
     before iio_context_add_device() is called for each configured
     device. If pytest connects between those two steps -- which the old
     fixture did as soon as socket.create_connection() succeeded -- it
     read back an empty XML and cached an empty device list, causing
     every test to fail on `iiod_context.devices`. Retry iio.Context()
     from the fixture until it reports at least one device or a 10 s
     deadline expires.

With these fixes, `west twister -T samples --integration` passes 10/10
native_sim test cases under default parallel execution.

Signed-off-by: Dimitrije Lilic <dimitrije.lilic@orioninc.com>

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
