### PR TITLE
Fix buffer detection for v0.x server with v1.0 client

### DIFF
--- a/emu.c
+++ b/emu.c
@@ -792,12 +792,34 @@ static int create_device(struct iio_context *ctx, xmlNode *n)
 		}
 	}
 
+	/* Handle legacy XML formats that have scan-elements but no explicit
+	 * <buffer> tags. Check if any channels have scan-elements and create
+	 * a buffer if needed.
+	 */
 	if (buf_legacy) {
 		struct iio_buffer *buf = iio_device_get_buffer(dev, 0);
+		unsigned int c;
+		bool has_scan_elements = false;
 
+		/* Check if any channels have scan-elements */
+		for (c = 0; c < iio_device_get_channels_count(dev); c++) {
+			struct iio_channel *chn = iio_device_get_channel(dev, c);
+
+			if (iio_channel_is_scan_element(chn)) {
+				has_scan_elements = true;
+				break;
+			}
+		}
+
+		/* Create buffer if we have scan-elements but no explicit buffer */
+		if (has_scan_elements && !buf) {
+			buf = iio_device_add_buffer(dev, 0);
+			if (!buf)
+				return -ENOMEM;
+		}
+
+		/* Add all scan-elements to the buffer */
 		if (buf) {
-			unsigned int c;
-
 			for (c = 0; c < iio_device_get_channels_count(dev); c++) {
 				struct iio_channel *chn = iio_device_get_channel(dev, c);
 

--- a/xml.c
+++ b/xml.c
@@ -415,24 +415,46 @@ static int create_device(struct iio_context *ctx, xmlNode *n)
 		}
 	}
 
-	/* Handle IIOD versions that only send <buffer-attribute>. At this point,
+	/* Handle IIOD versions that only send <buffer-attribute> or have
+	 * scan-elements but no explicit <buffer> tags. At this point,
 	 * we need to go all over the channels and add the ones that are scan elements
 	 * to the buffer.
 	 */
-	if (buf_legacy && buf) {
+	if (buf_legacy) {
 		unsigned int c;
+		bool has_scan_elements = false;
 
+		/* Check if any channels have scan-elements */
 		for (c = 0; c < iio_device_get_channels_count(dev); c++) {
 			struct iio_channel *chn = iio_device_get_channel(dev, c);
 
-			if (!iio_channel_is_scan_element(chn))
-				continue;
+			if (iio_channel_is_scan_element(chn)) {
+				has_scan_elements = true;
+				break;
+			}
+		}
 
-			err = iio_buffer_add_scan_element(buf, chn, NULL);
-			if (err < 0) {
-				dev_perror(dev, err,
-						"Unable to add scan element to legacy buffer\n");
-				return err;
+		/* Create buffer if we have scan-elements but no explicit buffer */
+		if (has_scan_elements && !buf) {
+			buf = iio_device_add_buffer(dev, 0);
+			if (!buf)
+				return -ENOMEM;
+		}
+
+		/* Add all scan-elements to the buffer */
+		if (buf) {
+			for (c = 0; c < iio_device_get_channels_count(dev); c++) {
+				struct iio_channel *chn = iio_device_get_channel(dev, c);
+
+				if (!iio_channel_is_scan_element(chn))
+					continue;
+
+				err = iio_buffer_add_scan_element(buf, chn, NULL);
+				if (err < 0) {
+					dev_perror(dev, err,
+							"Unable to add scan element to legacy buffer\n");
+					return err;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## PR Description

Fixes compatibility issue where v1.0 clients connecting to v0.x servers
reported "0 buffers found" even though devices were buffer-capable.

**Root cause:** Legacy compatibility code only created buffers when
`<buffer-attribute>` tags existed. v0.x servers send channels with
`<scan-element>` tags but no explicit `<buffer>` tags, so no buffer
was created.

**Fix:** Enhanced both xml and emu backends to:
- Check if channels have scan-elements
- Create legacy buffer if needed
- Add all scan-elements to the buffer

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
