### PR TITLE
ci: add missing deps for check-artifacts cmake run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,8 @@ jobs:
           set -e
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
-          apt-get install -y build-essential cmake git
+          apt-get install -y build-essential cmake git pkg-config \
+            libxml2-dev libusb-1.0-0-dev libavahi-client-dev bison flex
 
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
v0's CMakeLists.txt requires libusb-1.0 and libxml2 for configure_file to generate the artifact manifest.
