### PR TITLE
csharp: remove unreachable Dispose() in event example

### DIFF
--- a/bindings/csharp/examples/ExampleIIOEvent.cs
+++ b/bindings/csharp/examples/ExampleIIOEvent.cs
@@ -81,7 +81,6 @@ namespace IIOCSharp
                             return;
                         }
                     }
-                    event_stream.Dispose();
                 }
             }
         }


### PR DESCRIPTION

## PR Description

Removes an unreachable `Dispose()` call in the C# `ExampleIIOEvent` sample that the compiler flags as `CS0162: Unreachable code detected`. The event-reading loop only exits through the `return` inside its `catch` block, which already disposes the `EventStream`, so the `Dispose()` call placed after the loop could never run.

### Changes
- Remove the dead `event_stream.Dispose()` call after the `while (true)` loop in `bindings/csharp/examples/ExampleIIOEvent.cs`
  
 ### Test
- Compiled with `mcs` (warning gone) and ran the example with `mono` against a real context.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
