### PR TITLE
Standardize URI handling across examples

### DIFF
--- a/bindings/csharp/examples/ExampleIIOEvent.cs
+++ b/bindings/csharp/examples/ExampleIIOEvent.cs
@@ -19,18 +19,25 @@ namespace IIOCSharp
     {
         static void Main(string[] args)
         {
-            Scan scan = new Scan();
-            if (scan.nb_results > 0) {
-                Console.WriteLine("* Scanned contexts: " + scan.nb_results);
-            }
-            foreach (var entry in scan.results) {
-                Console.WriteLine("\t" + entry.Key + " " + entry.Value);
-            }
-            scan.Dispose();
-
-            if (args.Length <= 1)
+            if (args.Length < 2)
             {
+                if (args.Length == 0)
+                {
+                    Console.WriteLine("Scanning for available contexts...");
+                    Scan scan = new Scan();
+                    if (scan.nb_results > 0) {
+                        Console.WriteLine("* Scanned contexts: " + scan.nb_results);
+                    }
+                    foreach (var entry in scan.results) {
+                        Console.WriteLine("\t" + entry.Key + " " + entry.Value);
+                    }
+                    scan.Dispose();
+                    Console.WriteLine();
+                }
+
                 Console.WriteLine("Please provide the context URI and IIO device.\n");
+                Console.WriteLine("Usage: ExampleIIOEvent <uri> <device>");
+                Console.WriteLine("Example: ExampleIIOEvent ip:192.168.2.1 iio:device0\n");
                 return;
             }
 

--- a/bindings/csharp/examples/ExampleProgram.cs
+++ b/bindings/csharp/examples/ExampleProgram.cs
@@ -20,19 +20,30 @@ namespace IIOCSharp
         static void Main(string[] args)
         {
             const uint blocksize = 1024;
-            Scan scan = new Scan();
-            if (scan.nb_results > 0) {
-                Console.WriteLine("* Scanned contexts: " + scan.nb_results);
-            }
-            foreach (var entry in scan.results) {
-                Console.WriteLine("\t" + entry.Key + " " + entry.Value);
-            }
-            scan.Dispose();
 
+            if (args.Length < 1)
+            {
+                Console.WriteLine("Scanning for available contexts...");
+                Scan scan = new Scan();
+                if (scan.nb_results > 0) {
+                    Console.WriteLine("* Scanned contexts: " + scan.nb_results);
+                }
+                foreach (var entry in scan.results) {
+                    Console.WriteLine("\t" + entry.Key + " " + entry.Value);
+                }
+                scan.Dispose();
+
+                Console.WriteLine("\nPlease provide the context URI.\n");
+                Console.WriteLine("Usage: ExampleProgram <uri>");
+                Console.WriteLine("Example: ExampleProgram ip:192.168.2.1\n");
+                return;
+            }
+
+            string uri = args[0];
             Context ctx;
             try
             {
-                ctx = new Context("ip:192.168.2.1");
+                ctx = new Context(uri);
                 Console.WriteLine(ctx.xml);
             } catch (IIOException e)
             {

--- a/bindings/csharp/examples/PlutoExample.cs
+++ b/bindings/csharp/examples/PlutoExample.cs
@@ -21,7 +21,6 @@ namespace IIOCSharp
     static class PlutoExample
     {
         const int INT16_BYTE_STEP = 2;
-        const string URI = "ip:pluto.local";
         const double TXLO = 1000000000;
         const double TXBW = 5000000;
         const double TXFS = 3000000;
@@ -36,10 +35,29 @@ namespace IIOCSharp
 
         static void Main(string[] args)
         {
+            if (args.Length < 1)
+            {
+                Console.WriteLine("Scanning for available contexts...");
+                Scan scan = new Scan();
+                if (scan.nb_results > 0) {
+                    Console.WriteLine("* Scanned contexts: " + scan.nb_results);
+                }
+                foreach (var entry in scan.results) {
+                    Console.WriteLine("\t" + entry.Key + " " + entry.Value);
+                }
+                scan.Dispose();
+
+                Console.WriteLine("\nPlease provide the context URI.\n");
+                Console.WriteLine("Usage: PlutoExample <uri>");
+                Console.WriteLine("Example: PlutoExample ip:pluto.local\n");
+                return;
+            }
+
+            string uri = args[0];
             Context ctx;
             try
             {
-                ctx = new Context(URI);
+                ctx = new Context(uri);
             }
             catch (IIOException e)
             {


### PR DESCRIPTION
## PR Description

Require URI as a command-line argument for all C# examples instead of using hardcoded values. Perform context scanning only when no URI is provided, avoiding slow network scans when unnecessary. Add clear usage messages and scanning progress notification.


## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
