### PR TITLE
zephyr: samples: iiod: remove redundant network console test

### DIFF
--- a/zephyr/samples/iiod/sample.yaml
+++ b/zephyr/samples/iiod/sample.yaml
@@ -9,15 +9,6 @@ common:
     regex:
       - "Booting Zephyr OS"
 tests:
-  sample.iiod.network:
-    extra_args:
-      - SNIPPET=iiod-network
-    extra_configs:
-      - CONFIG_LIBIIO_IIOD_ADC_EMUL=y
-      - CONFIG_LIBIIO_IIOD_SENSOR_EMUL=y
-    platform_allow:
-      - native_sim
-
   sample.iiod.network.pytest:
     extra_args:
       - SNIPPET=iiod-network


### PR DESCRIPTION
The sample.iiod.network scenario was a simple console test that only checked for "Booting Zephyr OS" on native_sim. The sample.iiod.network.pytest scenario covers this and much more. Running both in parallel caused a port conflict: both binaries competed to bind port 30431, making the pytest scenario fail intermittently when the console scenario grabbed the port first.

Remove sample.iiod.network since it is fully superseded by sample.iiod.network.pytest on native_sim.

Assisted-by: Claude:claude-sonnet-4-6

Alternative to #1491

cc: @dimitrije-lilic

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
