### PR TITLE
ci: add Ubuntu 26.04 build to Azure Pipelines

### DIFF
--- a/CI/azure/prepare_assets.sh
+++ b/CI/azure/prepare_assets.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 release_artifacts() {
-        local deb_linux_assets='Fedora-34 Fedora-28 Ubuntu-20.04 Ubuntu-22.04 Ubuntu-24.04 Debian-11 Debian-12 openSUSE-15.4'
+        local deb_linux_assets='Fedora-34 Fedora-28 Ubuntu-20.04 Ubuntu-22.04 Ubuntu-24.04 Ubuntu-26.04 Debian-11 Debian-12 openSUSE-15.4'
         cd "${BUILD_ARTIFACTSTAGINGDIRECTORY}"
         for i in $deb_linux_assets; do
                 cd "Linux-${i}"
@@ -71,7 +71,7 @@ release_artifacts() {
 }
 
 swdownloads_artifacts() {
-        local linux_dist='Fedora-34 Fedora-28 Ubuntu-20.04 Ubuntu-22.04 Ubuntu-24.04 Debian-11 Debian-12 openSUSE-15.4'
+        local linux_dist='Fedora-34 Fedora-28 Ubuntu-20.04 Ubuntu-22.04 Ubuntu-24.04 Ubuntu-26.04 Debian-11 Debian-12 openSUSE-15.4'
         for distribution in $linux_dist; do
 		cd "${BUILD_ARTIFACTSTAGINGDIRECTORY}/Linux-${distribution}"
 		if [ "${distribution}" == "Fedora-34" ] || [ "${distribution}" == "Fedora-28" ]; then

--- a/artifact_manifest.txt.cmakein
+++ b/artifact_manifest.txt.cmakein
@@ -21,6 +21,9 @@ Linux-Ubuntu-22.04/libiio-@VERSION@.g@LIBIIO_VERSION_GIT@-Linux-Ubuntu-22.04.tar
 Linux-Ubuntu-24.04/libiio-@VERSION@.g@LIBIIO_VERSION_GIT@-Linux-Ubuntu-24.04.deb
 Linux-Ubuntu-24.04/libiio-@VERSION@.g@LIBIIO_VERSION_GIT@-Linux-Ubuntu-24.04.tar.gz
 
+Linux-Ubuntu-26.04/libiio-@VERSION@.g@LIBIIO_VERSION_GIT@-Linux-Ubuntu-26.04.deb
+Linux-Ubuntu-26.04/libiio-@VERSION@.g@LIBIIO_VERSION_GIT@-Linux-Ubuntu-26.04.tar.gz
+
 Linux-openSUSE-15.4/libiio-@VERSION@.g@LIBIIO_VERSION_GIT@-Linux-openSUSE-15.4.rpm
 Linux-openSUSE-15.4/libiio-@VERSION@.g@LIBIIO_VERSION_GIT@-Linux-openSUSE-15.4.tar.gz
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -109,6 +109,9 @@ stages:
         ubuntu_24_04:
           image: 'tfcollins/libiio_ubuntu_24_04-ci:latest'
           artifactName: 'Linux-Ubuntu-24.04'
+        ubuntu_26_04:
+          image: 'tfcollins/libiio_ubuntu_26_04-ci:latest'
+          artifactName: 'Linux-Ubuntu-26.04'
         fedora28:
           image: 'tfcollins/libiio_fedora_28-ci:latest'
           artifactName: 'Linux-Fedora-28'


### PR DESCRIPTION
## Summary
  - Add Ubuntu 26.04 to the Azure Pipelines Linux build matrix using the `tfcollins/libiio_ubuntu_26_04-ci:latest` Docker image
  - Update `CI/azure/prepare_assets.sh` to include Ubuntu 26.04 in both `release` and `swdownloads` artifact preparation
  - Add Ubuntu 26.04 `.deb` and `.tar.gz` entries to `artifact_manifest.txt.cmakein`

  ## Test plan
  - [x] Verify the `tfcollins/libiio_ubuntu_26_04-ci:latest` Docker image exists on Docker Hub
  - [x] Run the pipeline and confirm the Ubuntu 26.04 build succeeds
  - [x] Verify Ubuntu 26.04 artifacts appear in the artifact manifest check