### PR TITLE
libiio.iss: set LIBIIO_VERSION system environment variable

### DIFF
--- a/libiio.iss.cmakein
+++ b/libiio.iss.cmakein
@@ -50,3 +50,6 @@ Source: "D:\a\1\a\Windows-VS-2022-x64\BUILD_TYPE\libzstd.dll"; DestDir: "{sys}";
 Source: "D:\a\1\a\Windows-VS-2022-x64\libiio-sharp.dll"; DestDir: "{commoncf}\libiio"; Flags: replacesameversion
 Source: "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\VCREDIST_VERSION\x64\Microsoft.VC143.CRT\msvcp140.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Flags: onlyifdoesntexist
 Source: "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC\VCREDIST_VERSION\x64\Microsoft.VC143.CRT\vcruntime140.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Flags: onlyifdoesntexist
+
+[Registry]
+Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; ValueType: string; ValueName: "LIBIIO_VERSION"; ValueData: "@VERSION@"; Flags: uninsdeletevalue


### PR DESCRIPTION
## PR Description
This PR adds a `LIBIIO_VERSION` system environment variable to the Windows installer, as requested by downstream consumers.
After running the libiio installer, the variable is available system-wide and can be used by applications to verify that the correct version of libiio is installed.

This feature was requested.

### Changes
- Add `[Registry]` section to `libiio.iss.cmakein` that writes `LIBIIO_VERSION` to `HKLM\...\Environment` at install time

### How it works
1. Inno Setup processes `libiio.iss` (generated from `libiio.iss.cmakein` by CMake, with `@VERSION@` substituted to e.g. `1.0`)
2. During install, the `[Registry]` section writes `LIBIIO_VERSION=1.0`  to the system environment registry key
3. Any new process started after install picks up the variable
4. On uninstall, the `uninsdeletevalue` flag removes it automatically




## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
