### PR TITLE
Throw exceptions early to avoid reaching invalid states

### DIFF
--- a/bindings/csharp/Attr.cs
+++ b/bindings/csharp/Attr.cs
@@ -47,15 +47,25 @@ namespace iio
 
         internal Attr(IntPtr attr)
         {
+            if (attr == IntPtr.Zero)
+                throw new IIOException("Attribute pointer is null");
+
             this.attr = attr;
-            this.name = UTF8Marshaler.PtrToStringUTF8(iio_attr_get_name(attr));
-            this.filename = Marshal.PtrToStringAnsi(iio_attr_get_filename(attr)); // Filesystem paths are ASCII
+
+            IntPtr name_ptr = iio_attr_get_name(attr);
+            this.name = name_ptr == IntPtr.Zero ? "" : UTF8Marshaler.PtrToStringUTF8(name_ptr);
+
+            IntPtr filename_ptr = iio_attr_get_filename(attr);
+            this.filename = filename_ptr == IntPtr.Zero ? "" : Marshal.PtrToStringAnsi(filename_ptr);
         }
 
         /// <summary>Read the value of this attribute as a <c>string</c>.</summary>
         /// <exception cref="IioLib.IIOException">The attribute could not be read.</exception>
         public string read()
         {
+            if (attr == IntPtr.Zero)
+                throw new IIOException("Attribute handle is invalid");
+
             byte[] buffer = new byte[4096];
             int err = iio_attr_read_raw(attr, buffer, (uint)buffer.Length);
             if (err < 0)
@@ -76,6 +86,9 @@ namespace iio
         /// <exception cref="IioLib.IIOException">The attribute could not be written.</exception>
         public void write(string val)
         {
+            if (attr == IntPtr.Zero)
+                throw new IIOException("Attribute handle is invalid");
+
             IntPtr valptr = UTF8Marshaler.StringToHGlobalUTF8(val);
             try
             {

--- a/bindings/csharp/Block.cs
+++ b/bindings/csharp/Block.cs
@@ -76,6 +76,8 @@ namespace iio
 
         public int enqueue(uint bytes_used = 0, bool cyclic = false)
         {
+            ThrowIfDisposed();
+
             if (enqueued) {
                 throw new IIOException("Block is already enqueued");
             }
@@ -92,6 +94,8 @@ namespace iio
 
         public int dequeue(bool nonblock = false)
         {
+            ThrowIfDisposed();
+
             if (!enqueued) {
                 throw new IIOException("Block has not been enqueued");
             }
@@ -108,35 +112,66 @@ namespace iio
         /// <remarks>The number of samples written will not exceed the size of the buffer.</remarks>
         public void fill(byte[] array)
         {
-            long length = (long) iio_block_end(hdl) - (long) iio_block_start(hdl);
+            ThrowIfDisposed();
+
+            if (array == null)
+                throw new ArgumentNullException("array");
+
+            IntPtr start = iio_block_start(hdl);
+            IntPtr end = iio_block_end(hdl);
+
+            if (start == IntPtr.Zero || end == IntPtr.Zero)
+                throw new IIOException("Block returned null pointer — block may be in an invalid state");
+
+            long length = (long)end - (long)start;
+            if (length < 0)
+                throw new IIOException("Block has invalid bounds (end < start)");
+
             if (length > array.Length)
-            {
                 length = array.Length;
-            }
-            Marshal.Copy(array, 0, iio_block_start(hdl), (int)length);
+
+            Marshal.Copy(array, 0, start, (int)length);
         }
 
         /// <summary>Extract the samples from the <see cref="iio.IOBuffer"/> object.</summary>
         /// <param name="array">A <c>byte</c> array containing the extracted samples.</param>
         public void read(byte[] array)
         {
-            long length = (long) iio_block_end(hdl) - (long) iio_block_start(hdl);
+            ThrowIfDisposed();
+
+            if (array == null)
+                throw new ArgumentNullException("array");
+
+            IntPtr start = iio_block_start(hdl);
+            IntPtr end = iio_block_end(hdl);
+
+            if (start == IntPtr.Zero || end == IntPtr.Zero)
+                throw new IIOException("Block returned null pointer — block may be in an invalid state");
+
+            long length = (long)end - (long)start;
+            if (length < 0)
+                throw new IIOException("Block has invalid bounds (end < start)");
+
             if (length > array.Length)
-            {
                 length = array.Length;
-            }
-            Marshal.Copy(iio_block_start(hdl), array, 0, (int)length);
+
+            Marshal.Copy(start, array, 0, (int)length);
         }
 
         /// <summary>Gets a pointer to the first sample from the current buffer for a specific channel.</summary>
         /// <param name="ch">The channel for which to find the first sample.</param>
         public IntPtr first(Channel ch)
         {
+            ThrowIfDisposed();
+
             if (ch == null)
-            {
-                throw new IIOException("The channel should not be null!");
-            }
-            return iio_block_first(hdl, ch.chn);
+                throw new ArgumentNullException("ch");
+
+            IntPtr result = iio_block_first(hdl, ch.chn);
+            if (result == IntPtr.Zero)
+                throw new IIOException("Unable to get first sample pointer for channel");
+
+            return result;
         }
     }
 }

--- a/bindings/csharp/Channel.cs
+++ b/bindings/csharp/Channel.cs
@@ -274,7 +274,13 @@ namespace iio
 
         internal Channel(Device dev, IntPtr chn)
         {
+            if (chn == IntPtr.Zero)
+                throw new IIOException("Channel pointer is null");
+
             IntPtr fmt_struct = iio_channel_get_data_format(chn);
+            if (fmt_struct == IntPtr.Zero)
+                throw new IIOException("Unable to get data format for channel");
+
             uint nb_attrs = iio_channel_get_attrs_count(chn);
             uint nb_event_attrs = iio_channel_get_event_attrs_count(chn);
 
@@ -287,7 +293,10 @@ namespace iio
             var attrsDict = new Dictionary<string, Attr>();
             for (uint i = 0; i < nb_attrs; i++)
             {
-                Attr a = new Attr(iio_channel_get_attr(chn, i));
+                IntPtr attr_ptr = iio_channel_get_attr(chn, i);
+                if (attr_ptr == IntPtr.Zero)
+                    throw new IIOException("Unable to get channel attribute at index " + i);
+                Attr a = new Attr(attr_ptr);
                 attrsDict[a.name] = a;
             }
             attrs = attrsDict;
@@ -295,7 +304,10 @@ namespace iio
             var eventAttrsDict = new Dictionary<string, Attr>();
             for (uint i = 0; i < nb_event_attrs; i++)
             {
-                Attr a = new Attr(iio_channel_get_event_attr(chn, i));
+                IntPtr attr_ptr = iio_channel_get_event_attr(chn, i);
+                if (attr_ptr == IntPtr.Zero)
+                    throw new IIOException("Unable to get channel event attribute at index " + i);
+                Attr a = new Attr(attr_ptr);
                 eventAttrsDict[a.name] = a;
             }
             event_attrs = eventAttrsDict;
@@ -313,7 +325,11 @@ namespace iio
             IntPtr label_ptr = iio_channel_get_label(this.chn);
             label = label_ptr == IntPtr.Zero ? "" : UTF8Marshaler.PtrToStringUTF8(label_ptr);
 
-            id = Marshal.PtrToStringAnsi(iio_channel_get_id(this.chn)); // Channel IDs are ASCII (kernel-defined)
+            IntPtr id_ptr = iio_channel_get_id(this.chn);
+            if (id_ptr == IntPtr.Zero)
+                throw new IIOException("Unable to get channel ID");
+            id = Marshal.PtrToStringAnsi(id_ptr);
+
             output = iio_channel_is_output(this.chn);
             scan_element = iio_channel_is_scan_element(this.chn);
             index = (uint) iio_channel_get_index(this.chn);
@@ -322,18 +338,27 @@ namespace iio
         /// <summary>Enable the current channel, so that it can be used for I/O operations.</summary>
         public void enable(ChannelsMask mask)
         {
+            if (mask == null)
+                throw new ArgumentNullException("mask");
+
             iio_channel_enable(this.chn, mask.hdl);
         }
 
         /// <summary>Disable the current channel.</summary>
         public void disable(ChannelsMask mask)
         {
+            if (mask == null)
+                throw new ArgumentNullException("mask");
+
             iio_channel_disable(this.chn, mask.hdl);
         }
 
         /// <summary>Returns whether or not the channel has been enabled.</summary>
         public bool is_enabled(ChannelsMask mask)
         {
+            if (mask == null)
+                throw new ArgumentNullException("mask");
+
             return iio_channel_is_enabled(this.chn, mask.hdl);
         }
 
@@ -346,6 +371,9 @@ namespace iio
         /// <exception cref="IioLib.IIOException">The samples could not be read.</exception>
         public byte[] read(Block block, bool raw = false)
         {
+            if (block == null)
+                throw new ArgumentNullException("block");
+
             if (this.output)
                 throw new IIOException("Unable to read from output channel");
 
@@ -373,6 +401,11 @@ namespace iio
         /// <exception cref="IioLib.IIOException">The samples could not be written.</exception>
         public uint write(Block block, byte[] array, bool raw = false)
         {
+            if (block == null)
+                throw new ArgumentNullException("block");
+            if (array == null)
+                throw new ArgumentNullException("array");
+
             if (!this.output)
                 throw new IIOException("Unable to write to an input channel");
 

--- a/bindings/csharp/Context.cs
+++ b/bindings/csharp/Context.cs
@@ -246,6 +246,7 @@ namespace iio
         /// <exception cref="IioLib.IIOException">The timeout could not be applied.</exception>
         public void set_timeout(int timeout)
         {
+            ThrowIfDisposed();
             int ret = iio_context_set_timeout(hdl, timeout);
             if (ret < 0)
                 throw new IIOException("Unable to set timeout", ret);
@@ -255,6 +256,7 @@ namespace iio
         /// <exception cref="IioLib.IIOException">The context did not respond.</exception>
         public void ping()
         {
+            ThrowIfDisposed();
             int ret = iio_context_ping(hdl);
             if (ret < 0)
                 throw new IIOException("Ping failed", ret);
@@ -267,6 +269,7 @@ namespace iio
         /// <exception cref="IioLib.IIOException">Thrown if the parameters could not be retrieved.</exception>
         public IioContextParams GetContextParams()
         {
+            ThrowIfDisposed();
             IntPtr paramsPtr = iio_context_get_params(hdl);
             if (paramsPtr == IntPtr.Zero)
             {

--- a/bindings/csharp/Context.cs
+++ b/bindings/csharp/Context.cs
@@ -174,6 +174,9 @@ namespace iio
             for (uint i = 0; i < nb_devices; i++)
             {
                 IntPtr dev = iio_context_get_device(hdl, i);
+                if (dev == IntPtr.Zero)
+                    throw new IIOException("Unable to get device at index " + i);
+
                 if (iio_device_is_trigger(dev))
                 {
                     devicesList.Add(new Trigger(this, dev));
@@ -193,8 +196,12 @@ namespace iio
             xml = UTF8Marshaler.PtrToStringUTF8(xml_hdl.ptr);
             Marshal.FreeHGlobal(xml_hdl.ptr);
 
-            name = UTF8Marshaler.PtrToStringUTF8(iio_context_get_name(hdl));
-            description = UTF8Marshaler.PtrToStringUTF8(iio_context_get_description(hdl));
+            IntPtr name_ptr = iio_context_get_name(hdl);
+            name = name_ptr == IntPtr.Zero ? "" : UTF8Marshaler.PtrToStringUTF8(name_ptr);
+
+            IntPtr desc_ptr = iio_context_get_description(hdl);
+            description = desc_ptr == IntPtr.Zero ? "" : UTF8Marshaler.PtrToStringUTF8(desc_ptr);
+
             backend_version = new Version(hdl);
 
             attrs = new Dictionary<string, string>();
@@ -202,7 +209,10 @@ namespace iio
 
             for (uint i = 0; i < nbAttrs; i++)
             {
-                Attr attr = new Attr(iio_context_get_attr(hdl, i));
+                IntPtr attr_ptr = iio_context_get_attr(hdl, i);
+                if (attr_ptr == IntPtr.Zero)
+                    throw new IIOException("Unable to get context attribute at index " + i);
+                Attr attr = new Attr(attr_ptr);
                 attrs[attr.name] = attr.read();
             }
         }

--- a/bindings/csharp/Device.cs
+++ b/bindings/csharp/Device.cs
@@ -113,6 +113,9 @@ namespace iio
         // Constructor
         internal Device(Context ctx, IntPtr dev)
         {
+            if (dev == IntPtr.Zero)
+                throw new IIOException("Device pointer is null");
+
             this.ctx = ctx;
             this.dev = dev;
 
@@ -125,36 +128,54 @@ namespace iio
             var channelsList = new List<Channel>();
             for (uint i = 0; i < nb_channels; i++)
             {
-                channelsList.Add(new Channel(this, iio_device_get_channel(dev, i)));
+                IntPtr chn = iio_device_get_channel(dev, i);
+                if (chn == IntPtr.Zero)
+                    throw new IIOException("Unable to get channel at index " + i);
+                channelsList.Add(new Channel(this, chn));
             }
 
             var attrsDict = new Dictionary<string, Attr>();
             for (uint i = 0; i < nb_attrs; i++)
             {
-                Attr a = new Attr(iio_device_get_attr(dev, i));
+                IntPtr attr_ptr = iio_device_get_attr(dev, i);
+                if (attr_ptr == IntPtr.Zero)
+                    throw new IIOException("Unable to get device attribute at index " + i);
+                Attr a = new Attr(attr_ptr);
                 attrsDict[a.name] = a;
             }
 
             var debugAttrsDict = new Dictionary<string, Attr>();
             for (uint i = 0; i < nb_debug_attrs; i++)
             {
-                Attr a = new Attr(iio_device_get_debug_attr(dev, i));
+                IntPtr attr_ptr = iio_device_get_debug_attr(dev, i);
+                if (attr_ptr == IntPtr.Zero)
+                    throw new IIOException("Unable to get debug attribute at index " + i);
+                Attr a = new Attr(attr_ptr);
                 debugAttrsDict[a.name] = a;
             }
 
             var eventAttrsDict = new Dictionary<string, Attr>();
             for (uint i = 0; i < nb_event_attrs; i++)
             {
-                Attr a = new Attr(iio_device_get_event_attr(dev, i));
+                IntPtr attr_ptr = iio_device_get_event_attr(dev, i);
+                if (attr_ptr == IntPtr.Zero)
+                    throw new IIOException("Unable to get event attribute at index " + i);
+                Attr a = new Attr(attr_ptr);
                 eventAttrsDict[a.name] = a;
             }
 
-            id = Marshal.PtrToStringAnsi(iio_device_get_id(dev)); // Device IDs are ASCII (kernel-defined)
+            IntPtr id_ptr = iio_device_get_id(dev);
+            if (id_ptr == IntPtr.Zero)
+                throw new IIOException("Unable to get device ID");
+            id = Marshal.PtrToStringAnsi(id_ptr);
 
             var buffersList = new List<IOBuffer>();
             for (uint i = 0; i < nb_buffers; i++)
             {
-                buffersList.Add(new IOBuffer(this, iio_device_get_buffer(dev, i)));
+                IntPtr buf = iio_device_get_buffer(dev, i);
+                if (buf == IntPtr.Zero)
+                    throw new IIOException("Unable to get buffer at index " + i);
+                buffersList.Add(new IOBuffer(this, buf));
             }
 
             channels = channelsList;

--- a/bindings/csharp/EventStream.cs
+++ b/bindings/csharp/EventStream.cs
@@ -50,24 +50,37 @@ namespace iio
         /// <exception cref="IioLib.IIOException">Unable to read event.</exception>
         public IIOEvent read_event(bool nonblock)
         {
+            ThrowIfDisposed();
+
             IIOEventPtr iioeventptr;
             iioeventptr.id = 0;
             iioeventptr.timestamp = 0;
             IntPtr eventptr = Marshal.AllocHGlobal(Marshal.SizeOf(iioeventptr));
 
-            int ret = iio_event_stream_read(hdl, eventptr, nonblock);
-            if (ret < 0)
-                throw new IIOException("Unable to read event", ret);
-
-            IntPtr chnptr = iio_event_get_channel(eventptr, dev.dev, false);
-            Channel chn = new Channel(dev, chnptr);
-            IntPtr diffchnptr = iio_event_get_channel(eventptr, dev.dev, true);
-            if (diffchnptr != IntPtr.Zero)
+            try
             {
-                Channel chndiff = new Channel(dev, diffchnptr);
-                return new IIOEvent(eventptr, chn, chndiff);
+                int ret = iio_event_stream_read(hdl, eventptr, nonblock);
+                if (ret < 0)
+                    throw new IIOException("Unable to read event", ret);
+
+                IntPtr chnptr = iio_event_get_channel(eventptr, dev.dev, false);
+                if (chnptr == IntPtr.Zero)
+                    throw new IIOException("Unable to get channel from event");
+
+                Channel chn = new Channel(dev, chnptr);
+                IntPtr diffchnptr = iio_event_get_channel(eventptr, dev.dev, true);
+                if (diffchnptr != IntPtr.Zero)
+                {
+                    Channel chndiff = new Channel(dev, diffchnptr);
+                    return new IIOEvent(eventptr, chn, chndiff);
+                }
+                return new IIOEvent(eventptr, chn);
             }
-            return new IIOEvent(eventptr, chn);
+            catch
+            {
+                Marshal.FreeHGlobal(eventptr);
+                throw;
+            }
         }
 
         protected override void Destroy()

--- a/bindings/csharp/IIOEvent.cs
+++ b/bindings/csharp/IIOEvent.cs
@@ -77,6 +77,9 @@ namespace iio
 
         internal IIOEvent(IntPtr ev, Channel chn, Channel chndiff = null)
         {
+            if (ev == IntPtr.Zero)
+                throw new IIOException("Event pointer is null");
+
             this.ev = ev;
             event_ptr = (IIOEventPtr) Marshal.PtrToStructure(ev, typeof(IIOEventPtr));
             this.id = event_ptr.id;

--- a/bindings/csharp/IOBuffer.cs
+++ b/bindings/csharp/IOBuffer.cs
@@ -45,6 +45,9 @@ namespace iio
 
         internal IOBuffer(Device dev, IntPtr buffer)
         {
+            if (buffer == IntPtr.Zero)
+                throw new IIOException("Buffer pointer is null");
+
             this.dev = dev;
             this.buf = buffer;
 
@@ -52,7 +55,10 @@ namespace iio
             uint nb_buffer_attrs = iio_buffer_get_attrs_count(buf);
             for (uint i = 0; i < nb_buffer_attrs; i++)
             {
-                Attr a = new Attr(iio_buffer_get_attr(buf, i));
+                IntPtr attr_ptr = iio_buffer_get_attr(buf, i);
+                if (attr_ptr == IntPtr.Zero)
+                    throw new IIOException("Unable to get buffer attribute at index " + i);
+                Attr a = new Attr(attr_ptr);
                 attrsDict[a.name] = a;
             }
             attrs = attrsDict;
@@ -113,6 +119,7 @@ namespace iio
         public bool started {
             get { return is_started; }
             set {
+                ThrowIfDisposed();
                 int err;
                 if (value)
                     err = iio_buffer_stream_start(hdl);
@@ -139,11 +146,13 @@ namespace iio
 
         public void cancel()
         {
+            ThrowIfDisposed();
             iio_buffer_stream_cancel(hdl);
         }
 
         public Block create_block(uint size)
         {
+            ThrowIfDisposed();
             return new Block(this, size);
         }
 

--- a/bindings/csharp/IioLib.cs
+++ b/bindings/csharp/IioLib.cs
@@ -171,6 +171,12 @@ namespace iio
             }
         }
 
+        protected void ThrowIfDisposed()
+        {
+            if (hdl == IntPtr.Zero)
+                throw new ObjectDisposedException(GetType().Name);
+        }
+
         protected abstract void Destroy();
     }
 

--- a/bindings/csharp/Scan.cs
+++ b/bindings/csharp/Scan.cs
@@ -64,8 +64,14 @@ namespace iio
             var resultsDict = new Dictionary<string, string>();
 
             for (uint i = 0; i < nb_results; i++) {
-                string uri = Marshal.PtrToStringAnsi(iio_scan_get_uri(hdl, i)); // URIs are ASCII (RFC-compliant)
-                string dsc = UTF8Marshaler.PtrToStringUTF8(iio_scan_get_description(hdl, i));
+                IntPtr uri_ptr = iio_scan_get_uri(hdl, i);
+                if (uri_ptr == IntPtr.Zero)
+                    throw new IIOException("Unable to get scan URI at index " + i);
+
+                IntPtr dsc_ptr = iio_scan_get_description(hdl, i);
+
+                string uri = Marshal.PtrToStringAnsi(uri_ptr);
+                string dsc = dsc_ptr == IntPtr.Zero ? "" : UTF8Marshaler.PtrToStringUTF8(dsc_ptr);
 
                 resultsDict[uri] = dsc;
             }

--- a/bindings/csharp/Stream.cs
+++ b/bindings/csharp/Stream.cs
@@ -51,11 +51,13 @@ namespace iio
 
         public void cancel()
         {
+            ThrowIfDisposed();
             iio_stream_cancel(hdl);
         }
 
         public Block next()
         {
+            ThrowIfDisposed();
             IIOPtr ptr = iio_stream_get_next_block(hdl);
             if (!ptr)
                 throw new IIOException("Unable to get next block", ptr);


### PR DESCRIPTION
## PR Description

Make the C# bindings more robust by doing internal checking (mostly on pointers and whether the object has been disposed or not) and throw catchable exceptions instead of allowing use of unavailable resources which causes other types of exceptions to be thrown at a time that the hole program is in a bad state.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
