### PR TITLE
iiod: guard invalidate_sample_size_cache for non-v0 builds

### DIFF
--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -328,7 +328,8 @@ static void handle_refresh_format(struct parser_pdata *pdata, const struct iiod_
 	if (ret < 0)
 		goto out_send_error;
 
-	invalidate_sample_size_cache(dev);
+	if (WITH_IIOD_V0_COMPAT)
+		invalidate_sample_size_cache(dev);
 
 	const struct iio_data_format *fmt = iio_channel_get_data_format(chn);
 	char endian = fmt->is_be ? 'b' : 'l';

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -47,6 +47,7 @@ if(CONFIG_LIBIIO)
     WITH_EXTERNAL_BACKEND=1
     # Only define the minimal macros actually needed for compilation
     WITH_IIOD_USB_DMABUF=0
+    WITH_IIOD_V0_COMPAT=0
     WITH_LOCAL_BACKEND=0
     WITH_NETWORK_BACKEND=0
     WITH_SERIAL_BACKEND=0


### PR DESCRIPTION
## PR Description
Fixes #1519: `iiod` fails to link on Zephyr with `undefined reference to invalidate_sample_size_cache`. That function lives in `ops.c`, only compiled when `WITH_IIOD_V0_COMPAT` is on, but `responder.c`'s always-built binary handler called it unconditionally.

### Changes
- Guard `invalidate_sample_size_cache(dev)` in `handle_refresh_format()` (`iiod/responder.c`) behind `if (WITH_IIOD_V0_COMPAT)`
- Define `WITH_IIOD_V0_COMPAT=0` in `zephyr/CMakeLists.txt`

### How it works
1. v1's `REFRESH_FORMAT` updates the channel's shared format, then invalidates any live v0 session's cached `sample_size` so it recomputes.
2. On builds without `ops.c` (Zephyr, `-DWITH_IIOD_V0_COMPAT=OFF`), the macro is a compile-time `0`, so the call is dead-code-eliminated.

### Tests
Verified on hardware (ZC706/FMCOMMS2): a v0 (legacy ASCII) client with an open buffer session stays intact after a separate v1 (binary) client calls REFRESH_FORMAT on the same device.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
