### PR TITLE
zephyr: samples: overlays: introduce typed iio-sensors/iio-adcs sub-bus hierarchy

### DIFF
--- a/zephyr/samples/iiod/CMakeLists.txt
+++ b/zephyr/samples/iiod/CMakeLists.txt
@@ -27,6 +27,11 @@ if(CONFIG_LIBIIO_IIOD_SENSOR_EMUL)
   list(APPEND EXTRA_CONF_FILE sensor-emul.conf)
 endif()
 
+if(CONFIG_LIBIIO_IIOD_MULTI_SENSOR_EMUL)
+  list(APPEND EXTRA_DTC_OVERLAY_FILE multi-sensor-emul.overlay)
+  list(APPEND EXTRA_CONF_FILE sensor-emul.conf)
+endif()
+
 if(CONFIG_LIBIIO_IIOD_SENSOR_ADXL345)
   list(APPEND EXTRA_DTC_OVERLAY_FILE adxl345.overlay)
   list(APPEND EXTRA_CONF_FILE adxl345.conf)

--- a/zephyr/samples/iiod/Kconfig
+++ b/zephyr/samples/iiod/Kconfig
@@ -13,6 +13,13 @@ config LIBIIO_IIOD_SENSOR_EMUL
 	help
 	  Enable sensor emulator IIO device driver.
 
+config LIBIIO_IIOD_MULTI_SENSOR_EMUL
+	bool "Enable multi-sensor emulator (two ADLTC2990 instances)"
+	help
+	  Enable two emulated ADLTC2990 sensor instances. Demonstrates that
+	  the reg property and @N unit-address are required when multiple
+	  nodes share the same compatible and name within an iio-sensors bus.
+
 config LIBIIO_IIOD_SENSOR_ADXL345
 	bool "Enable adxl345 sensor"
 	help

--- a/zephyr/samples/iiod/adc-emul.overlay
+++ b/zephyr/samples/iiod/adc-emul.overlay
@@ -6,15 +6,17 @@
 
 / {
 	iio-context {
-		#address-cells = <1>;
-		#size-cells = <0>;
+		iio-adcs {
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-		iio-device@1 {
-			compatible = "iio,io-channels";
-			reg = <1>;
-			io-channels = <&adc_emul 0>, <&adc_emul 1>;
-			io-channel-names = "voltage0", "voltage1";
-			io-name = "adc-emul";
+			adc-emul@0 {
+				compatible = "iio,io-channels";
+				reg = <0>;
+				io-channels = <&adc_emul 0>, <&adc_emul 1>;
+				io-channel-names = "voltage0", "voltage1";
+				io-name = "adc-emul";
+			};
 		};
 	};
 

--- a/zephyr/samples/iiod/adc-max32.overlay
+++ b/zephyr/samples/iiod/adc-max32.overlay
@@ -6,15 +6,17 @@
 
 / {
 	iio-context {
-		#address-cells = <1>;
-		#size-cells = <0>;
+		iio-adcs {
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-		iio-device@0 {
-			compatible = "iio,adc";
-			reg = <0>;
-			io-channels = <&adc 0>;
-			io-channel-names = "adc_in_ch0";
-			io-name = "max32-adc";
+			max32-adc@0 {
+				compatible = "iio,adc";
+				reg = <0>;
+				io-channels = <&adc 0>;
+				io-channel-names = "adc_in_ch0";
+				io-name = "max32-adc";
+			};
 		};
 	};
 };
@@ -24,7 +26,7 @@
 };
 
 &adc {
-	/*clocks = */ 
+	/*clocks = */
 	pinctrl-0 = <&adc_clk_ext_p0_9>;
 	pinctrl-names = "default";
 

--- a/zephyr/samples/iiod/adxl345.overlay
+++ b/zephyr/samples/iiod/adxl345.overlay
@@ -40,24 +40,23 @@
 / {
 	/* IIO Context for libiio */
 	iio-context {
-		#address-cells = <1>;
-		#size-cells = <0>;
+		iio-sensors {
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-		/* IIO Device wrapper for ADXL345 */
-		iio-device@1 {
-			compatible = "iio,sensor";
-			reg = <1>;
-			sensor-device = <&adxl345>;
-			/* Expose 3-axis accelerometer channels via IIO
-			 * ADXL345 provides X, Y, Z acceleration data
-			 */
-			sensor-channels = <
-				IIO_SENSOR_CHAN_ACCEL_X
-				IIO_SENSOR_CHAN_ACCEL_Y
-				IIO_SENSOR_CHAN_ACCEL_Z
-			>;
-			buffer-name = "buffer0";
-			io-name = "adxl345";
+			/* ADXL345 3-axis Accelerometer */
+			adxl345@0 {
+				compatible = "iio,sensor";
+				reg = <0>;
+				sensor-device = <&adxl345>;
+				sensor-channels = <
+					IIO_SENSOR_CHAN_ACCEL_X
+					IIO_SENSOR_CHAN_ACCEL_Y
+					IIO_SENSOR_CHAN_ACCEL_Z
+				>;
+				buffer-name = "buffer0";
+				io-name = "adxl345";
+			};
 		};
 	};
 };

--- a/zephyr/samples/iiod/eval_ad4052_ardz.overlay
+++ b/zephyr/samples/iiod/eval_ad4052_ardz.overlay
@@ -6,15 +6,17 @@
 
 / {
 	iio-context {
-		#address-cells = <1>;
-		#size-cells = <0>;
+		iio-adcs {
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-		iio-device@0 {
-			compatible = "iio,adc";
-			reg = <0>;
-			io-channels = <&adc4052_eval_ad4052_ardz 0>;
-			io-channel-names = "adc_in_ch0";
-			io-name = "ad4052";
+			ad4052@0 {
+				compatible = "iio,adc";
+				reg = <0>;
+				io-channels = <&adc4052_eval_ad4052_ardz 0>;
+				io-channel-names = "adc_in_ch0";
+				io-name = "ad4052";
+			};
 		};
 	};
 };

--- a/zephyr/samples/iiod/multi-sensor-emul.overlay
+++ b/zephyr/samples/iiod/multi-sensor-emul.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Analog Devices, Inc.
+ * Copyright (c) 2026 Analog Devices, Inc.
  *
  * SPDX-License-Identifier: MIT
  */
@@ -13,10 +13,11 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
+			/* First ADLTC2990 instance — I2C address 0x4c */
 			ltc2990@0 {
 				compatible = "iio,sensor";
 				reg = <0>;
-				sensor-device = <&adltc2990_emul>;
+				sensor-device = <&adltc2990_emul_0>;
 				sensor-channels = <
 					IIO_SENSOR_CHAN_VOLTAGE
 					IIO_SENSOR_CHAN_VOLTAGE
@@ -27,12 +28,30 @@
 					IIO_SENSOR_CHAN_AMBIENT_TEMP
 				>;
 				buffer-name = "buffer0";
-				io-name = "ltc2990";
+				io-name = "ltc2990-0";
+			};
+
+			/* Second ADLTC2990 instance — I2C address 0x4e */
+			ltc2990@1 {
+				compatible = "iio,sensor";
+				reg = <1>;
+				sensor-device = <&adltc2990_emul_1>;
+				sensor-channels = <
+					IIO_SENSOR_CHAN_VOLTAGE
+					IIO_SENSOR_CHAN_VOLTAGE
+					IIO_SENSOR_CHAN_VOLTAGE
+					IIO_SENSOR_CHAN_VOLTAGE
+					IIO_SENSOR_CHAN_CURRENT
+					IIO_SENSOR_CHAN_DIE_TEMP
+					IIO_SENSOR_CHAN_AMBIENT_TEMP
+				>;
+				buffer-name = "buffer1";
+				io-name = "ltc2990-1";
 			};
 		};
 	};
 
-	/* Emulated I2C bus */
+	/* Emulated I2C bus hosting both ADLTC2990 instances */
 	i2c_emul: i2c@100 {
 		compatible = "zephyr,i2c-emul-controller";
 		reg = <0x100 4>;
@@ -41,9 +60,22 @@
 		#size-cells = <0>;
 		status = "okay";
 
-		adltc2990_emul: adltc2990@4c {
+		adltc2990_emul_0: adltc2990@4c {
 			compatible = "adi,adltc2990";
 			reg = <0x4c>;
+			status = "okay";
+			measurement-mode = <0 0>;
+			pins-v1-v2-current-resistor = <0>;
+			pins-v3-v4-current-resistor = <0>;
+			pin-v1-voltage-divider-resistors = <500 1000>;
+			pin-v2-voltage-divider-resistors = <110000 100000>;
+			pin-v3-voltage-divider-resistors = <7000 1000>;
+			pin-v4-voltage-divider-resistors = <500 1000>;
+		};
+
+		adltc2990_emul_1: adltc2990@4e {
+			compatible = "adi,adltc2990";
+			reg = <0x4e>;
 			status = "okay";
 			measurement-mode = <0 0>;
 			pins-v1-v2-current-resistor = <0>;

--- a/zephyr/samples/iiod/pmod_acl.overlay
+++ b/zephyr/samples/iiod/pmod_acl.overlay
@@ -8,18 +8,20 @@
 
 / {
 	iio-context {
-		#address-cells = <1>;
-		#size-cells = <0>;
+		iio-sensors {
+			#address-cells = <1>;
+			#size-cells = <0>;
 
-		iio-device@1 {
-			compatible = "iio,sensor";
-			reg = <1>;
-			sensor-device = <&adxl345_pmod_acl>;
-			sensor-channels = <IIO_SENSOR_CHAN_ACCEL_X
-					   IIO_SENSOR_CHAN_ACCEL_Y
-					   IIO_SENSOR_CHAN_ACCEL_Z>;
-			buffer-name = "buffer0";
-			io-name = "adxl345";
+			adxl345@0 {
+				compatible = "iio,sensor";
+				reg = <0>;
+				sensor-device = <&adxl345_pmod_acl>;
+				sensor-channels = <IIO_SENSOR_CHAN_ACCEL_X
+						   IIO_SENSOR_CHAN_ACCEL_Y
+						   IIO_SENSOR_CHAN_ACCEL_Z>;
+				buffer-name = "buffer0";
+				io-name = "pmod-adxl345";
+			};
 		};
 	};
 };

--- a/zephyr/samples/iiod/sample.yaml
+++ b/zephyr/samples/iiod/sample.yaml
@@ -80,6 +80,16 @@ tests:
     platform_allow:
       - apard32690/max32690/m4
 
+  sample.iiod.console.multi-sensor-emul:
+    extra_args:
+      - SNIPPET=iiod-console
+    extra_configs:
+      - CONFIG_LIBIIO_IIOD_MULTI_SENSOR_EMUL=y
+    platform_allow:
+      - apard32690/max32690/m4
+      - adi_sdp_k1
+      - frdm_k64f
+
   sample.iiod.console.eval_ad4052_ardz:
     extra_args:
       - SNIPPET=iiod-console


### PR DESCRIPTION
## PR Description

Previously all IIO device nodes in the iiod sample overlays were flat children of iio-context, using a generic iio-device@N node name and a hand-allocated reg value to avoid collisions when multiple overlays are stacked:

{
iio-context {
#address-cells = <1>;
#size-cells = <0>;
iio-device@a { compatible = "iio,sensor"; reg = <10>; ... };
iio-device@0 { compatible = "iio,io-channels"; reg = <0>; ... };
};
};

This had problem:

Collision risk — reg values had to be manually allocated across all overlay files. Combining two overlays that happened to use the same @N address would silently merge the nodes, corrupting the device tree with no build error.

Solution: typed sub-bus containers
Each iio-context now contains typed sub-bus container nodes that own their own independent address space:

{
iio-context {
iio-adcs {
#address-cells = <1>;
#size-cells = <0>;
adc-emul@0 { compatible = "iio,io-channels"; reg = <0>; ... };
};
iio-sensors {
#address-cells = <1>;
#size-cells = <0>;
adxl345@0 { compatible = "iio,sensor"; reg = <0>; ... };
ltc2990@0 { compatible = "iio,sensor"; reg = <0>; ... };
};
};
};

Because each sub-bus has its own address space, reg starts from 0 in every container. Any combination of overlays is collision-free by construction — no manual allocation table is needed.

No C code changes are required. DT_INST_FOREACH_STATUS_OKAY scans the entire flattened device tree by compatible string and is completely insensitive to where in the tree a node lives. backend.c and all IIO device drivers (sensor.c, io_channels.c, trigger_*.c) are unchanged.

Node naming
Leaf node names follow the device name (@N) pattern used throughout the Zephyr tree for sub-device nodes (e.g. MFD children). The io-name property continues to carry the identity string exposed to libiio clients via iio_info.

Why reg cannot be removed
A new multi-sensor-emul.overlay is added to demonstrate the case that makes reg mandatory: two ADLTC2990 emulator instances in the same iio-sensors container. Without reg = and the @N unit-address, both nodes would share the path /iio-context/iio-sensors/ltc2990, which is a hard DTS error. With reg they become ltc2990@0 and ltc2990@1.

Before the two nodes would have an identical DT path:

/iio-context/iio-sensors/ltc2990 <-- collision, DTS error

With reg the paths are unique:

/iio-context/iio-sensors/ltc2990@0
/iio-context/iio-sensors/ltc2990@1

Signed-off-by: Dimitrije Lilic <dimitrije.lilic@orioninc.com>

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
