### PR TITLE
[RFC] local: fix mmap/dmabuf block hang on small block sizes

### DIFF
--- a/local-dmabuf.c
+++ b/local-dmabuf.c
@@ -195,6 +195,10 @@ struct iio_block_pdata *local_create_dmabuf(
 
 	pdata->dmabuf_supported = true;
 
+	/* Keep the smallest block size seen on this buffer. */
+	if (!pdata->size || size < pdata->size)
+		pdata->size = size;
+
 	close(devfd);
 
 	return priv;

--- a/local-mmap.c
+++ b/local-mmap.c
@@ -142,6 +142,10 @@ struct iio_block_pdata *local_create_mmap_block(
 	*data = priv->pdata.data;
 	ppdata->mmap_block_mask |= IIO_BIT(priv->idx);
 
+	/* Keep the smallest block size seen on this buffer. */
+	if (!pdata->size || priv->block.size < pdata->size)
+		pdata->size = priv->block.size;
+
 	return &priv->pdata;
 
 out_free_priv:

--- a/local.c
+++ b/local.c
@@ -289,16 +289,27 @@ static int local_enable_buffer(
 		struct iio_buffer_pdata *pdata, size_t nb_samples, bool enable, bool cyclic)
 {
 	int ret;
+	size_t bufsize = nb_samples;
 
 	if ((pdata->dmabuf_supported | pdata->mmap_supported) != !nb_samples)
 		return -EINVAL;
 
-	if (enable && nb_samples) {
-		ret = local_set_buffer_size(pdata, nb_samples);
+	/*
+	 * The read/write path sizes length/watermark in samples
+	 * (nb_samples). mmap/dmabuf always pass nb_samples == 0 here, and
+	 * the kernel's DMA buffer core tracks their readiness in bytes, so
+	 * use pdata->size (the byte size of the smallest block allocated)
+	 * instead.
+	 */
+	if (!bufsize && (pdata->dmabuf_supported || pdata->mmap_supported))
+		bufsize = pdata->size;
+
+	if (enable && bufsize) {
+		ret = local_set_buffer_size(pdata, bufsize);
 		if (ret)
 			return ret;
 
-		ret = local_set_watermark(pdata, nb_samples);
+		ret = local_set_watermark(pdata, bufsize);
 		if (ret)
 			return ret;
 	}


### PR DESCRIPTION
## PR Description
This PR fixes a hang in the zero-copy mmap and DMABUF block APIs when a block smaller than the kernel driver's default watermark is used, by having libiio configure the kernel's `length`/`watermark` sysfs attributes to match the actual block size. This applies to any device streamed through `local_create_mmap_block()` / `local_create_dmabuf()`, e.g. `iio_rwdev`, `iio_readdev`, or any client using mmap/dmabuf directly.

**This is posted as a draft/RFC.** The fix works and is verified on hardware. From reading the kernel source, it looks like `poll()` on the buffer fd (libiio's `buffer_check_ready()` in `local.c` is where we wait on it) is gated by the kernel's `iio_buffer_ready()` comparing bytes available against `watermark`, and nothing sets `watermark` to match the block size or smaller on the mmap/dmabuf path, so a client requesting less data than the driver's default watermark hangs forever.


### Benefits
- Small mmap/DMABUF block sizes now stream reliably instead of hanging indefinitely in `poll()`

### Changes
- `local-mmap.c` / `local-dmabuf.c`: record the allocated block's byte size on the buffer's `iio_buffer_pdata` (`pdata->size`) when a block is created
- `local.c`: `local_enable_buffer()` falls back to that recorded size as the `length`/`watermark` value whenever `nb_samples == 0` on an mmap or dmabuf-backed buffer, instead of leaving the kernel's driver defaults untouched


### Hardware verification
Reproduced and fixed on an M2K over `iiod` (`iio:device4`, `m2k-adc`), using `iio_rwdev` against the mmap block path on real hardware:

Without the fix, `iio_rwdev -u ip:10.48.69.120 -b 10 -s 10 iio:device4` hangs and eventually times out:
(Note: the same output is seen running locally as well to rule out an iiod problem)
```
ERROR: iio:device4: Unable to dequeue block: Connection timed out (110)
ERROR: iio:device4: Unable to get next block: Connection timed out (110)
```

With the fix applied, the same exact command streams data immediately:
```
marius_lucacel@HYB-x65dZfDDJgW:~$ iio_rwdev -u ip:10.48.69.120 -b 10 -s 10 iio:device4
����������������&␦������������������
                                    ����        -����
```

The bug was found while testing a m2k with libiio v1 initially. I saw those error messages and came to the conclusion reading from a buffer works above a threshold which turns out to be given by the watermark.

## Open questions

1. Is it expected that libiio itself has to set `length`/`watermark` for the block API, given `BLOCK_ALLOC_IOCTL` already communicates the block size to the kernel out-of-band? If so, why doesn't this fix (or something equivalent) already exist in `local_enable_buffer()` or lower in the linux repo? Was this simply never hit because most existing users allocate blocks larger than the driver's default watermark?
2. Has anyone else hit this hang with libiio's mmap/dmabuf API before, and if so, was it worked around differently (e.g. by always allocating blocks larger than the default watermark) rather than by having libiio set `length`/`watermark` explicitly?
3. We've only reproduced and verified this hang (and the fix) on the mmap block path (`local-mmap.c`); we haven't exercised the DMABUF path (`local-dmabuf.c`) on hardware. This commit applies the identical `pdata->size` fix to both, but is the DMABUF path actually affected by this bug, or does it have some other mechanism that already avoids it?


## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
