### PR TITLE
ci: add libaio-dev to check-artifacts dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,8 @@ jobs:
           export DEBIAN_FRONTEND=noninteractive
           apt-get update
           apt-get install -y build-essential cmake git pkg-config \
-            libxml2-dev libusb-1.0-0-dev libavahi-client-dev bison flex
+            libxml2-dev libusb-1.0-0-dev libavahi-client-dev libaio-dev \
+            bison flex
 
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
One more dependency is missing from the Check Artifacts stage of the build.