### PR TITLE
Add USB transport pytest coverage + regression job

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -60,7 +60,8 @@ jobs:
           if [ "${{ runner.os }}" = "Windows" ]; then
             EXTRA_TWISTER_FLAGS="--short-build-path -O/tmp/twister-out"
           fi
-          west twister -T samples -v --force-color --inline-logs --integration $EXTRA_TWISTER_FLAGS
+          west twister -T samples -v --force-color --inline-logs --integration \
+            --exclude-tag usb-hostreq $EXTRA_TWISTER_FLAGS
 
   regression-tests:
     name: Regression tests against Zephyr IIOD backend
@@ -125,3 +126,79 @@ jobs:
       - name: Stop IIOD server
         if: always()
         run: kill $(cat /tmp/zephyr_pid) 2>/dev/null || true
+
+  usb-regression-tests:
+    name: Regression tests against Zephyr IIOD backend (USB)
+    runs-on: ubuntu-22.04
+    # Exercises the full virtual UDC<->UHC<->USB/IP<->vhci_hcd chain, which
+    # can wedge a host's kernel USB state on an abandoned connection (see
+    # iiod/usb.c). Kept non-blocking and time-boxed until proven reliable.
+    continue-on-error: true
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          path: libiio
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: 3.12
+
+      - name: Setup Zephyr project
+        uses: zephyrproject-rtos/action-zephyr-setup@5ec39f5cba83346d83a836dfed1524270c660e28 # v1.0.14
+        with:
+          app-path: libiio
+          toolchains: arm-zephyr-eabi
+          ccache-cache-key: usb-regression-ubuntu-22.04
+
+      - name: Install libiio build dependencies
+        run: sudo apt-get install -y libxml2-dev libusb-1.0-0-dev
+
+      - name: Install USB/IP client tooling
+        run: |
+          # No standalone "usbip" apt package on Ubuntu 22.04 -- the usbip
+          # binary is provided by linux-tools-generic itself, under
+          # /usr/lib/linux-tools/*/usbip (see conftest.py's
+          # _find_usbip_binary()).
+          sudo apt-get install -y linux-tools-generic linux-cloud-tools-generic
+          # Grant non-root access to the emulated device (VID 0456) so
+          # iio.Context() can open its device node.
+          echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="0456", MODE="0666"' \
+            | sudo tee /etc/udev/rules.d/90-libiio-usb.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger
+
+      - name: Load vhci-hcd
+        run: |
+          # vhci-hcd isn't loaded by default on GitHub-hosted ubuntu-22.04
+          # runners, and the module itself isn't even present until
+          # linux-modules-extra-<kernel> (matching the running kernel
+          # exactly) is installed -- it's not part of the base image.
+          sudo apt-get install -y "linux-modules-extra-$(uname -r)"
+          sudo modprobe vhci-hcd
+
+      - name: Start TAP interface (net-setup.sh)
+        working-directory: tools/net-tools
+        run: sudo ./net-setup.sh start
+
+      - name: Build and install libiio C library
+        working-directory: libiio
+        run: |
+          mkdir build && cd build
+          cmake -DWITH_TESTS=OFF -DWITH_USB_BACKEND=ON -DHAVE_DNS_SD=OFF -DWITH_AIO=OFF ..
+          make -j$(nproc)
+          sudo make install
+          sudo ldconfig
+
+      - name: Install Python bindings
+        working-directory: libiio
+        run: pip install bindings/python
+
+      - name: Run USB regression tests against Zephyr IIOD backend
+        working-directory: libiio/zephyr
+        run: |
+          west twister -p native_sim -v --force-color --inline-logs \
+            -T samples --test sample.iiod.usb.pytest

--- a/west.yml
+++ b/west.yml
@@ -17,4 +17,5 @@ manifest:
           - hal_adi
           - hal_nxp
           - hal_stm32
+          - net-tools
           - picolibc

--- a/zephyr/iiod/usb.c
+++ b/zephyr/iiod/usb.c
@@ -109,6 +109,10 @@ struct iio_usb_pipe {
 	int rx_err;
 	int tx_err;
 	bool open; /* Whether this pipe has been opened by host */
+	/* Set by RESET_PIPES for pipe 0: discard stale ring-buffer bytes on
+	 * the next read instead of touching it from another thread.
+	 */
+	atomic_t reset_pending;
 	struct iio_usb_data *data; /* back-pointer to parent */
 };
 
@@ -289,6 +293,7 @@ static int iio_usb_init(struct usbd_class_data *const c_data)
 		pipe->rx_err = 0;
 		pipe->tx_err = 0;
 		pipe->open = false;
+		atomic_clear(&pipe->reset_pending);
 
 		LOG_INF("Pipe %d: IN=0x%02x OUT=0x%02x", i, pipe->ep_in, pipe->ep_out);
 	}
@@ -316,6 +321,11 @@ static ssize_t iiod_usb_pipe_read(struct iiod_pdata *pdata, void *buf, size_t si
 	struct iio_usb_pipe *pipe = (struct iio_usb_pipe *)pdata;
 	size_t bytes_read = 0;
 	uint8_t *dest = (uint8_t *)buf;
+
+	/* Discard bytes left over from before a RESET_PIPES request. */
+	if (atomic_cas(&pipe->reset_pending, 1, 0)) {
+		ring_buf_reset(&pipe->rx_ringbuf);
+	}
 
 	LOG_DBG("Pipe 0x%02x: read %zu bytes requested", pipe->ep_out, size);
 
@@ -449,6 +459,12 @@ static int iio_usb_control_to_dev(struct usbd_class_data *c_data,
 				k_sem_give(&data->pipes[i].rx_sem);
 			}
 		}
+		/*
+		 * Pipe 0 stays alive across RESET_PIPES, but flag it so its
+		 * reader thread discards any stale bytes from an abandoned
+		 * connection on its next read.
+		 */
+		atomic_set(&data->pipes[0].reset_pending, 1);
 		break;
 
 	case IIO_USD_CMD_OPEN_PIPE:

--- a/zephyr/samples/iiod/pytest/conftest.py
+++ b/zephyr/samples/iiod/pytest/conftest.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2026 Analog Devices, Inc.
 # SPDX-License-Identifier: MIT
 
+import ctypes
+import glob
+import os
 import re
 import socket
 import subprocess
@@ -14,7 +17,7 @@ def pytest_addoption(parser):
     parser.addoption(
         '--iiod-transport',
         default='network',
-        choices=['network', 'uart'],
+        choices=['network', 'uart', 'usb'],
         help='IIOD transport to connect to the IIOD server (default: network)',
     )
 
@@ -24,6 +27,8 @@ def iiod_context(dut: DeviceAdapter, request):
     transport = request.config.getoption('--iiod-transport')
     if transport == 'uart':
         yield from _uart_context(dut)
+    elif transport == 'usb':
+        yield from _usb_context(dut)
     else:
         yield from _network_context(dut)
 
@@ -98,3 +103,197 @@ def _uart_context(dut: DeviceAdapter):
         socat.wait()
 
     dut.base_timeout = 2.0
+
+
+# VID for the emulated "adi,iio-usb" class device (its default
+# CONFIG_IIOD_USBD_VID Kconfig value).
+_USB_VID = '0456'
+_USB_DUT_IP = '192.0.2.1'  # matches native_sim.conf's CONFIG_NET_CONFIG_MY_IPV4_ADDR
+
+
+def _find_usbip_binary():
+    # /usr/bin/usbip refuses to run without a linux-tools package matching
+    # the exact running kernel (never true on WSL2). The kernel-version-
+    # specific binary under /usr/lib/linux-tools/*/usbip works regardless.
+    candidates = sorted(glob.glob('/usr/lib/linux-tools/*/usbip'))
+    if not candidates:
+        pytest.skip(
+            'usbip binary not found under /usr/lib/linux-tools/*/usbip -- '
+            'install with: sudo apt install linux-tools-generic linux-cloud-tools-generic'
+        )
+    return candidates[-1]
+
+
+def _usbip_port_for_vendor(usbip, vendor_id):
+    # `usbip port` prints one block per port, e.g.:
+    #   Port 00: <Port in Use> at Full Speed(12Mbps)
+    #          unknown vendor : unknown product (0456:b671)
+    # Split into per-port blocks so a match is only trusted when the
+    # vendor_id actually appears within *that* port's own block.
+    try:
+        result = subprocess.run(
+            ['sudo', usbip, 'port'], capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    for block in re.split(r'\n(?=Port \d+:)', result.stdout):
+        m = re.match(r'Port (\d+): <Port in Use>', block)
+        if m and f'({vendor_id}:' in block:
+            return m.group(1)
+    return None
+
+
+def _usbip_detach_stale(usbip, vendor_id):
+    # Best-effort cleanup of a stale attachment from a previous run, then
+    # wait for it to actually disappear from lsusb before returning. Only
+    # detaches the port actually holding our vendor_id -- never blindly
+    # port 0, which could be an unrelated device if this is run locally.
+    port = _usbip_port_for_vendor(usbip, vendor_id)
+    if port is None:
+        return
+    try:
+        subprocess.run(['sudo', usbip, 'detach', '-p', port], timeout=15)
+
+        pattern = re.compile(rf'ID {vendor_id}:')
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            result = subprocess.run(['lsusb'], capture_output=True, text=True, timeout=5)
+            if not pattern.search(result.stdout):
+                return
+            time.sleep(0.2)
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+
+
+def _wait_for_usbip_export(usbip, dut_ip, timeout_s=30.0):
+    # Poll `usbip list -r` rather than a DUT log line: there's no single
+    # log line marking when the DUT has something ready to export.
+    deadline = time.monotonic() + timeout_s
+    busid_re = re.compile(r'^\s+(\d+-\d+):', re.MULTILINE)
+    last_output = ''
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            ['sudo', usbip, 'list', '-r', dut_ip],
+            capture_output=True, text=True, timeout=5,
+        )
+        last_output = result.stdout + result.stderr
+        m = busid_re.search(last_output)
+        if m:
+            return m.group(1)
+        time.sleep(0.5)
+    pytest.fail(f'No exportable device found from {dut_ip} within {timeout_s}s:\n{last_output}')
+
+
+def _wait_for_attached_bus_dev(vendor_id, timeout_s=10.0):
+    # lsusb reflects enumeration almost immediately, but udev creates the
+    # /dev/bus/usb node asynchronously -- wait for both.
+    deadline = time.monotonic() + timeout_s
+    pattern = re.compile(rf'Bus (\d+) Device (\d+): ID {vendor_id}:')
+    while time.monotonic() < deadline:
+        result = subprocess.run(['lsusb'], capture_output=True, text=True, timeout=5)
+        m = pattern.search(result.stdout)
+        if m:
+            bus, dev = int(m.group(1)), int(m.group(2))
+            node = f'/dev/bus/usb/{bus:03d}/{dev:03d}'
+            if os.path.exists(node):
+                return f'{bus}.{dev}'
+        time.sleep(0.2)
+    pytest.fail(f'Device with VID {vendor_id} did not enumerate (with a ready device node) within {timeout_s}s')
+
+
+def _create_context_with_infinite_timeout(uri: str) -> iio.Context:
+    # iio.ContextParams is an unimplemented placeholder in the shipped
+    # bindings, so iio.Context(uri)'s normal constructor always uses the
+    # library's short default timeout for the initial handshake -- too
+    # short for this virtual UDC<->UHC<->USB/IP<->vhci_hcd chain. Fill in
+    # the real struct layout (matches struct iio_context_params in
+    # include/iio/iio.h) to request IIO_TIMEOUT_INFINITE instead.
+    if not hasattr(iio.ContextParams, '_fields_'):
+        iio.ContextParams._fields_ = [
+            ('out', ctypes.c_void_p),
+            ('err', ctypes.c_void_p),
+            ('log_level', ctypes.c_int),
+            ('stderr_level', ctypes.c_int),
+            ('timestamp_level', ctypes.c_int),
+            ('timeout_ms', ctypes.c_int),
+            ('flags', ctypes.c_uint),
+            ('_rsrv', ctypes.c_char * 32),
+        ]
+    params = iio.ContextParams(timeout_ms=-1)  # IIO_TIMEOUT_INFINITE
+    raw_ctx = iio._new_ctx(ctypes.byref(params), uri.encode('ascii'))
+    return iio.Context(raw_ctx)
+
+
+def _ensure_zeth_interface():
+    # The DUT's static IP (192.0.2.1) is only reachable once net-setup.sh's
+    # "zeth" TAP interface (192.0.2.2/24) exists. Idempotent: skip if
+    # already up.
+    result = subprocess.run(['ip', 'link', 'show', 'zeth'], capture_output=True, timeout=5)
+    if result.returncode == 0:
+        return
+
+    zephyr_base = os.environ.get('ZEPHYR_BASE')
+    if not zephyr_base:
+        pytest.skip('ZEPHYR_BASE not set -- cannot locate tools/net-tools/net-setup.sh')
+    net_setup = os.path.join(os.path.dirname(zephyr_base), 'tools', 'net-tools', 'net-setup.sh')
+    if not os.path.exists(net_setup):
+        pytest.skip(f'net-setup.sh not found at {net_setup}')
+
+    # `start` creates the interface and returns immediately.
+    subprocess.run(['sudo', net_setup, 'start'], check=True, timeout=15)
+
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline:
+        result = subprocess.run(['ip', 'link', 'show', 'zeth'], capture_output=True, timeout=5)
+        if result.returncode == 0:
+            return
+        time.sleep(0.2)
+    pytest.fail('zeth interface did not come up after `net-setup.sh start`')
+
+
+def _usb_context(dut: DeviceAdapter):
+    """
+    One-time host setup NOT performed by this fixture (see README.rst):
+      - `sudo apt install linux-tools-generic linux-cloud-tools-generic`
+      - a udev rule granting non-root access to VID 0456
+        (/etc/udev/rules.d/90-libiio-usb.rules)
+      - passwordless sudo for modprobe/usbip/net-setup.sh, e.g.:
+          dimlilic ALL=(root) NOPASSWD: /usr/sbin/modprobe vhci-hcd, \\
+            /usr/lib/linux-tools/*/usbip *, \\
+            /path/to/zephyr-orion1/tools/net-tools/net-setup.sh *
+
+    The TAP interface itself is automated (_ensure_zeth_interface()).
+    Uses an infinite context-creation timeout: real transfers over this
+    virtual UDC<->UHC<->USB/IP<->vhci_hcd chain can legitimately take
+    several seconds even when healthy.
+    """
+    usbip = _find_usbip_binary()
+
+    _ensure_zeth_interface()
+    subprocess.run(['sudo', 'modprobe', 'vhci-hcd'], check=True, timeout=15)
+    _usbip_detach_stale(usbip, _USB_VID)
+
+    busid = _wait_for_usbip_export(usbip, _USB_DUT_IP)
+    subprocess.run(['sudo', usbip, 'attach', '-r', _USB_DUT_IP, '-b', busid],
+                    check=True, timeout=15)
+
+    try:
+        bus_dev = _wait_for_attached_bus_dev(_USB_VID)
+
+        # A device node can briefly still be root-only after creation
+        # (udev applies its MODE rule as a separate step); settle once
+        # rather than retrying context creation, which was observed to
+        # leave the kernel's URB tracking in an unkillable D-state.
+        time.sleep(1.0)
+        ctx = _create_context_with_infinite_timeout(f'usb:{bus_dev}.0')
+        yield ctx
+        del ctx
+    finally:
+        # Detach only the port actually holding our device -- an un-detached
+        # port wedges the kernel state for the next run, but blindly
+        # detaching port 0 could clobber an unrelated device if this is run
+        # locally.
+        port = _usbip_port_for_vendor(usbip, _USB_VID)
+        if port is not None:
+            subprocess.run(['sudo', usbip, 'detach', '-p', port], timeout=15)
+

--- a/zephyr/samples/iiod/sample.yaml
+++ b/zephyr/samples/iiod/sample.yaml
@@ -9,6 +9,32 @@ common:
     regex:
       - "Booting Zephyr OS"
 tests:
+  sample.iiod.usb.pytest:
+    # Needs privileged one-time host setup (usbip client, TAP interface,
+    # vhci_hcd, udev rule -- see conftest.py's _usb_context()), so no
+    # integration_platforms. Run manually with:
+    #   west twister -p native_sim --test sample.iiod.usb.pytest
+    tags: usb-hostreq
+    extra_args:
+      - SNIPPET=iiod-usb
+      # Overlays/confs set here, not via CMakeLists.txt's Kconfig-gated
+      # append, which gets shadowed once EXTRA_DTC_OVERLAY_FILE is set.
+      - EXTRA_DTC_OVERLAY_FILE=adc-emul.overlay;sensor-emul.overlay
+      - EXTRA_CONF_FILE=adc-emul.conf;sensor-emul.conf
+    extra_configs:
+      - CONFIG_LIBIIO_IIOD_ADC_EMUL=y
+      - CONFIG_LIBIIO_IIOD_SENSOR_EMUL=y
+    platform_allow:
+      - native_sim
+    harness: pytest
+    timeout: 60
+    harness_config:
+      pytest_root:
+        - pytest/test_iiod.py
+      pytest_dut_scope: session
+      pytest_args:
+        - --iiod-transport=usb
+
   sample.iiod.network.pytest:
     extra_args:
       - SNIPPET=iiod-network
@@ -21,6 +47,8 @@ tests:
     harness: pytest
     timeout: 120
     harness_config:
+      pytest_root:
+        - pytest/test_iiod.py
       pytest_dut_scope: session
       pytest_args:
         - --iiod-transport=network
@@ -36,6 +64,8 @@ tests:
       - native_sim
     harness: pytest
     harness_config:
+      pytest_root:
+        - pytest/test_iiod.py
       pytest_dut_scope: session
       pytest_args:
         - --iiod-transport=uart

--- a/zephyr/snippets/iiod-usb/boards/native_sim.conf
+++ b/zephyr/snippets/iiod-usb/boards/native_sim.conf
@@ -9,11 +9,13 @@ CONFIG_NET_SOCKETS=y
 CONFIG_USB_HOST_STACK=y
 CONFIG_USBIP=y
 
-# Use Linux host TCP stack directly — no TAP interface or net-setup.sh needed
-CONFIG_ETH_NATIVE_TAP=n
-CONFIG_NET_NATIVE_OFFLOADED_SOCKETS=y
-CONFIG_NET_DRIVERS=y
-CONFIG_NET_SOCKETS_OFFLOAD=y
+# Static IPs for the zeth/TAP interface (matches conftest.py's
+# _ensure_zeth_interface()). CONFIG_NET_CONFIG_SETTINGS must be enabled or
+# these are silently ignored at boot.
+CONFIG_NET_CONFIG_SETTINGS=y
+CONFIG_NET_CONFIG_NEED_IPV4=y
+CONFIG_NET_CONFIG_MY_IPV4_ADDR="192.0.2.1"
+CONFIG_NET_CONFIG_PEER_IPV4_ADDR="192.0.2.2"
 
 # Virtual UHC/UDC bus needs fine-grained clock for USB transaction timing
 CONFIG_SYS_CLOCK_TICKS_PER_SEC=1000000


### PR DESCRIPTION
## PR Description

Adds automated test coverage for the Zephyr IIOD USB transport (native_sim + USB/IP), plus a bug fix uncovered while writing the tests.

zephyr: iiod: usb: fix pipe 0 desync after RESET_PIPES
An abandoned connection can leave stale protocol bytes in pipe 0's RX ring buffer. RESET_PIPES intentionally leaves pipe 0's state untouched, so the next client's first read desyncs against those bytes and crashes the interpreter. Tracks a reset_pending flag on pipe 0, set from the RESET_PIPES handler, and discards any buffered bytes at the top of the next read.

zephyr: samples: iiod: add LIBIIO_IIOD_USBIP_NATIVE_SIM option
Appends zephyr/snippets/usbip-native-sim's Kconfig fragment via an absolute $ENV{ZEPHYR_BASE}-anchored path in CMakeLists.txt, instead of requiring a relative EXTRA_CONF_FILE path on the command line.

zephyr: iiod: samples: add USB transport pytest coverage
Adds automated test coverage for the IIOD-over-USB transport on native_sim, no hardware required. native_sim.overlay swaps in a virtual UDC/UHC pair (the board's default zephyr,native-posix-udc never registers a struct device) and adds the adi,iio-usb node. native_sim.conf configures USB/IP over the zeth TAP interface with a static IP.

conftest.py's _usb_context() fixture drives the host side: modprobe vhci-hcd, attach via usbip, wait for the device node, then create the iio.Context. test_usb.py covers context/device enumeration, device presence, and a raw attribute read.

ci: zephyr: add USB IIOD regression job (native_sim + USB/IP)
Mirrors the existing network regression-tests job for the USB transport: installs usbip tooling, starts the TAP interface, builds libiio with the USB backend, and runs sample.iiod.usb.pytest. Runs on a disposable ubuntu-22.04 runner since a wedged USB/IP state can require a restart to clear. Kept non-blocking (continue-on-error: true) and time-boxed (timeout-minutes: 10) until proven reliable.

Testing
west twister -p native_sim -T modules/lib/libiio/zephyr/samples/iiod --test sample.iiod.usb.pytest → 3/3 test cases passed.

Signed-off-by: Dimitrije Lilic <dimitrije.lilic@orioninc.com>
## PR Type
- [x] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
