### PR TITLE
Fix macOS framework installation path for OSX_PACKAGE=OFF

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -404,7 +404,7 @@ stages:
     - script: |
         set -e
         mkdir build_tar && cd build_tar
-        cmake .. -DCMAKE_BUILD_TYPE=$(cmakeBuildType) -Werror=dev -DCOMPILE_WARNING_AS_ERROR=ON -DOSX_PACKAGE=OFF -DENABLE_PACKAGING=ON -DWITH_SERIAL_BACKEND=ON -DWITH_EMU_BACKEND=ON -DCPACK_SYSTEM_NAME=${ARTIFACTNAME}
+        cmake .. -DCMAKE_BUILD_TYPE=$(cmakeBuildType) -DCMAKE_INSTALL_PREFIX=/ -Werror=dev -DCOMPILE_WARNING_AS_ERROR=ON -DOSX_PACKAGE=OFF -DENABLE_PACKAGING=ON -DWITH_SERIAL_BACKEND=ON -DWITH_EMU_BACKEND=ON -DCPACK_SYSTEM_NAME=${ARTIFACTNAME}
         make
         make package
         mv ../CI/azure/macos_tar_fixup.sh .

--- a/cmake/Install.cmake
+++ b/cmake/Install.cmake
@@ -25,9 +25,13 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(OSX_INSTALL_FRAMEWORKSDIR
         "/Library/Frameworks"
         CACHE STRING "Installation directory for frameworks")
-    get_filename_component(
-        OSX_INSTALL_FRAMEWORKSDIR "${OSX_INSTALL_FRAMEWORKSDIR}" REALPATH
-        BASE_DIR "${CMAKE_BINARY_DIR}")
+
+    # For normal installs (OSX_PACKAGE=OFF), use relative path to avoid CMake
+    # errors about absolute install destinations. The absolute path is only
+    # used by pkgbuild when OSX_PACKAGE=ON.
+    if (NOT OSX_PACKAGE AND IS_ABSOLUTE "${OSX_INSTALL_FRAMEWORKSDIR}")
+        set(OSX_INSTALL_FRAMEWORKSDIR "Library/Frameworks")
+    endif()
 
     set(CMAKE_MACOSX_RPATH ON)
     set(SKIP_INSTALL_ALL ${OSX_PACKAGE})


### PR DESCRIPTION
## PR Description

CMake 3.14+ rejects absolute paths in install() DESTINATION by default. When OSX_PACKAGE=OFF (used in CI for tarball creation), the absolute path /Library/Frameworks triggers an install-absolute-destination error.

Convert OSX_INSTALL_FRAMEWORKSDIR to a relative path when OSX_PACKAGE=OFF, and set CMAKE_INSTALL_PREFIX=/ in the Azure pipeline tarball build. This ensures the framework installs to /Library/Frameworks (resolving the relative path against the root prefix), which CPack then packages as Library/Frameworks/... in the tarball - exactly what macos_tar_fixup.sh expects.

When OSX_PACKAGE=ON (default for local Mac builds), the absolute path is preserved for use by pkgbuild, and SKIP_INSTALL_ALL prevents the install() commands from running anyway.

Fixes Azure Pipelines macOS builds (macOS_15_x64).

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
