### PR TITLE
usb: only clear io_ctx->transfer if it still points to its own transfer

### DIFF
--- a/usb.c
+++ b/usb.c
@@ -698,7 +698,8 @@ unlock:
 
 	/* Same as above. This needs to be atomic in regards to usb_cancel(). */
 	iio_mutex_lock(io_ctx->lock);
-	io_ctx->transfer = NULL;
+	if (io_ctx->transfer == transfer)
+		io_ctx->transfer = NULL;
 	iio_mutex_unlock(io_ctx->lock);
 
 	libusb_free_transfer(transfer);


### PR DESCRIPTION
It has been observed for Zephyr and no-OS devices running libiio servers that the libiio client interrogating them sometimes remains hanging, never terminating. This showed up intermittently with iio_info over the USB backend: the client stops making progress and never returns, and has to be killed manually. Debugging shows the main thread parked in the join waiting for the read thread, while the read thread is parked forever in the while (!completed) event loop in usb_sync_transfer().

The USB write and read threads share the same io_ctx, and therefore the same io_ctx->transfer slot. Read blocks in usb_sync_transfer() until it either receives a response on the IN endpoint or its transfer is aborted via libusb_cancel_transfer() (which triggers sync_transfer_cb() and sets completed to 1).

When the write thread finishes before read, it unconditionally set io_ctx->transfer to NULL on cleanup. But read was still pending, and the transfer pointer it relied on in the shared slot had just been cleared out from under it. At teardown, usb_cancel() then finds io_ctx->transfer == NULL and never calls libusb_cancel_transfer(), so sync_transfer_cb() never fires for read's transfer, completed is never set, and read hangs forever - and so does the join.

transfer is a per-call local variable while io_ctx->transfer is a shared slot. Guarding the clear with "if (io_ctx->transfer == transfer)" makes the write path clear the slot only when it still holds its own transfer, so once read has published its transfer into the slot write leaves it untouched and it stays visible to usb_cancel().

Tested with thousands of successive iio_info invocations without a single hang.

## PR Description

- Please replace this comment with a summary of your changes, and add any context
necessary to understand them. List any dependencies required for this change.
- To check the checkboxes below, insert a 'x' between square brackets (without
any space), or simply check them after publishing the PR.
- If you changes include a breaking change, please specify dependent PRs in the
description and try to push all related PRs simultaneously.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
