### PR TITLE
Fix Python bindings on embedded systems without dev tools

### DIFF
--- a/bindings/python/iio/__init__.py
+++ b/bindings/python/iio/__init__.py
@@ -328,6 +328,21 @@ if "Windows" in _system():
 else:
     # Non-windows, possibly Posix system
     _lib_loc = find_library("iio")
+
+    if _lib_loc is None:
+        # find_library failed - try direct loading for embedded systems
+        # (common on buildroot/yocto systems without gcc/ldconfig)
+        import sys
+        if sys.platform.startswith('linux'):
+            for name in ['libiio.so.1', 'libiio.so']:
+                try:
+                    # Attempt load to verify it's valid
+                    _cdll(name)
+                    _lib_loc = name
+                    break
+                except OSError:
+                    continue
+
     if _lib_loc is not None:
         if _path.islink(_lib_loc):
             _lib_loc = _path.realpath(_lib_loc)


### PR DESCRIPTION
## PR Description

The Python bindings use ctypes.util.find_library() to locate libiio, which relies on external programs (ldconfig, gcc, objdump, ld) that are often absent in minimal embedded environments like buildroot or Yocto. When these tools are missing, find_library() returns None, causing the bindings to fail with "undefined symbol" errors.

This commit adds a fallback mechanism that activates only when find_library() returns None on Linux systems. It attempts to load the library directly using canonical soname patterns (libiio.so.1, libiio.so), validating each candidate before accepting it.

Closes #1379.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
