### PR TITLE
Fix buffer not being properly closed on stream destroy

### DIFF
--- a/stream.c
+++ b/stream.c
@@ -101,6 +101,10 @@ void iio_stream_destroy(struct iio_stream *stream)
 	}
 
 	free(stream->blocks);
+
+	if (stream->buf_enabled)
+		iio_buffer_stream_stop(stream->buf_stream);
+
 	iio_buffer_close(stream->buf_stream);
 	free(stream);
 }


### PR DESCRIPTION
## PR Description
iio_stream_destroy() was missing a call to iio_buffer_stream_stop() before closing the buffer. This meant that on the legacy text protocol, the CLOSE command was never sent to the server, and on the binary protocol, the IIOD_OP_DISABLE_BUFFER command was skipped.

This caused failures when reusing the same buffer for a second stream: the server still considered the buffer open/enabled from the first stream, so the second OPEN would fail or produce I/O errors. This was observed when interacting with a baremetal system running TinyIIOD (which is v0.x so it knows only the ASCII protocol).

The compat layer (iio_buffer_destroy) already had the correct sequence of cancel -> stop -> destroy blocks -> close, but the v1 Stream API path was missing the stop step.

To reproduce the issue, the following command sequences for `stream` was used:
create -> use -> destroy -> create -> use -> destroy

### Legacy text protocol (v0.x servers like tinyIIOD or IIOD)

| Step | Before fix | After fix |
|---|---|---|
| Create stream 1 | `OPEN <dev> <samples> <mask>` | `OPEN <dev> <samples> <mask>` |
| next() | `READBUF <dev> <len>` × N | `READBUF <dev> <len>` × N |
| Destroy stream 1 | _(nothing)_ | **`CLOSE <dev>`** |
| Create stream 2 | `OPEN <dev> <samples> <mask>` | `OPEN <dev> <samples> <mask>` |
| next() | **EIO — buffer still open** | `READBUF <dev> <len>` × N |
| Destroy stream 2 | _(nothing)_ | **`CLOSE <dev>`** |

### Binary protocol (IIOD v1.0+)

| Step | Before fix | After fix |
|---|---|---|
| Create stream 1 | `OPEN_BUFFER`, `CREATE_BLOCK` × N | `OPEN_BUFFER`, `CREATE_BLOCK` × N |
| next() | `ENABLE_BUFFER`, `TRANSFER_BLOCK` × N | `ENABLE_BUFFER`, `TRANSFER_BLOCK` × N |
| Destroy stream 1 | `FREE_BLOCK` × N, `CLOSE_BUFFER` | **`DISABLE_BUFFER`**, `FREE_BLOCK` × N, `CLOSE_BUFFER` |
| Create stream 2 | `OPEN_BUFFER`, `CREATE_BLOCK` × N | `OPEN_BUFFER`, `CREATE_BLOCK` × N |
| next() | works (iiod handles it) | `ENABLE_BUFFER`, `TRANSFER_BLOCK` × N |
| Destroy stream 2 | `FREE_BLOCK` × N, `CLOSE_BUFFER` | **`DISABLE_BUFFER`**, `FREE_BLOCK` × N, `CLOSE_BUFFER` |

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
