### PR TITLE
ci: flatten macOS artifacts for Cloudsmith upload

### DIFF
--- a/.github/workflows/_macos-builds.yml
+++ b/.github/workflows/_macos-builds.yml
@@ -68,10 +68,14 @@ jobs:
           ./macos_tar_fixup.sh
           cd ..
 
+      - name: Collect artifacts
+        run: |
+          mkdir -p staging
+          cp build/*.pkg staging/
+          cp build_tar/*.tar.gz staging/
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
-          path: |
-            build/*.pkg
-            build_tar/*.tar.gz
+          path: staging/


### PR DESCRIPTION
Fix macOS artifacts not being uploaded to Cloudsmith: the upload step used two source paths (`build/*.pkg` and `build_tar/*.tar.gz`), causing `upload-artifact` to preserve the directory structure. The Cloudsmith push loop only checks immediate children, so nested files were silently skipped. Collect outputs into a flat staging directory before uploading.
