### PR TITLE
cmake: place iio_tests_helper.a in build root, not build/utils

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -89,7 +89,7 @@ endif ()
 if (PTHREAD_LIBRARIES OR ANDROID)
     project(iio_adi_xflow_check C)
     add_executable(iio_adi_xflow_check iio_adi_xflow_check.c)
-    target_link_libraries(iio_adi_xflow_check iio iio_tests_helper
+    target_link_libraries(iio_adi_xflow_check iio iio_utils_helper
                           ${PTHREAD_LIBRARIES})
     set(IIO_EXAMPLES_TARGETS ${IIO_EXAMPLES_TARGETS} iio_adi_xflow_check)
 endif ()

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -17,17 +17,17 @@ if (WIN32)
     configure_file(../properties.rc.cmakein ${LIBIIO_RC} @ONLY)
 endif ()
 
-add_library(iio_tests_helper STATIC iio_common.c gen_code.c)
-target_link_libraries(iio_tests_helper LINK_PRIVATE iio iio_common_config)
+add_library(iio_utils_helper OBJECT iio_common.c gen_code.c)
+target_link_libraries(iio_utils_helper LINK_PRIVATE iio iio_common_config)
 target_compile_definitions(iio_common_config INTERFACE _POSIX_C_SOURCE=200809L)
 if (MSVC)
-    target_sources(iio_tests_helper PRIVATE ../deps/wingetopt/src/getopt.c)
-    target_include_directories(iio_tests_helper PUBLIC ../deps/wingetopt/src)
-    target_compile_definitions(iio_tests_helper PRIVATE _CRT_SECURE_NO_WARNINGS)
-    target_link_options(iio_tests_helper PUBLIC /DEBUG)
+    target_sources(iio_utils_helper PRIVATE ../deps/wingetopt/src/getopt.c)
+    target_include_directories(iio_utils_helper PUBLIC ../deps/wingetopt/src)
+    target_compile_definitions(iio_utils_helper PRIVATE _CRT_SECURE_NO_WARNINGS)
+    target_link_options(iio_utils_helper PUBLIC /DEBUG)
 endif ()
 set_target_properties(
-    iio_tests_helper
+    iio_utils_helper
     PROPERTIES C_STANDARD 99
                C_STANDARD_REQUIRED ON
                C_EXTENSIONS OFF)
@@ -43,7 +43,7 @@ foreach (test ${IIO_UTILS_TARGETS})
     if (CMAKE_COMPILER_IS_GNUCC)
         target_compile_definitions(${test} PRIVATE IIO_CHECK_RET)
     endif ()
-    target_link_libraries(${test} LINK_PRIVATE iio iio_tests_helper)
+    target_link_libraries(${test} LINK_PRIVATE iio iio_utils_helper)
     if (MSVC)
         target_link_options(${test} PUBLIC /DEBUG)
     endif ()


### PR DESCRIPTION
## PR Description
`iio_tests_helper` was an internal static library used only to link the utils/ command-line tools (`iio_info`, `iio_attr`, etc.) and the `iio_adi_xflow_check` example. It's declared in `utils/CMakeLists.txt`, so CMake defaulted its archive output to `build/utils/`, mixed in alongside the actual utility executables it's meant to hold. It's also unrelated to the real test suite in `tests/api/`, despite the name.

### Benefits
- `build/utils/` now contains only the utility executables, no internal linking artifact
- No archive is ever built, so there's nothing to place or track an output directory for
- Name (`iio_utils_helper`) now matches what the library actually does

### Changes
- `utils/CMakeLists.txt`: change `iio_tests_helper` from a `STATIC` library to an `OBJECT` library
- Rename `iio_tests_helper` to `iio_utils_helper` throughout `utils/CMakeLists.txt` and `examples/CMakeLists.txt`

### Tests
- Clean build from this branch: exit 0, `find` confirms no `.a`/archive exists anywhere in the build tree for this target
- Both functions the library provides verified working: context autodetect (`iio_info -a`) and code-gen (`iio_attr -g`)

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
