### PR TITLE
iiod: responder: don't treat a negative response code as a discard length

### DIFF
--- a/iiod-responder.c
+++ b/iiod-responder.c
@@ -288,9 +288,11 @@ static int iiod_responder_reader_worker(struct iiod_responder *priv)
 
 		if (!io) {
 			/* We received a response, but have no client waiting
-			 * for it, so drop it. */
+			 * for it, so drop it. A code <= 0 is a status code and
+			 * carries no payload, so there is nothing to discard. */
 			iio_mutex_unlock(priv->lock);
-			iiod_discard_data(priv, cmd.code);
+			if (cmd.code > 0)
+				iiod_discard_data(priv, cmd.code);
 			iio_mutex_lock(priv->lock);
 			continue;
 		}


### PR DESCRIPTION
## PR Description

In iiod_responder_reader_worker(), when a RESPONSE frame arrives whose client_id
is no longer in the readers list (for example the request already timed out and
was cancelled by iiod_io_wait_for_response()), the code unconditionally calls
iiod_discard_data(priv, cmd.code).

cmd.code is an int32_t. A code <= 0 is a status/error code that carries no
payload; this is exactly how the server replies to a failed operation (e.g.
iiod_io_send_response_code(io, -EINVAL) sends op=RESPONSE, code<0, no data).
Passed to iiod_discard_data() as a size_t, a negative code becomes an enormous
(about 1.8e19-byte) drain that consumes every subsequent byte on the multiplexed
connection, desynchronizing the client context.

This guards the discard on cmd.code > 0, matching the sibling path a few lines
below (the "io->r_io.nb_buf && cmd.code > 0" check). A response with a positive
code (a real payload awaiting drain) is still drained unchanged.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (n/a: internal behavior fix)
