### PR TITLE
Check if context is invalid before using it in iio-event utility

### DIFF
--- a/utils/iio_event.c
+++ b/utils/iio_event.c
@@ -132,6 +132,9 @@ int main(int argc, char **argv)
 		goto out_ctx_destroy;
 	}
 
+	if (!ctx)
+		goto out_ctx_destroy;
+
 	name = cmn_strndup(argw[optind], NAME_MAX);
 	dev = iio_context_find_device(ctx, name);
 	free(name);


### PR DESCRIPTION
## PR Description

Check if the iio context returned by `handle_common_opts()` is valid and close application if it's not.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [ ] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
