### PR TITLE
iiod-client: fix reg_write not waiting for its actual response

### DIFF
--- a/iiod-client.c
+++ b/iiod-client.c
@@ -1932,7 +1932,6 @@ int iiod_client_reg_write(struct iiod_client *client, const struct iio_device *d
 	struct iiod_io *io = iiod_responder_get_default_io(client->responder);
 	struct iiod_command cmd;
 	struct iiod_buf buf;
-	int ret;
 
 	cmd.op = IIOD_OP_REG_WRITE;
 	cmd.dev = (uint8_t)iio_device_get_index(dev);
@@ -1941,11 +1940,7 @@ int iiod_client_reg_write(struct iiod_client *client, const struct iio_device *d
 	buf.ptr = &value;
 	buf.size = sizeof(value);
 
-	ret = iiod_io_send_command(io, &cmd, &buf, 1);
-	if (ret < 0)
-		return ret;
-
-	return iiod_io_wait_for_command_done(io);
+	return iiod_io_exec_command(io, &cmd, &buf, NULL);
 }
 
 int iiod_client_nop(struct iiod_client *client)


### PR DESCRIPTION
## PR Description

`iiod_client_reg_write()` sent its command but never actually waited for the server's response - it only confirmed the outgoing write was flushed, so it never registered as a reader for the reply. That unclaimed response could then be consumed by whatever unrelated command issued the next request on the shared `default_io` channel, corrupting that command's result.

### Changes
- Replace the manual `iiod_io_send_command()` + `iiod_io_wait_for_command_done()` sequence in `iiod_client_reg_write()` with `iiod_io_exec_command()`, which registers for and waits on the matching response

### How it works
1. `iiod_client_reg_write()` builds the `IIOD_OP_REG_WRITE` command and value buffer as before.
2. It now calls `iiod_io_exec_command(io, &cmd, &buf, NULL)`, matching the pattern already used by `iiod_client_reg_read()`.
3. `iiod_io_exec_command()` registers as the reader before sending, so the reply is always matched to the call that issued it.

### Testing
Verified against real M2k hardware (`ad9963`): wrote/read back a register 50 times, including back-to-back writes immediately followed by an unrelated attribute read (the interleaving that previously risked misdelivery). All 50 iterations passed with correct values and no mismatches.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
