### PR TITLE
zephyr: Add support for the Zephyr SENSOR_CHAN_LIGHT channel

### DIFF
--- a/zephyr/drivers/iio_device/sensor.c
+++ b/zephyr/drivers/iio_device/sensor.c
@@ -60,6 +60,7 @@ static const struct sensor_channel_map channel_map[] = {
 
 	{SENSOR_CHAN_PRESS,         "pressure",         NULL,      16, false},
 	{SENSOR_CHAN_HUMIDITY,      "humidityrelative", NULL,      16, false},
+	{SENSOR_CHAN_LIGHT,         "illuminance",      NULL,      16, false},
 	{SENSOR_CHAN_AMBIENT_LIGHT, "illuminance",      NULL,      16, false},
 };
 


### PR DESCRIPTION

## PR Description

Include support for the other Zephyr light channel, used by some sensor drivers (e.g. veml7700). Tested locally with an Adafruid VEML7700 board connected over STEMMA to an Adafruit Metro RP2040 board.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
