### PR TITLE
bindings: python: fix iio_device_get_trigger for v1.0 API

### DIFF
--- a/bindings/python/iio/__init__.py
+++ b/bindings/python/iio/__init__.py
@@ -80,6 +80,12 @@ def _check_ptr_err(result, func, arguments):
     return result
 
 
+def _check_ptr_err_allow_null(result, func, arguments):
+    if result is None:
+        return result
+    return _check_ptr_err(result, func, arguments)
+
+
 # pylint: enable=unused-argument
 
 # Python 2 and Python 3 compatible _isstring function.
@@ -599,12 +605,9 @@ _d_is_trigger.restype = c_bool
 _d_is_trigger.argtypes = (_DevicePtr,)
 
 _d_get_trigger = _lib.iio_device_get_trigger
-_d_get_trigger.restype = c_int
-_d_get_trigger.argtypes = (
-    _DevicePtr,
-    _POINTER(_DevicePtr),
-)
-_d_get_trigger.errcheck = _check_negative
+_d_get_trigger.restype = c_void_p
+_d_get_trigger.argtypes = (_DevicePtr,)
+_d_get_trigger.errcheck = _check_ptr_err_allow_null
 
 _d_set_trigger = _lib.iio_device_set_trigger
 _d_set_trigger.restype = c_int
@@ -1559,9 +1562,11 @@ class Device(_DeviceOrTrigger):
         _d_set_trigger(self._device, trigger._device if trigger else None)
 
     def _get_trigger(self):
-        value = _DevicePtr()
-        _d_get_trigger(self._device, _byref(value))
-        trig = Trigger(self.ctx, value.contents)
+        raw = _d_get_trigger(self._device)
+        if not raw:
+            return None
+        ptr = cast(raw, _DevicePtr)
+        trig = Trigger(self.ctx, ptr)
 
         for dev in self.ctx.devices:
             if trig.id == dev.id:


### PR DESCRIPTION
The v1.0 C API changed iio_device_get_trigger to return the trigger device pointer directly (NULL if none, error-encoded pointer on failure) instead of writing to an out-parameter. Update the Python binding to match.

Assisted-by: Claude:claude-opus-4.6

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
