### PR TITLE
compat, iiod: fix buffered I/O for v0 applications

### DIFF
--- a/compat.c
+++ b/compat.c
@@ -140,6 +140,11 @@ struct compat {
 	void (*iio_channel_convert)(const struct iio_channel *, void *, const void *);
 	void (*iio_channel_convert_inverse)(const struct iio_channel *, void *, const void *);
 
+	size_t (*iio_channel_read)(const struct iio_channel *, const struct iio_block *,
+			void *, size_t, bool);
+	size_t (*iio_channel_write)(const struct iio_channel *, struct iio_block *,
+			const void *, size_t, bool);
+
 	void (*iio_channel_enable)(const struct iio_channel *, struct iio_channels_mask *);
 	void (*iio_channel_disable)(const struct iio_channel *, struct iio_channels_mask *);
 	bool (*iio_channel_is_enabled)(
@@ -2153,6 +2158,42 @@ void *iio_buffer_end(const struct iio_buffer *buf)
 	return IIO_CALL(iio_block_end)(block);
 }
 
+size_t iio_channel_read_raw(const struct iio_channel *chn,
+		struct iio_buffer *buf, void *dst, size_t len)
+{
+	struct iio_buffer_compat *compat = IIO_CALL(iio_buffer_get_data)(buf);
+
+	return IIO_CALL(iio_channel_read)(chn, compat->blocks[compat->curr],
+					  dst, len, true);
+}
+
+size_t iio_channel_read(const struct iio_channel *chn,
+		struct iio_buffer *buf, void *dst, size_t len)
+{
+	struct iio_buffer_compat *compat = IIO_CALL(iio_buffer_get_data)(buf);
+
+	return IIO_CALL(iio_channel_read)(chn, compat->blocks[compat->curr],
+					  dst, len, false);
+}
+
+size_t iio_channel_write_raw(const struct iio_channel *chn,
+		struct iio_buffer *buf, const void *src, size_t len)
+{
+	struct iio_buffer_compat *compat = IIO_CALL(iio_buffer_get_data)(buf);
+
+	return IIO_CALL(iio_channel_write)(chn, compat->blocks[compat->curr],
+					   src, len, true);
+}
+
+size_t iio_channel_write(const struct iio_channel *chn,
+		struct iio_buffer *buf, const void *src, size_t len)
+{
+	struct iio_buffer_compat *compat = IIO_CALL(iio_buffer_get_data)(buf);
+
+	return IIO_CALL(iio_channel_write)(chn, compat->blocks[compat->curr],
+					   src, len, false);
+}
+
 ssize_t iio_buffer_foreach_sample(struct iio_buffer *buf,
 		ssize_t (*callback)(
 				const struct iio_channel *chn, void *src, size_t bytes, void *d),
@@ -2262,6 +2303,8 @@ static void compat_lib_init(void)
 	FIND_SYMBOL(ctx->lib, iio_channel_get_data_format);
 	FIND_SYMBOL(ctx->lib, iio_channel_convert);
 	FIND_SYMBOL(ctx->lib, iio_channel_convert_inverse);
+	FIND_SYMBOL(ctx->lib, iio_channel_read);
+	FIND_SYMBOL(ctx->lib, iio_channel_write);
 	FIND_SYMBOL(ctx->lib, iio_channel_enable);
 	FIND_SYMBOL(ctx->lib, iio_channel_disable);
 	FIND_SYMBOL(ctx->lib, iio_channel_is_enabled);

--- a/compat.c
+++ b/compat.c
@@ -1967,7 +1967,12 @@ struct iio_buffer *iio_device_create_buffer(
 	}
 
 	if (!dev_compat->is_tx) {
-		for (j = 1; j < nb_blocks; j++) {
+		/*
+		 * Enqueue every block, block 0 included, before the stream is
+		 * started. On an input buffer the kernel is the writer, so
+		 * there is nothing for userspace to hold back.
+		 */
+		for (j = 0; j < nb_blocks; j++) {
 			err = IIO_CALL(iio_block_enqueue)(compat->blocks[j], 0, false);
 			if (err)
 				goto err_free_blocks;
@@ -1977,6 +1982,8 @@ struct iio_buffer *iio_device_create_buffer(
 		if (err)
 			goto err_free_blocks;
 
+		/* Block 0 is already queued, so refill() must not queue it again. */
+		compat->enqueued = true;
 		compat->all_enqueued = true;
 	}
 

--- a/iiod/ops.c
+++ b/iiod/ops.c
@@ -101,6 +101,12 @@ struct DevEntry {
 	bool closed;
 	bool cancelled;
 
+	/*
+	 * Set once every output block has been queued with data. Guards
+	 * iio_block_dequeue(), like stream.c's all_enqueued.
+	 */
+	bool tx_all_enqueued;
+
 	unsigned int nb_blocks, curr_block;
 
 	/* Linked list of ThdEntry structures corresponding
@@ -370,6 +376,7 @@ static int create_buf_and_blocks(
 
 	entry->nb_blocks = nb_blocks;
 	entry->curr_block = 0;
+	entry->tx_all_enqueued = false;
 
 	return 0;
 
@@ -417,6 +424,8 @@ static void rw_thd(struct thread_pool *pool, void *d)
 	unsigned int nb_channels = iio_device_get_channels_count(dev);
 	struct iio_channel *chn;
 	struct iio_block *block;
+	struct iio_buffer *buf0 = iio_device_get_buffer(dev, 0);
+	bool is_output = buf0 && iio_buffer_is_output(buf0);
 	ssize_t nb_bytes, ret = 0;
 
 	IIO_DEBUG("R/W thread started for device %s\n", dev_label_or_name_or_id(dev));
@@ -462,13 +471,20 @@ static void rw_thd(struct thread_pool *pool, void *d)
 			}
 			entry->cancelled = false;
 
-			/* Enqueue empty blocks, to make sure they can be queued with data */
-			for (i = 0; !ret && i < entry->nb_blocks; i++)
-				ret = iio_block_enqueue(entry->blocks[i], 0, false);
+			/*
+			 * Enqueue empty blocks, to make sure they can be queued
+			 * with data. Input only: iio_block_enqueue() promotes
+			 * bytes_used == 0 to the full block size, which on an
+			 * output buffer would transmit an uninitialised block.
+			 */
+			if (!is_output) {
+				for (i = 0; !ret && i < entry->nb_blocks; i++)
+					ret = iio_block_enqueue(entry->blocks[i], 0, false);
 
-			if (i < entry->nb_blocks) {
-				IIO_ERROR("Unable to enqueue blocks\n");
-				break;
+				if (i < entry->nb_blocks) {
+					IIO_ERROR("Unable to enqueue blocks\n");
+					break;
+				}
 			}
 
 			ret = iio_buffer_stream_start(entry->buf_stream);
@@ -520,7 +536,20 @@ static void rw_thd(struct thread_pool *pool, void *d)
 
 		block = entry->blocks[entry->curr_block];
 
-		ret = iio_block_dequeue(block, false);
+		if (entry->cyclic) {
+			/*
+			 * A cyclic transfer has no completion callback, so the
+			 * block never comes back and there is nothing to wait
+			 * for. responder.c does the same.
+			 */
+			ret = 0;
+		} else if (is_output && !entry->tx_all_enqueued) {
+			/* Nothing queued on this output buffer yet, so there is
+			 * nothing to dequeue. */
+			ret = 0;
+		} else {
+			ret = iio_block_dequeue(block, false);
+		}
 
 		pthread_mutex_lock(&entry->thdlist_lock);
 
@@ -532,9 +561,15 @@ static void rw_thd(struct thread_pool *pool, void *d)
 			for (thd = SLIST_FIRST(&entry->thdlist_head); thd; thd = next_thd) {
 				next_thd = SLIST_NEXT(thd, dev_list_entry);
 
-				if (!thd->active || thd->is_writer)
+				if (!thd->active)
 					continue;
 
+				/*
+				 * Writers too: only signal_thread() clears
+				 * thd->nb, so an unsignalled writer keeps
+				 * has_writers true and this loop spins on the
+				 * same failing dequeue.
+				 */
 				signal_thread(thd, ret);
 			}
 
@@ -613,6 +648,7 @@ static void rw_thd(struct thread_pool *pool, void *d)
 
 		ret = iio_block_enqueue(block, nb_bytes, entry->cyclic);
 		entry->curr_block = (entry->curr_block + 1) % entry->nb_blocks;
+		entry->tx_all_enqueued |= is_output && entry->curr_block == 0;
 
 		if (entry->cancelled) {
 			pthread_mutex_unlock(&entry->thdlist_lock);


### PR DESCRIPTION
## PR Description

Three fixes to the v0 compat path: two in the compat layer, one in iiod's v0 protocol support.

### Benefits

- libm2k works through the compat layer at all — it calls `iio_channel_write()` on every push, which failed to resolve
- Input buffers work with `nb_kernel_buffers` set to 1, which previously could not read a sample
- Fixes the Scopy Signal Generator freeze on M2K: Run hung the UI and left the DAC at `-EBUSY` until iiod restarted

### Changes

- Add `iio_channel_read()`, `iio_channel_read_raw()`, `iio_channel_write()`, `iio_channel_write_raw()`
- Queue every input block in `iio_device_create_buffer()` before `iio_buffer_stream_start()`, matching `stream.c`; set `compat->enqueued` so `refill()` doesn't queue block 0 twice
- Restrict `rw_thd()`'s empty-block pre-enqueue to input buffers
- Add `tx_all_enqueued` to `struct DevEntry`, guarding `iio_block_dequeue()` on output buffers
- Skip the dequeue for cyclic transfers, which have no completion callback
- Signal writer threads as well as readers on completion

### Backwards Compatibility

No API or ABI change — four unresolved functions added, none changed. TX still keeps block 0 for the application to write. The iiod change drops a transfer that was never meaningful.

### Testing

| test | before | after |
|---|---|---|
| any libm2k use | `undefined symbol: iio_channel_write` at import | works |
| Scopy Signal Generator Run | UI freeze, DAC stuck at `-EBUSY` | works |
| `test_pattern_generator_pulse` | hangs forever | passes |
| `test_noncyclic_buffer` | hangs forever | passes, 0.6 s |

- v0 ABI now complete: 147 symbols, no gaps against a real 0.26 build
- `iio_info`, `iio_attr`, `iio_genxml` byte-identical to the pre-fix layer across 9 XML contexts; `iio_attr` matches 0.26 in all four modes
- `dummy-iiostream`, `iio_readdev` and `iio_writedev` from the v0 branch, cyclic and non-cyclic
- `ad9361-iiostream` on an FMCOMMS2: simultaneous RX+TX, non-cyclic 1 MiS buffers, ~46 MSmp each way over 20 s through the compat layer and ~48 MSmp with a real 0.26 client
- builds clean with `LIBIIO_COMPAT`, `WITH_IIOD` and `WITH_IIOD_V0_COMPAT` each on and off
- libm2k suite: 70 pass, 1 fail, 4 error, 1 skip of 76; the failures are pre-existing

Also wrote a v0-API hardware harness, run two ways — through the compat layer against a stock 1.x iiod, and with a real 0.26 client against a patched iiod, since only the latter reaches `rw_thd()`. It covers: RX refill with `nb_kernel_buffers` at 1 and at the default, all four new channel helpers, TX non-cyclic across more cycles than there are kernel buffers, TX cyclic start/teardown/reopen, and an induced dequeue failure checking the daemon is not left wedged.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
