### PR TITLE
usb: fix teardown hang when cancellation races transfer submission

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -607,6 +607,7 @@ static int usb_sync_transfer(struct iio_context_pdata *pdata, struct iiod_client
 {
 	unsigned char ep;
 	struct libusb_transfer *transfer = NULL;
+	bool cancel_requested = false;
 	int completed = 0;
 	int ret;
 
@@ -665,12 +666,32 @@ unlock:
 		return ret;
 
 	while (!completed) {
-		ret = libusb_handle_events_completed(pdata->ctx, &completed);
+		/*
+		 * Wait in bounded steps rather than indefinitely, so that a
+		 * cancellation requested after this transfer was submitted is
+		 * still acted upon. usb_cancel() can only cancel a transfer that
+		 * is already in flight; without this, a cancellation that lands
+		 * in the window before submission leaves this loop waiting for a
+		 * transfer that never completes, and the iiod-responder reader
+		 * thread can never be joined.
+		 */
+		struct timeval tv = { .tv_sec = 0, .tv_usec = 100 * 1000 };
+
+		ret = libusb_handle_events_timeout_completed(pdata->ctx, &tv, &completed);
 		if (ret < 0) {
 			if (ret == LIBUSB_ERROR_INTERRUPTED)
 				continue;
 			libusb_cancel_transfer(transfer);
 			continue;
+		}
+
+		if (!completed && !cancel_requested) {
+			iio_mutex_lock(io_ctx->lock);
+			cancel_requested = io_ctx->cancelled;
+			iio_mutex_unlock(io_ctx->lock);
+
+			if (cancel_requested)
+				libusb_cancel_transfer(transfer);
 		}
 	}
 


### PR DESCRIPTION
## PR Description

Destroying a USB context intermittently hangs. All I/O completes, then iio_context_destroy() never returns: the iiod-responder reader thread sits in an 8-byte bulk IN read and the main thread blocks in the join inside iiod_responder_wait_done().

That read carries a timeout_ms of -1, which usb_sync_transfer() maps to a libusb timeout of 0, meaning wait forever, so the only way out of it is libusb_cancel_transfer(). iiod_responder_stop() merely sets a flag and cannot interrupt a read already in progress, and usb_cancel() can only cancel a transfer that is already in flight. When cancellation lands in the window before the reader submits, nothing interrupts the transfer it submits next: the cancelled flag is consulted before submitting and never again once the completion loop is entered.

Wait for completion in bounded steps and re-check the flag, cancelling the in-flight transfer when cancellation was requested after it was submitted. Cancellation no longer depends on where the reader happens to be.

Reproducing it needs a context with more than one device, so that enough command exchanges occur to fall in the window; a single-device context never hit it. Over repeated iio_info runs against a two-device target the hang appeared in four of six attempts before and in none of twenty-four after.

Assisted-by: Claude:claude-opus-5

cc: @ralucabozdog 

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
