### PR TITLE
network: guard refresh_format with binary check

### DIFF
--- a/network.c
+++ b/network.c
@@ -530,6 +530,9 @@ static int network_refresh_format(const struct iio_channel *chn)
 	char format_str[256];
 	ssize_t ret;
 
+	if (!iiod_client_uses_binary_interface(pdata->iiod_client))
+		return -ENOTSUP;
+
 	ret = iiod_client_refresh_format(pdata->iiod_client, dev, chn,
 	                                   format_str, sizeof(format_str));
 	if (ret < 0)

--- a/serial.c
+++ b/serial.c
@@ -324,6 +324,9 @@ static int serial_refresh_format(const struct iio_channel *chn)
 	char format_str[256];
 	ssize_t ret;
 
+	if (!iiod_client_uses_binary_interface(pdata->iiod_client))
+		return -ENOTSUP;
+
 	ret = iiod_client_refresh_format(pdata->iiod_client, dev, chn,
 	                                   format_str, sizeof(format_str));
 	if (ret < 0)

--- a/usb.c
+++ b/usb.c
@@ -530,6 +530,9 @@ static int usb_refresh_format(const struct iio_channel *chn)
 	char format_str[256];
 	ssize_t ret;
 
+	if (!iiod_client_uses_binary_interface(pdata->io_ctx.iiod_client))
+		return -ENOTSUP;
+
 	ret = iiod_client_refresh_format(pdata->io_ctx.iiod_client, dev, chn,
 	                                   format_str, sizeof(format_str));
 	if (ret < 0)


### PR DESCRIPTION


## PR Description

network_refresh_format() uses iiod_client_refresh_format(), which sends the IIOD_OP_REFRESH_FORMAT binary command through the responder default I/O.

When connected to an older IIOD server that does not support the BINARY command, the client has no responder. Calling the binary refresh helper in that state dereferences a NULL responder.

Match the existing reg_read/reg_write behavior and return -ENOTSUP.

Stack trace:
```
(gdb) bt full
#0  0x00007ffff7fae5a0 in iiod_responder_get_default_io (priv=0x0) at /data/repos/libiio/iiod-responder.c:786
No locals.
#1  0x00007ffff7facea4 in iiod_client_refresh_format (client=0x409010, dev=0x4da8e0, chn=0x4dacc0,
    format_str=0x7fffffffb750 "\016", len=256) at /data/repos/libiio/iiod-client.c:1951
        io = 0x421db0
        cmd = {client_id = 36175, op = 248 '\370', dev = 247 '\367', code = 32767}
        iiod_buf = {ptr = 0x7fffffffb784, size = 4215645}
#2  0x00007ffff7fa416c in network_refresh_format (chn=0x4dacc0) at /data/repos/libiio/network.c:533
        dev = 0x4da8e0
        ctx = 0x421db0
        pdata = 0x4095d0
        new_format = {length = 2, bits = 0, shift = 4199206, is_signed = false, is_fully_defined = false, is_be = false,
          with_scale = false, scale = 0, repeat = 4294967295, offset = 6.9533490432051762e-310}
        chn_rw = 0x4dacc0
        format_str = "\016\000\000\000\000\000\000\000xr\246\367\377\177\000\000\210\234\325\367\377\177\000\000\364\343\374\367\377\177\000\000\323\t\000\000\000\000\000\000\275\335\374\367\377\177\000\000\000u\246\367", '\000' <repeats 12 times>, "н\373\367\377\177\000\000O\215\370\367\377\177\000\000\360s\246\367\377\177\000\000н\373\367\377\177\000\000x\301\373\367\377\177\000\000\000\271\377\377\377\177\000\000\314?\f\257\000\000\000\000E\355\374\367\377\177\000\000\002\000\000\000\000\000\000\000\360s\246\367\377\177\000\000\001", '\000' <repeats 15 times>, "\001\000\000\000\000\000\000\000н\373\367\377\177\000\000(\271\377\377\377\177\000\000\001\000\000\000\377\177", '\000' <repeats 18 times>...
        ret = 140737353859856
#3  0x00007ffff7f9133f in iio_channel_refresh_format (chn=0x4dacc0) at /data/repos/libiio/channel.c:500
        dev = 0x4da8e0
        ops = 0x7ffff7fb9c60 <network_ops>
#4  0x00007ffff7f93a43 in iio_context_update_scale_offset (ctx=0x421db0) at /data/repos/libiio/context.c:707
        attr = 0x0
        chn = 0x4dacc0
        dev = 0x4da8e0
        i = 4
        j = 0
        err = 3
#5  0x00007ffff7f9405c in iio_create_context (params=0x7fffffffc620, uri=0x409430 "ip:10.44.3.137")
    at /data/repos/libiio/context.c:789
        params2 = {out = 0x0, err = 0x0, log_level = LEVEL_INFO, stderr_level = LEVEL_WARNING,
          timestamp_level = LEVEL_DEBUG, timeout_ms = 5000, flags = 0, __rsrv = '\000' <repeats 31 times>}
        backend = 0x7ffff7fb99c0 <iio_ip_backend>
        ctx = 0x421db0
        uri_dup = 0x0
--Type <RET> for more, q to quit, c to continue without paging--
        i = 2
        err = -134881696
#6  0x0000000000404660 in handle_common_opts (name=0x405354 "iio_info", argc=3, argv=0x4093c0, optstring=0x40535d "dn",
    options=0x405040 <options>, options_descriptions=0x4082b0 <options_descriptions>, default_params=0x0,
    err_code=0x7fffffffcae4) at /data/repos/libiio/utils/iio_common.c:357
        ctx = 0x0
        params = {out = 0x0, err = 0x0, log_level = 0, stderr_level = 0, timestamp_level = 0, timeout_ms = 0, flags = 0,
          __rsrv = '\000' <repeats 31 times>}
        backend = IIO_URI
        arg = 0x409430 "ip:10.44.3.137"
        do_scan = false
        detect_context = false
        buf = "hVu:a::S::T:dn\000\000\330\314\377\377\377\177\000\000N\177\375\367\377\177\000\000 \n\326\367\377\177\000\000\276\212\340\367\377\177\000\000@\306\377\377\377\177\000\000p\306\377\377\377\177\000\000\003\000\000\000\000\000\000\000\000\320\377\367\377\177\000\000\330\314\377\377\377\177\000\000N\177\375\367\377\177\000\000\366\320\377\377\377\177\000\000\000\000\000\000\000\000\000\000\377\000\000\000\000\000\000\000\377\000\000\000\000\000\000\000\366\320\377\377\377\177\000\000 \000\000\000\000\000\000\000\300\n\365\367\377\177\000\000N\177\375\367\377\177\000\000\310\346\365\367\377\177\000\000\320}@\000\000\000\000\000\330\314\377\377\377\177\000\000\200\037\000\000\377\377\000\000\001\000\000\000\000\000\000\000"...
        opts = 0x409450
        err = -14656
        c = -1
#7  0x0000000000402ec6 in main (argc=3, argv=0x7fffffffccb8) at /data/repos/libiio/utils/iio_info.c:270
        argw = 0x4093c0
        dev = 0x7ffff7fc5663 <_dl_catch_error+37>
        trig = 0x2f8
        ch = 0x800
        name = 0x7fffffffcb97 ""
        label = 0x7ffff7dff8df <__libc_malloc2+241> "H\205\300t\217H\213P\370\366\302\002u\206\203\342\004\017\204}\377\377\377H\215P\360H\215\r\277\021\025"
        i = 32767
        j = 4158564126
        k = 0
        nb_devices = 0
        nb_channels = 4294967295
        nb_ctx_attrs = 4232048
        nb_attrs = 4294967240
        nb_buffers = 0
        mask = 0x7ffff7ffcac0 <_rtld_local_ro>
        attr = 0x40
        buffer = 0x840
        stream = 0x18
        opts = 0x409370
        c = 0
        ret = 1
        read_sysfs_attr = true
        read_debug_attr = false
```

Solves v1 host to v0.26 eval

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
