### PR TITLE
zephyr: iiod: network: consolidate hex debug with LOG_HEXDUMP_DBG

### DIFF
--- a/zephyr/iiod/network.c
+++ b/zephyr/iiod/network.c
@@ -64,7 +64,6 @@ static ssize_t iiod_network_read(struct iiod_pdata *pdata, void *buf, size_t siz
 	size_t bytes_read = 0;
 	int read = 0;
 	int this_fd;
-	int i;
 
 	if (!client) {
 		return -EPERM;
@@ -77,17 +76,12 @@ static ssize_t iiod_network_read(struct iiod_pdata *pdata, void *buf, size_t siz
 
 	while (bytes_read < size) {
 		read = recv(this_fd, buffer, size - bytes_read, 0);
+		LOG_DBG("[Client %d] Read %d/%d bytes", client->client_num, read, size);
+		LOG_HEXDUMP_DBG(buffer, read, "");
 
 		if (read > 0) {
-			if (read <= 20)
-				for(i = 0; i < size; i++) {
-					LOG_DBG("%02x ", buffer[i]);
-				}
 			buffer += read;
 			bytes_read += read;
-
-			LOG_DBG("[Client %d] Read %d characters from read_cb; size = %d",
-				client->client_num, read, size);
 		}
 		else if (read < 0) {
 			if (errno == ECONNRESET || errno == ENOTCONN) {
@@ -114,7 +108,6 @@ static ssize_t iiod_network_write(struct iiod_pdata *pdata, const void *buf, siz
 	int bytes_sent = 0;
 	int sent = 0;
 	int this_fd;
-	int i;
 
 	if (!client) {
 		return -EPERM;
@@ -127,6 +120,8 @@ static ssize_t iiod_network_write(struct iiod_pdata *pdata, const void *buf, siz
 
 	while (bytes_sent < size) {
 		sent = send(this_fd, buffer, size - bytes_sent, 0);
+		LOG_DBG("[Client %d] Wrote %d/%d bytes", client->client_num, sent, size);
+		LOG_HEXDUMP_DBG(buffer, sent, "");
 
 		if (sent < 0) {
 			LOG_ERR("[Client %d] error: send: %d",
@@ -134,17 +129,8 @@ static ssize_t iiod_network_write(struct iiod_pdata *pdata, const void *buf, siz
 			return -ESRCH;
 		}
 
-		if (sent <= 20) {
-			for(i = 0; i < size; i++) {
-				LOG_DBG("%02x ", buffer[i]);
-			}
-		}
-
 		buffer += sent;
 		bytes_sent += sent;
-
-		LOG_DBG("[Client %d] Written %d characters in write_cb; size = %zu; bytes_sent = %d",
-			client->client_num, sent, size, bytes_sent);
 	}
 
 	return (ssize_t)bytes_sent;


### PR DESCRIPTION
The read and write paths each had a separate hand-rolled for-loop that logged individual bytes via LOG_DBG(). Both loops iterated over `size` instead of the actual bytes transferred and were skipped for transfers larger than 20 bytes, producing incomplete and misleading output.

Replace both with LOG_HEXDUMP_DBG(), consolidating the duplicate hex data messages into a single, consistent debug helper that operates on the actual transfer length. Remove the now-unused `int i` variables.

Assisted-by: Claude:claude-sonnet-4-6

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
