### PR TITLE
Fix not being able to read iio events when connected to an IIOD server

### DIFF
--- a/iiod-client.c
+++ b/iiod-client.c
@@ -1831,7 +1831,7 @@ struct iio_event_stream_pdata *iiod_client_open_event_stream(
 	/* Use infinite timeout for blocking events reads, as those only make
 	 * sense when running in a thread, and we don't want them to return
 	 * without any event. */
-	iiod_io_set_timeout(pdata->io, 0);
+	iiod_io_set_timeout(pdata->io, -1);
 
 	/* Send a request to read an event. This bootstraps the event reading
 	 * mechanism. */


### PR DESCRIPTION

## PR Description
09b757dc changed the internal timeout convention to match poll(): -1 means wait forever, 0 means do not wait at all, and a positive value is a timeout in milliseconds. Before that, 0 was the value that meant wait forever. One call site was not updated - the one that puts the event stream into "infinite timeout" mode - so the event stream ended up asking for the exact opposite of what its comment says: never wait.

The visible effect is that iio_device_create_event_stream() fails with "Connection timed out" against any remote context, including iiod, tinyiiod and no-OS servers. Nothing has actually timed out: while setting up the stream the client queues its first "read an event" request, then instantly gives up waiting for that request to be sent and cancels it. The request never leaves the client, and the stream is torn down. Server logs show the event stream being opened and closed again with no read in between, and the client fails within a fraction of a second instead of after its configured timeout.

It is a race, if the background thread that writes to the socket happens to pick up the request before the cancel arrives, the request goes out and events are received normally. Any delay on the client side - stepping through the code in a debugger, for instance - makes the problem disappear.

Pass -1 so blocking event reads wait indefinitely, as intended. This was the only call site left using 0 to mean infinite.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
