### PR TITLE
Relicense C# bindings under MIT license

### DIFF
--- a/COPYING_MIT.txt
+++ b/COPYING_MIT.txt
@@ -51,3 +51,26 @@ tinyiiod/tinyiiod.c
 tinyiiod/tinyiiod.h
 utilities.c
 xml.c
+
+C# Bindings:
+
+bindings/csharp/Attr.cs
+bindings/csharp/Block.cs
+bindings/csharp/Channel.cs
+bindings/csharp/ChannelsMask.cs
+bindings/csharp/Context.cs
+bindings/csharp/Device.cs
+bindings/csharp/EventStream.cs
+bindings/csharp/IIOEvent.cs
+bindings/csharp/IOBuffer.cs
+bindings/csharp/IioLib.cs
+bindings/csharp/Scan.cs
+bindings/csharp/Stream.cs
+bindings/csharp/Trigger.cs
+bindings/csharp/UTF8Marshaler.cs
+bindings/csharp/examples/ExampleIIOEvent.cs
+bindings/csharp/examples/ExampleProgram.cs
+bindings/csharp/examples/PlutoExample.cs
+bindings/csharp/tests/IntegrationTests.cs
+bindings/csharp/tests/SmokeTests.cs
+bindings/csharp/tests/TestFramework.cs

--- a/bindings/csharp/Attr.cs
+++ b/bindings/csharp/Attr.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/bindings/csharp/Block.cs
+++ b/bindings/csharp/Block.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/bindings/csharp/Channel.cs
+++ b/bindings/csharp/Channel.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/bindings/csharp/ChannelsMask.cs
+++ b/bindings/csharp/ChannelsMask.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/bindings/csharp/Context.cs
+++ b/bindings/csharp/Context.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/bindings/csharp/Device.cs
+++ b/bindings/csharp/Device.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/bindings/csharp/EventStream.cs
+++ b/bindings/csharp/EventStream.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/bindings/csharp/IIOEvent.cs
+++ b/bindings/csharp/IIOEvent.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/bindings/csharp/IOBuffer.cs
+++ b/bindings/csharp/IOBuffer.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/bindings/csharp/IioLib.cs
+++ b/bindings/csharp/IioLib.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/bindings/csharp/Scan.cs
+++ b/bindings/csharp/Scan.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/bindings/csharp/Stream.cs
+++ b/bindings/csharp/Stream.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/bindings/csharp/Trigger.cs
+++ b/bindings/csharp/Trigger.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/bindings/csharp/UTF8Marshaler.cs
+++ b/bindings/csharp/UTF8Marshaler.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/bindings/csharp/examples/ExampleIIOEvent.cs
+++ b/bindings/csharp/examples/ExampleIIOEvent.cs
@@ -1,21 +1,10 @@
+// SPDX-License-Identifier: MIT
 /*
+ * libiio - Library for interfacing industrial I/O (IIO) devices
+ *
  * Copyright (C) 2024 Analog Devices, Inc.
  * Author: Alexandra Trifan <Alexandra.Trifan@analog.com>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * */
+ */
 
 using System;
 using System.Collections.Generic;

--- a/bindings/csharp/examples/ExampleProgram.cs
+++ b/bindings/csharp/examples/ExampleProgram.cs
@@ -1,21 +1,10 @@
+// SPDX-License-Identifier: MIT
 /*
+ * libiio - Library for interfacing industrial I/O (IIO) devices
+ *
  * Copyright (C) 2014 Analog Devices, Inc.
  * Author: Paul Cercueil <paul.cercueil@analog.com>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * */
+ */
 
 using System;
 using System.Collections.Generic;

--- a/bindings/csharp/examples/PlutoExample.cs
+++ b/bindings/csharp/examples/PlutoExample.cs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: LGPL-2.1-or-later
+// SPDX-License-Identifier: MIT
 /*
  * libiio - Library for interfacing industrial I/O (IIO) devices
  *

--- a/bindings/csharp/mainpage.dox
+++ b/bindings/csharp/mainpage.dox
@@ -6,13 +6,11 @@
 <a href="../index.html">Back to libIIO</a> 
 
 @section license License
-libiio and the C# bindings have been developed and are released under the terms of the GNU Lesser General Public
-License, version 2.1 or (at your option) any later version.
+The C# bindings for libiio are released under the terms of the MIT License.
 This open-source license allows anyone to use the library in proprietary or open-source applications,
-commercial or non-commercial. If you modify the bindings or library, you must provide the modified source
-code along with any binary distribution.
+commercial or non-commercial, with minimal restrictions.
 
-The full terms of the library license can be found at: http://opensource.org/licenses/LGPL-2.1
+The full terms of the license can be found at: https://opensource.org/licenses/MIT
 
 @section code_model Code Model
 The basic building blocks of the C# bindings are the core classes organized within the iio namespace:

--- a/bindings/csharp/tests/IntegrationTests.cs
+++ b/bindings/csharp/tests/IntegrationTests.cs
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+/*
+ * libiio - Library for interfacing industrial I/O (IIO) devices
+ *
+ * Copyright (C) 2015 Analog Devices, Inc.
+ */
+
 using System;
 using System.IO;
 using iio;

--- a/bindings/csharp/tests/SmokeTests.cs
+++ b/bindings/csharp/tests/SmokeTests.cs
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+/*
+ * libiio - Library for interfacing industrial I/O (IIO) devices
+ *
+ * Copyright (C) 2015 Analog Devices, Inc.
+ */
+
 using System;
 using System.IO;
 using System.Reflection;

--- a/bindings/csharp/tests/TestFramework.cs
+++ b/bindings/csharp/tests/TestFramework.cs
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+/*
+ * libiio - Library for interfacing industrial I/O (IIO) devices
+ *
+ * Copyright (C) 2015 Analog Devices, Inc.
+ */
+
 using System;
 
 namespace LibiioTests


### PR DESCRIPTION
## PR Description

As part of our ongoing efforts to enhance the flexibility and usability of libiio, we are relicensing the C# bindings from LGPL-2.1 to the MIT license.

Files relicensed:
 - bindings/csharp/*.cs (14 main binding files)
 - bindings/csharp/examples/*.cs (3 example files)
 - bindings/csharp/tests/*.cs (3 test files)

This change aims to better support proprietary applications and enable broader adoption of the C# bindings in commercial software without the copyleft requirements of LGPL.

The MIT license provides greater permissiveness, allowing developers to use the C# bindings in both open-source and proprietary applications without requiring source code disclosure.

All contributors whose code remains in the current state of the C# bindings have provided their written consent for this relicensing.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [x] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
