### PR TITLE
Python bindings: define license as a string SPDX expression

### DIFF
--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,12 +1,12 @@
 [build-system]
-requires = ["setuptools>=40.6.0"]
+requires = ["setuptools>=77.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "pylibiio"
 dynamic = ["version", "readme"]
 description = "Analog Devices python interfaces for hardware with Industrial I/O drivers"
-license = { text = "LGPL-2-or-later" }
+license = "LGPL-2.1-or-later"
 classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",


### PR DESCRIPTION
## PR Description

Setuptools warns that the mapping form of `project.license` is deprecated (see #1498 for the full warning), and the value should be an SPDX expression string as defined in PEP 639. Setuptools supports this format starting with version 77.0.0.

`LGPL-2-or-later` is not a [defined SPDX license identifier](https://spdx.org/licenses/), version `2.0` or `2.1` must be specified. Update to `LGPL-2.1-or-later`, which matches the `SPDX-License-Identifier` header in `bindings/python/iio/__init__.py`, as well as `COPYING.txt`.

Closes: #1498 

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
