### PR TITLE
 zephyr: Remove reg devicetree property from IIO devices

### DIFF
--- a/zephyr/drivers/iio_device/io_channels.c
+++ b/zephyr/drivers/iio_device/io_channels.c
@@ -41,7 +41,6 @@ struct iio_device_io_channels_channel {
 struct iio_device_io_channels_config {
 	const struct iio_device_io_channels_channel *channels;
 	size_t num_channels;
-	uint8_t address;
 };
 
 struct iio_device_io_channels_channel_adc_overrides {
@@ -776,7 +775,6 @@ static const struct iio_device_io_channels_channel iio_device_io_channels_##inst
 };												\
 												\
 static const struct iio_device_io_channels_config iio_device_io_channel_config_##inst = {	\
-	.address = DT_INST_REG_ADDR(inst),							\
 	.channels = iio_device_io_channels_##inst,						\
 	.num_channels = ARRAY_SIZE(iio_device_io_channels_##inst),				\
 };												\

--- a/zephyr/dts/bindings/iio/iio,iio-device.yaml
+++ b/zephyr/dts/bindings/iio/iio,iio-device.yaml
@@ -4,9 +4,6 @@
 include: base.yaml
 
 properties:
-  reg:
-    required: true
-
   io-name:
     type: string
     description: |

--- a/zephyr/samples/iiod/adc-emul.overlay
+++ b/zephyr/samples/iiod/adc-emul.overlay
@@ -7,12 +7,8 @@
 / {
 	iio-context {
 		iio-adcs {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			adc-emul@0 {
+			adc-emul {
 				compatible = "iio,io-channels";
-				reg = <0>;
 				io-channels = <&adc_emul 0>, <&adc_emul 1>;
 				io-channel-names = "voltage0", "voltage1";
 				io-name = "adc-emul";

--- a/zephyr/samples/iiod/adc-max32.overlay
+++ b/zephyr/samples/iiod/adc-max32.overlay
@@ -7,12 +7,8 @@
 / {
 	iio-context {
 		iio-adcs {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			max32-adc@0 {
+			max32-adc {
 				compatible = "iio,adc";
-				reg = <0>;
 				io-channels = <&adc 0>;
 				io-channel-names = "adc_in_ch0";
 				io-name = "max32-adc";

--- a/zephyr/samples/iiod/adxl345.overlay
+++ b/zephyr/samples/iiod/adxl345.overlay
@@ -41,13 +41,9 @@
 	/* IIO Context for libiio */
 	iio-context {
 		iio-sensors {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
 			/* ADXL345 3-axis Accelerometer */
-			adxl345@0 {
+			adxl345 {
 				compatible = "iio,sensor";
-				reg = <0>;
 				sensor-device = <&adxl345>;
 				sensor-channels = <
 					IIO_SENSOR_CHAN_ACCEL_X

--- a/zephyr/samples/iiod/boards/frdm_k64f_mk64f12.overlay
+++ b/zephyr/samples/iiod/boards/frdm_k64f_mk64f12.overlay
@@ -8,12 +8,8 @@
 
 / {
 	iio-context {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		iio-device@3 {
+		fxos8700 {
 			compatible = "iio,sensor";
-			reg = <3>;
 			sensor-device = <&fxos8700>;
 			sensor-channels = <IIO_SENSOR_CHAN_ACCEL_X
 					   IIO_SENSOR_CHAN_ACCEL_Y

--- a/zephyr/samples/iiod/eval_ad4052_ardz.overlay
+++ b/zephyr/samples/iiod/eval_ad4052_ardz.overlay
@@ -7,12 +7,8 @@
 / {
 	iio-context {
 		iio-adcs {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			ad4052@0 {
+			ad4052 {
 				compatible = "iio,adc";
-				reg = <0>;
 				io-channels = <&adc4052_eval_ad4052_ardz 0>;
 				io-channel-names = "adc_in_ch0";
 				io-name = "ad4052";

--- a/zephyr/samples/iiod/eval_adxl362_ardz.overlay
+++ b/zephyr/samples/iiod/eval_adxl362_ardz.overlay
@@ -8,12 +8,8 @@
 
 / {
 	iio-context {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		iio-device@4 {
+		adxl362_eval_adxl362_ardz {
 			compatible = "iio,sensor";
-			reg = <4>;
 			sensor-device = <&adxl362_eval_adxl362_ardz>;
 			sensor-channels = <IIO_SENSOR_CHAN_ACCEL_X
 					   IIO_SENSOR_CHAN_ACCEL_Y

--- a/zephyr/samples/iiod/multi-sensor-emul.overlay
+++ b/zephyr/samples/iiod/multi-sensor-emul.overlay
@@ -10,13 +10,9 @@
 / {
 	iio-context {
 		iio-sensors {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
 			/* First ADLTC2990 instance — I2C address 0x4c */
-			ltc2990@0 {
+			ltc2990_0 {
 				compatible = "iio,sensor";
-				reg = <0>;
 				sensor-device = <&adltc2990_emul_0>;
 				sensor-channels = <
 					IIO_SENSOR_CHAN_VOLTAGE
@@ -32,9 +28,8 @@
 			};
 
 			/* Second ADLTC2990 instance — I2C address 0x4e */
-			ltc2990@1 {
+			ltc2990_1 {
 				compatible = "iio,sensor";
-				reg = <1>;
 				sensor-device = <&adltc2990_emul_1>;
 				sensor-channels = <
 					IIO_SENSOR_CHAN_VOLTAGE

--- a/zephyr/samples/iiod/pmod_acl.overlay
+++ b/zephyr/samples/iiod/pmod_acl.overlay
@@ -9,12 +9,8 @@
 / {
 	iio-context {
 		iio-sensors {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			adxl345@0 {
+			adxl345_pmod_acl {
 				compatible = "iio,sensor";
-				reg = <0>;
 				sensor-device = <&adxl345_pmod_acl>;
 				sensor-channels = <IIO_SENSOR_CHAN_ACCEL_X
 						   IIO_SENSOR_CHAN_ACCEL_Y

--- a/zephyr/samples/iiod/sensor-emul.overlay
+++ b/zephyr/samples/iiod/sensor-emul.overlay
@@ -10,12 +10,8 @@
 / {
 	iio-context {
 		iio-sensors {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			ltc2990@0 {
+			ltc2990 {
 				compatible = "iio,sensor";
-				reg = <0>;
 				sensor-device = <&adltc2990_emul>;
 				sensor-channels = <
 					IIO_SENSOR_CHAN_VOLTAGE


### PR DESCRIPTION
## PR Description

Simplify the devicetree syntax for IIO devices by removing the unused/unneeded `reg` property requirement, since the reg value is no longer used by the Zephyr backend.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
