### PR TITLE
tests: api: skip instead of crashing on null context

### DIFF
--- a/tests/api/test_channel.c
+++ b/tests/api/test_channel.c
@@ -190,6 +190,11 @@ TEST_FUNCTION(channel_mask_operations)
 {
 	setup_test_channel();
 
+	if (!test_ctx) {
+		DEBUG_PRINT("  SKIP: No test context available\n");
+		return;
+	}
+
 	/* Find a channel that is a scan element in order to test enabling/disabling */
 	struct iio_channel *iio_chn = NULL;
 	unsigned int nb_devices = iio_context_get_devices_count(test_ctx);

--- a/tests/api/test_context.c
+++ b/tests/api/test_context.c
@@ -73,9 +73,8 @@ TEST_FUNCTION(context_creation_with_params)
 	};
 
 	struct iio_context *ctx = create_test_context("TESTS_API_URI", "local:", &params);
-	if (iio_err(ctx)) {
-		DEBUG_PRINT("  INFO: Context creation with params failed with error %d\n",
-				iio_err(ctx));
+	if (!ctx) {
+		DEBUG_PRINT("  SKIP: No context for params test\n");
 		return;
 	}
 

--- a/tests/api/test_lowlevel.c
+++ b/tests/api/test_lowlevel.c
@@ -35,7 +35,7 @@ TEST_FUNCTION(channels_mask_operations)
 TEST_FUNCTION(sample_size_calculation)
 {
 	struct iio_context *ctx = create_test_context("TESTS_API_URI", "local:", NULL);
-	if (iio_err(ctx) && !ctx) {
+	if (!ctx) {
 		DEBUG_PRINT("  SKIP: No context for sample size test\n");
 		TEST_ASSERT(true, "Sample size test skipped");
 		return;


### PR DESCRIPTION
When libiio is built without the local backend and TESTS_API_URI is unset, three api tests (test_context, test_channel, test_lowlevel) dereference a NULL context instead of skipping: two segfault, one fails an assertion. This makes their skip guards work.

Why the guards were dead: create_test_context() normalises every failure to NULL, it returns NULL whenever iio_err() is set and otherwise returns the context (tests/test_helpers.h:22-27). So by the time a test body runs, iio_err(ctx) is always 0, the if (iio_err(ctx)) guards could never fire, and the code fell through to a NULL dereference. The fix guards on the pointer instead (if (!ctx) / if (!test_ctx)), the skip idiom the other api tests already use.

The skip policy these tests were meant to honour was added in #1447 (May 2026): "Skip tests if no backend available ... This ensures tests run in environments with varying backend support" (tests/api/README.md:104-115). That PR added the README and the emu variants but not the guards in these three bodies.

Verified in a container build with no local backend: the three now skip cleanly instead of two segfaults and one failure. CI config (WITH_LOCAL_BACKEND=ON): full suite still 49/49, zero added skips. Emu subset: 36/36.

setup_test_channel() keeps a fourth, redundant iio_err() check on the same normalised return; harmless, left as-is, happy to clean it up in a follow-up.

Not tested: Linux x86_64 in a container only, no real hardware.

## PR Type

- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist

- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)