### PR TITLE
csharp: Add ErrorCode property to IIOException

### DIFF
--- a/bindings/csharp/IioLib.cs
+++ b/bindings/csharp/IioLib.cs
@@ -52,6 +52,13 @@ namespace iio
 
     public class IIOException : Exception
     {
+        /// <summary>Default value of <see cref="ErrorCode"/> when no error code is associated with the exception.</summary>
+        public const int NoErrorCode = 0;
+
+        /// <summary>The underlying negative errno-style error code associated with this exception,
+        /// or <see cref="NoErrorCode"/> if none is available.</summary>
+        public int ErrorCode { get; private set; }
+
         public IIOException(string fmt) : base(fmt)
         {
         }
@@ -59,11 +66,13 @@ namespace iio
         public IIOException(string fmt, IIOPtr ptr)
             : base(string.Format("{0}: {1}", fmt, ptr.str()))
         {
+            ErrorCode = ptr.computeError();
         }
 
         public IIOException(string fmt, int err)
 	    : base(string.Format("{0}: {1}", fmt, IioLib.strerror(err)))
         {
+            ErrorCode = err;
         }
     }
 


### PR DESCRIPTION
## PR Description
Adds an **`ErrorCode`** property to `IIOException` in the C# bindings, so client code can check the actual error code instead of parsing the exception message string.

### Benefits
- No more parsing message strings to figure out what failed
- Works for both native errno failures and the wrapper's own validation errors
- No behavior change for existing code

### Changes
- `IIOException.NoErrorCode`: const `0`, means no code, wrapper only error
- `IIOException.ErrorCode`: new `{ get; private set; }` property
- `IIOException(string, IIOPtr)` constructor: sets `ErrorCode` from `ptr.computeError()`
- `IIOException(string, int)` constructor: sets `ErrorCode` from `err`

### How it works
1. A native call fails and returns an `IIOPtr` or `int` errno.
2. The `IIOException` constructor stores it in `ErrorCode`.
3. Wrapper only errors, like `Context.get_device()` on an unknown name, use the message only constructor, so `ErrorCode` stays `NoErrorCode`.
4. The caller catches `IIOException`, and reads `ex.ErrorCode`.


Tested against real hardware (ZCU102 board over `ip:`), confirming real error codes like `-EACCES`, `-ENOTSUP`, and `-EINVAL`, alongside the `NoErrorCode` case for wrapper only validation errors.

### Usage
```csharp
try {
    ctx.get_device("hwmon0").reg_read(
} catch (IIOException ex) {
    if (ex.ErrorCode == IIOException.N
        // wrapper side validation error, no native call happened
    } else {
        // real errno, e.g. -EACCES, -
    }
}
```
## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
