### PR TITLE
[RFC]Avoid cached channel data format

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -440,6 +440,49 @@ long iio_channel_get_index(const struct iio_channel *chn)
 	return chn->index;
 }
 
+int iio_parse_channel_type(const char *format_str, struct iio_data_format *fmt)
+{
+	char endian, sign;
+	int err;
+
+	if (!format_str || !fmt)
+		return -EINVAL;
+
+	/* Parse format string with repeat count: "le:s16/16X4>>0" */
+	if (strchr(format_str, 'X')) {
+		err = iio_sscanf(format_str, "%ce:%c%u/%uX%u>>%u",
+#ifdef _MSC_BUILD
+				&endian, (unsigned int)sizeof(endian),
+				&sign, (unsigned int)sizeof(sign),
+#else
+				&endian, &sign,
+#endif
+				&fmt->bits, &fmt->length, &fmt->repeat, &fmt->shift);
+		if (err != 6)
+			return -EINVAL;
+	} else {
+		/* Parse format string without repeat count: "le:s16/16>>0" */
+		fmt->repeat = 1;
+		err = iio_sscanf(format_str, "%ce:%c%u/%u>>%u",
+#ifdef _MSC_BUILD
+				&endian, (unsigned int)sizeof(endian),
+				&sign, (unsigned int)sizeof(sign),
+#else
+				&endian, &sign,
+#endif
+				&fmt->bits, &fmt->length, &fmt->shift);
+		if (err != 5)
+			return -EINVAL;
+	}
+
+	/* Set format flags */
+	fmt->is_be = (endian == 'b');
+	fmt->is_signed = (sign == 's' || sign == 'S');
+	fmt->is_fully_defined = (sign == 'S' || sign == 'U' || fmt->bits == fmt->length);
+
+	return 0;
+}
+
 const struct iio_data_format *iio_channel_get_data_format(const struct iio_channel *chn)
 {
 	return &chn->format;

--- a/channel.c
+++ b/channel.c
@@ -485,6 +485,26 @@ int iio_parse_channel_type(const char *format_str, struct iio_data_format *fmt)
 
 const struct iio_data_format *iio_channel_get_data_format(const struct iio_channel *chn)
 {
+	const struct iio_attr *attr;
+	char type_str[64];
+	ssize_t ret;
+	struct iio_data_format new_format;
+
+	/* For scan elements, try to refresh format from "type" attribute */
+	if (chn->is_scan_element) {
+		attr = iio_channel_find_attr(chn, "type");
+		if (attr) {
+			ret = iio_attr_read_raw(attr, type_str, sizeof(type_str));
+			if (ret > 0) {
+				if (iio_parse_channel_type(type_str, &new_format) == 0) {
+					memcpy(&((struct iio_channel *)chn)->format,
+					       &new_format, sizeof(new_format));
+				}
+			}
+		}
+	}
+
+	/* Return cached format (either freshly updated or original) */
 	return &chn->format;
 }
 

--- a/device.c
+++ b/device.c
@@ -377,7 +377,7 @@ ssize_t iio_device_get_sample_size(
 
 	for (i = 0; i < dev->nb_channels; i++) {
 		const struct iio_channel *chn = dev->channels[i];
-		unsigned int length = chn->format.length / 8 * chn->format.repeat;
+		unsigned int length;
 
 		if (chn->index < 0)
 			break;
@@ -388,6 +388,11 @@ ssize_t iio_device_get_sample_size(
 			prev = chn;
 			continue;
 		}
+
+		if (chn->is_scan_element)
+			(void)iio_channel_get_data_format(chn);
+
+		length = chn->format.length / 8 * chn->format.repeat;
 
 		if (length > largest)
 			largest = length;

--- a/emu.c
+++ b/emu.c
@@ -563,35 +563,9 @@ static int setup_scan_element(
 				return -EINVAL;
 			*index = (long)value;
 		} else if (!strcmp(name, "format")) {
-			char e, s;
-			if (strchr(content, 'X')) {
-				err = iio_sscanf(content, "%ce:%c%u/%uX%u>>%u",
-#ifdef _MSC_BUILD
-						&e, (unsigned int)sizeof(e), &s,
-						(unsigned int)sizeof(s),
-#else
-						&e, &s,
-#endif
-						&fmt->bits, &fmt->length, &fmt->repeat,
-						&fmt->shift);
-				if (err != 6)
-					return -EINVAL;
-			} else {
-				fmt->repeat = 1;
-				err = iio_sscanf(content, "%ce:%c%u/%u>>%u",
-#ifdef _MSC_BUILD
-						&e, (unsigned int)sizeof(e), &s,
-						(unsigned int)sizeof(s),
-#else
-						&e, &s,
-#endif
-						&fmt->bits, &fmt->length, &fmt->shift);
-				if (err != 5)
-					return -EINVAL;
-			}
-			fmt->is_be = e == 'b';
-			fmt->is_signed = (s == 's' || s == 'S');
-			fmt->is_fully_defined = (s == 'S' || s == 'U' || fmt->bits == fmt->length);
+			err = iio_parse_channel_type(content, fmt);
+			if (err)
+				return err;
 		} else if (!strcmp(name, "scale")) {
 			char *end;
 			float value;

--- a/iio-private.h
+++ b/iio-private.h
@@ -231,6 +231,7 @@ int iio_dynamic_scan(const struct iio_context_params *params, struct iio_scan *c
 
 void iio_channel_init_finalize(struct iio_channel *chn);
 unsigned int find_channel_modifier(const char *s, size_t *len_p);
+int iio_parse_channel_type(const char *format_str, struct iio_data_format *fmt);
 
 char *iio_strndup(const char *str, size_t n);
 char *iio_strtok_r(char *str, const char *delim, char **saveptr);

--- a/include/iio/iio.h
+++ b/include/iio/iio.h
@@ -1546,8 +1546,17 @@ __api __check_ret __pure long iio_channel_get_index(const struct iio_channel *ch
 
 /** @brief Get a pointer to a channel's data format structure
  * @param chn A pointer to an iio_channel structure
+ *
+ * For scan element channels, this function attempts to refresh the format by
+ * reading the "type" attribute. If the read succeeds, the cached format is
+ * updated. If the read fails or the "type" attribute doesn't exist, the
+ * cached format is returned.
+ *
+ * Note: This function may perform I/O (sysfs read for local backend, network
+ * round-trip for network backends).
+ *
  * @return A pointer to the channel's iio_data_format structure */
-__api __check_ret __cnst const struct iio_data_format *iio_channel_get_data_format(
+__api __check_ret const struct iio_data_format *iio_channel_get_data_format(
 		const struct iio_channel *chn);
 
 /** @brief Convert the sample from hardware format to host format

--- a/local.c
+++ b/local.c
@@ -1143,18 +1143,28 @@ static int add_scan_element(void *d, const char *path)
 	if (string_ends_with(attr, "_en"))
 		return iio_buffer_add_scan_element(buffer, chn, attr_path);
 
-	/* _index and _type are very much constant for the channel (even if the channel is
+	/* _index is constant for the channel (even if the channel is
 	 * present in multiple buffers). Hence, if the channel is already marked as a scan, don't
 	 * bother in getting those attributes again.
-	 *
-	 * !\FIXME: In fact, the above is not quite true for _type as we can have multiple scan
-	 * types for the same channel (that can change at runtime). But that is not currently
-	 * supported anyways.
 	 */
 	if (string_ends_with(attr, "_index"))
 		return handle_scan_element_attr(chn, "index", attr_path);
 
-	return handle_scan_element_attr(chn, "type", attr_path);
+	/* _type can change at runtime on some devices (e.g., when oversampling_ratio
+	 * or resolution attributes are modified). Expose it as a channel attribute
+	 * so users can refresh it dynamically.
+	 */
+	if (string_ends_with(attr, "_type")) {
+		/* Add as a channel attribute for dynamic access */
+		ret = iio_channel_add_attr(chn, "type", IIO_ATTR_TYPE_CHANNEL, attr_path);
+		if (ret < 0)
+			return ret;
+
+		/* Also parse and cache initially */
+		return handle_scan_element_attr(chn, "type", attr_path);
+	}
+
+	return -EINVAL;
 }
 
 static bool is_scan_element_attr(const char *name)

--- a/local.c
+++ b/local.c
@@ -832,34 +832,8 @@ static int handle_scan_element_attr(struct iio_channel *chn, const char *name, c
 		}
 	} else if (!strcmp(name, "type")) {
 		ret = local_read_dev_attr(dev, 0, path, buf, sizeof(buf), IIO_ATTR_TYPE_DEVICE);
-		if (ret > 0) {
-			char endian, sign;
-
-			if (strchr(buf, 'X')) {
-				iio_sscanf(buf, "%ce:%c%u/%uX%u>>%u",
-#ifdef _MSC_BUILD
-						&endian, sizeof(endian), &sign, sizeof(sign),
-#else
-						&endian, &sign,
-#endif
-						&chn->format.bits, &chn->format.length,
-						&chn->format.repeat, &chn->format.shift);
-			} else {
-				chn->format.repeat = 1;
-				iio_sscanf(buf, "%ce:%c%u/%u>>%u",
-#ifdef _MSC_BUILD
-						&endian, sizeof(endian), &sign, sizeof(sign),
-#else
-						&endian, &sign,
-#endif
-						&chn->format.bits, &chn->format.length,
-						&chn->format.shift);
-			}
-			chn->format.is_signed = (sign == 's' || sign == 'S');
-			chn->format.is_fully_defined = (sign == 'S' || sign == 'U' ||
-							chn->format.bits == chn->format.length);
-			chn->format.is_be = endian == 'b';
-		}
+		if (ret > 0)
+			ret = iio_parse_channel_type(buf, &chn->format);
 	} else {
 		return -EINVAL;
 	}

--- a/xml.c
+++ b/xml.c
@@ -15,6 +15,7 @@
 #include <string.h>
 
 #include "attr.h"
+#include "iio-private.h"
 
 #define XML_HEADER "<?xml version=\"1.0\""
 
@@ -101,35 +102,9 @@ static int setup_scan_element(
 				return -EINVAL;
 			*index = (long)value;
 		} else if (!strcmp(name, "format")) {
-			char e, s;
-			if (strchr(content, 'X')) {
-				err = iio_sscanf(content, "%ce:%c%u/%uX%u>>%u",
-#ifdef _MSC_BUILD
-						&e, (unsigned int)sizeof(e), &s,
-						(unsigned int)sizeof(s),
-#else
-						&e, &s,
-#endif
-						&fmt->bits, &fmt->length, &fmt->repeat,
-						&fmt->shift);
-				if (err != 6)
-					return -EINVAL;
-			} else {
-				fmt->repeat = 1;
-				err = iio_sscanf(content, "%ce:%c%u/%u>>%u",
-#ifdef _MSC_BUILD
-						&e, (unsigned int)sizeof(e), &s,
-						(unsigned int)sizeof(s),
-#else
-						&e, &s,
-#endif
-						&fmt->bits, &fmt->length, &fmt->shift);
-				if (err != 5)
-					return -EINVAL;
-			}
-			fmt->is_be = e == 'b';
-			fmt->is_signed = (s == 's' || s == 'S');
-			fmt->is_fully_defined = (s == 'S' || s == 'U' || fmt->bits == fmt->length);
+			err = iio_parse_channel_type(content, fmt);
+			if (err)
+				return err;
 		} else if (!strcmp(name, "scale")) {
 			char *end;
 			float value;


### PR DESCRIPTION
## PR Description

Change the behaviour of the `iio_channel_get_data_format()` to read the most up to date information regarding the samples format of the channel. This is opposed to retrieving the cached information that was put together at context creation time.
It leverages the existing attribute reading functionality. So, it does not require a new IIOD command.

## Some observations:
1. This approach cause the "type" attribute to be called a number of times. Reading 1024 samples from a device having 4 channels causes "type" to be read 32 times.
```
sudo utils/iio_rwdev -s 1024 cf-ad9361-lpc > data.bin
get_sample_size(), Call count: 1
get_data_format(). Call no: 1
get_data_format(). Call no: 2
get_data_format(). Call no: 3
get_data_format(). Call no: 4
get_sample_size(), Call count: 2
get_data_format(). Call no: 5
get_data_format(). Call no: 6
get_data_format(). Call no: 7
get_data_format(). Call no: 8
get_sample_size(), Call count: 3
get_data_format(). Call no: 9
get_data_format(). Call no: 10
get_data_format(). Call no: 11
get_data_format(). Call no: 12
get_sample_size(), Call count: 4
get_data_format(). Call no: 13
get_data_format(). Call no: 14
get_data_format(). Call no: 15
get_data_format(). Call no: 16
get_sample_size(), Call count: 5
get_data_format(). Call no: 17
get_data_format(). Call no: 18
get_data_format(). Call no: 19
get_data_format(). Call no: 20
get_sample_size(), Call count: 6
get_data_format(). Call no: 21
get_data_format(). Call no: 22
get_data_format(). Call no: 23
get_data_format(). Call no: 24
get_sample_size(), Call count: 7
get_data_format(). Call no: 25
get_data_format(). Call no: 26
get_data_format(). Call no: 27
get_data_format(). Call no: 28
get_sample_size(), Call count: 8
get_data_format(). Call no: 29
get_data_format(). Call no: 30
get_data_format(). Call no: 31
get_data_format(). Call no: 32
```

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
