### PR TITLE
zephyr: Add Zephyr implementation of the libiio lock and thread API

### DIFF
--- a/.github/workflows/zephyr.yml
+++ b/.github/workflows/zephyr.yml
@@ -60,7 +60,7 @@ jobs:
           if [ "${{ runner.os }}" = "Windows" ]; then
             EXTRA_TWISTER_FLAGS="--short-build-path -O/tmp/twister-out"
           fi
-          west twister -T samples -v --force-color --inline-logs --integration \
+          west twister -T samples -T tests -v --force-color --inline-logs --integration \
             --exclude-tag usb-hostreq $EXTRA_TWISTER_FLAGS
 
   regression-tests:

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -1350,10 +1350,12 @@ static void iiod_responder_free_resources(struct parser_pdata *pdata)
 int binary_parse(struct parser_pdata *pdata)
 {
 	struct iiod_responder *responder;
+	int ret;
 
 	responder = iiod_responder_create(&iiod_responder_ops, pdata);
-	if (!responder)
-		return -ENOMEM;
+	ret = iio_err(responder);
+	if (ret)
+		return ret;
 
 	/* TODO: poll main thread pool FD */
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -13,7 +13,6 @@ if(CONFIG_LIBIIO)
     ${ZEPHYR_LIBIIO_MODULE_DIR}/channel.c
     ${ZEPHYR_LIBIIO_MODULE_DIR}/attr.c
     ${ZEPHYR_LIBIIO_MODULE_DIR}/utilities.c
-    ${ZEPHYR_LIBIIO_MODULE_DIR}/lock-dummy.c
     ${ZEPHYR_LIBIIO_MODULE_DIR}/scan.c
     ${ZEPHYR_LIBIIO_MODULE_DIR}/buffer.c
     ${ZEPHYR_LIBIIO_MODULE_DIR}/stream.c
@@ -30,6 +29,16 @@ if(CONFIG_LIBIIO)
     ${ZEPHYR_LIBIIO_MODULE_DIR}/zephyr/libiio_log.c
   )
 
+  # The lock backend and NO_THREADS must change together: the NO_THREADS paths
+  # in task.c release a mutex they do not hold, which only works with no-ops.
+  if(CONFIG_LIBIIO_MULTITHREADING)
+    zephyr_library_sources(${ZEPHYR_LIBIIO_MODULE_DIR}/zephyr/lock.c)
+    set(LIBIIO_NO_THREADS 0)
+  else()
+    zephyr_library_sources(${ZEPHYR_LIBIIO_MODULE_DIR}/lock-dummy.c)
+    set(LIBIIO_NO_THREADS 1)
+  endif()
+
   zephyr_include_directories(
     ${ZEPHYR_LIBIIO_MODULE_DIR}/zephyr/include
     ${ZEPHYR_LIBIIO_MODULE_DIR}/include
@@ -41,7 +50,7 @@ if(CONFIG_LIBIIO)
 
   zephyr_library_compile_definitions(
     LIBIIO_STATIC=1
-    NO_THREADS=1
+    NO_THREADS=${LIBIIO_NO_THREADS}
     WITH_ZSTD=0
     WITH_LIBTINYIIOD=1
     WITH_EXTERNAL_BACKEND=1

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -22,6 +22,70 @@ config LIBIIO_LOG_MSG_SIZE
 	  logging subsystem. Increase this value if libiio log messages are
 	  being truncated.
 
+config LIBIIO_MULTITHREADING
+	bool "libiio multi-threading support"
+	help
+	  Build libiio with real locking and threading, backed by Zephyr
+	  k_mutex/k_condvar/k_thread instead of the no-op stubs in
+	  lock-dummy.c, and with NO_THREADS=0. The two must change together:
+	  the NO_THREADS paths in task.c run task bodies inline and release a
+	  mutex they do not hold, which is only harmless with no-op mutexes.
+
+	  Enable this when more than one iiod interpreter runs concurrently, as
+	  the network and USB transports already do. The responder then gets
+	  its own reader and writer threads and the locks on the shared buffer
+	  and event stream lists take effect.
+
+if LIBIIO_MULTITHREADING
+
+config LIBIIO_THREAD_POOL_SIZE
+	int "Maximum number of libiio internal threads"
+	default 12 if LIBIIO_IIOD_NETWORK
+	default 6
+	help
+	  Slots in the static libiio thread pool. Each costs
+	  LIBIIO_THREAD_STACK_SIZE bytes whether used or not.
+
+	  Demand is 2 per connection (responder reader and writer), plus 2 per
+	  iiod buffer and 1 per buffer or event stream.
+
+config LIBIIO_THREAD_STACK_SIZE
+	int "Stack size for libiio internal threads"
+	default 4096
+	help
+	  Stack size for each pool slot. The deepest user is the responder
+	  reader thread running the iiod command dispatch.
+
+config LIBIIO_THREAD_PRIORITY
+	int "Priority for libiio internal threads"
+	default 5
+	help
+	  Priority for every thread in the pool.
+
+config LIBIIO_MUTEX_POOL_SIZE
+	int "Maximum number of libiio mutexes"
+	default 48 if LIBIIO_IIOD_NETWORK
+	default 24
+	help
+	  Slots in the static iio_mutex pool. Three are held permanently by
+	  tinyiiod. Each connection needs one for the responder, one for its
+	  default io, one for the writer task, and one per in-flight task token
+	  and command-created io. Each iiod buffer adds one for the buffer
+	  entry, one for the stream, one per enqueue/dequeue task and one per
+	  block token.
+
+config LIBIIO_COND_POOL_SIZE
+	int "Maximum number of libiio condition variables"
+	default 32 if LIBIIO_IIOD_NETWORK
+	default 16
+	help
+	  Slots in the static iio_cond pool. Condition variables pair with
+	  mutexes everywhere except the global tinyiiod locks and the
+	  per-buffer and per-stream locks, so this can be smaller than
+	  LIBIIO_MUTEX_POOL_SIZE.
+
+endif # LIBIIO_MULTITHREADING
+
 rsource "drivers/Kconfig"
 rsource "iiod/Kconfig"
 

--- a/zephyr/iiod/Kconfig
+++ b/zephyr/iiod/Kconfig
@@ -3,6 +3,7 @@
 
 menuconfig LIBIIO_IIOD_NETWORK
 	bool "Network iiod server"
+	imply LIBIIO_MULTITHREADING
 	help
 	  Enable the iiod server over a network interface.
 
@@ -83,6 +84,7 @@ endif # LIBIIO_IIOD_UART
 
 menuconfig LIBIIO_IIOD_USB
 	bool "USB iiod server"
+	imply LIBIIO_MULTITHREADING
 	depends on USB_DEVICE_STACK_NEXT
 	depends on DT_HAS_ADI_IIO_USB_ENABLED
 	help

--- a/zephyr/lock.c
+++ b/zephyr/lock.c
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <iio/iio.h>
+#include <iio/iio-lock.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/bitarray.h>
+#include <zephyr/toolchain.h>
+
+#include <errno.h>
+
+LOG_MODULE_REGISTER(libiio_lock, CONFIG_LIBIIO_LOG_LEVEL);
+
+struct iio_thrd {
+	struct k_thread thread;
+	size_t slot;
+	int (*fn)(void *);
+	void *arg;
+	int ret;
+};
+
+static struct k_mutex iio_mutex_pool[CONFIG_LIBIIO_MUTEX_POOL_SIZE];
+SYS_BITARRAY_DEFINE_STATIC(iio_mutex_bitarray, CONFIG_LIBIIO_MUTEX_POOL_SIZE);
+
+static struct k_condvar iio_cond_pool[CONFIG_LIBIIO_COND_POOL_SIZE];
+SYS_BITARRAY_DEFINE_STATIC(iio_cond_bitarray, CONFIG_LIBIIO_COND_POOL_SIZE);
+
+static K_KERNEL_STACK_ARRAY_DEFINE(iio_thread_stacks, CONFIG_LIBIIO_THREAD_POOL_SIZE,
+				   CONFIG_LIBIIO_THREAD_STACK_SIZE);
+
+static struct iio_thrd iio_thread_pool[CONFIG_LIBIIO_THREAD_POOL_SIZE];
+SYS_BITARRAY_DEFINE_STATIC(iio_thread_bitarray, CONFIG_LIBIIO_THREAD_POOL_SIZE);
+
+struct iio_mutex *iio_mutex_create(void)
+{
+	size_t bit;
+
+	if (sys_bitarray_alloc(&iio_mutex_bitarray, 1, &bit) < 0) {
+		LOG_ERR("Out of iio_mutex slots, raise CONFIG_LIBIIO_MUTEX_POOL_SIZE (%d)",
+			CONFIG_LIBIIO_MUTEX_POOL_SIZE);
+		return iio_ptr(-ENOMEM);
+	}
+
+	k_mutex_init(&iio_mutex_pool[bit]);
+
+	return (struct iio_mutex *)&iio_mutex_pool[bit];
+}
+
+void iio_mutex_destroy(struct iio_mutex *lock)
+{
+	struct k_mutex *m = (struct k_mutex *)lock;
+	int ret;
+
+	__ASSERT(IS_ARRAY_ELEMENT(iio_mutex_pool, m),
+		 "iio_mutex_destroy() on a pointer outside the pool");
+
+	/* -EFAULT means the slot was already free, so two owners now share it. */
+	ret = sys_bitarray_free(&iio_mutex_bitarray, 1, m - iio_mutex_pool);
+	__ASSERT(ret == 0, "iio_mutex slot %d was not allocated (%d)",
+		 (int)(m - iio_mutex_pool), ret);
+	ARG_UNUSED(ret);
+}
+
+void iio_mutex_lock(struct iio_mutex *lock)
+{
+	struct k_mutex *m = (struct k_mutex *)lock;
+
+	__ASSERT(IS_ARRAY_ELEMENT(iio_mutex_pool, m),
+		 "iio_mutex_lock() on a pointer outside the pool");
+
+	k_mutex_lock(m, K_FOREVER);
+}
+
+void iio_mutex_unlock(struct iio_mutex *lock)
+{
+	struct k_mutex *m = (struct k_mutex *)lock;
+
+	__ASSERT(IS_ARRAY_ELEMENT(iio_mutex_pool, m),
+		 "iio_mutex_unlock() on a pointer outside the pool");
+
+	k_mutex_unlock(m);
+}
+
+struct iio_cond *iio_cond_create(void)
+{
+	size_t bit;
+
+	if (sys_bitarray_alloc(&iio_cond_bitarray, 1, &bit) < 0) {
+		LOG_ERR("Out of iio_cond slots, raise CONFIG_LIBIIO_COND_POOL_SIZE (%d)",
+			CONFIG_LIBIIO_COND_POOL_SIZE);
+		return iio_ptr(-ENOMEM);
+	}
+
+	k_condvar_init(&iio_cond_pool[bit]);
+
+	return (struct iio_cond *)&iio_cond_pool[bit];
+}
+
+void iio_cond_destroy(struct iio_cond *cond)
+{
+	struct k_condvar *c = (struct k_condvar *)cond;
+	int ret;
+
+	__ASSERT(IS_ARRAY_ELEMENT(iio_cond_pool, c),
+		 "iio_cond_destroy() on a pointer outside the pool");
+
+	ret = sys_bitarray_free(&iio_cond_bitarray, 1, c - iio_cond_pool);
+	__ASSERT(ret == 0, "iio_cond slot %d was not allocated (%d)",
+		 (int)(c - iio_cond_pool), ret);
+	ARG_UNUSED(ret);
+}
+
+int iio_cond_wait(struct iio_cond *cond, struct iio_mutex *lock, int timeout_ms)
+{
+	struct k_condvar *c = (struct k_condvar *)cond;
+	struct k_mutex *m = (struct k_mutex *)lock;
+	int ret;
+
+	__ASSERT(IS_ARRAY_ELEMENT(iio_cond_pool, c),
+		 "iio_cond_wait() on a pointer outside the pool");
+
+	__ASSERT(IS_ARRAY_ELEMENT(iio_mutex_pool, m),
+		 "iio_cond_wait() on a pointer outside the pool");
+
+	/* Do not wait, and keep the mutex held, as the other backends do. */
+	if (timeout_ms == 0)
+		return -ETIMEDOUT;
+
+	ret = k_condvar_wait(c, m, timeout_ms < 0 ? K_FOREVER : K_MSEC(timeout_ms));
+
+	/* libiio callers expect -ETIMEDOUT, k_condvar_wait() reports -EAGAIN */
+	if (ret == -EAGAIN)
+		return -ETIMEDOUT;
+
+	return ret;
+}
+
+void iio_cond_signal(struct iio_cond *cond)
+{
+	struct k_condvar *c = (struct k_condvar *)cond;
+
+	__ASSERT(IS_ARRAY_ELEMENT(iio_cond_pool, c),
+		 "iio_cond_signal() on a pointer outside the pool");
+
+	k_condvar_signal(c);
+}
+
+static void iio_thrd_entry(void *p1, void *p2, void *p3)
+{
+	struct iio_thrd *thrd = p1;
+
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	thrd->ret = thrd->fn(thrd->arg);
+}
+
+struct iio_thrd *iio_thrd_create(int (*thrd)(void *), void *d, const char *name)
+{
+	struct iio_thrd *iio_thrd;
+	size_t bit;
+
+	if (!thrd)
+		return iio_ptr(-EINVAL);
+
+	if (sys_bitarray_alloc(&iio_thread_bitarray, 1, &bit) < 0) {
+		LOG_ERR("Out of iio_thrd slots, raise CONFIG_LIBIIO_THREAD_POOL_SIZE (%d)",
+			CONFIG_LIBIIO_THREAD_POOL_SIZE);
+		return iio_ptr(-ENOMEM);
+	}
+
+	iio_thrd = &iio_thread_pool[bit];
+	iio_thrd->slot = bit;
+	iio_thrd->fn = thrd;
+	iio_thrd->arg = d;
+	iio_thrd->ret = 0;
+
+	k_thread_create(&iio_thrd->thread, iio_thread_stacks[bit],
+			K_KERNEL_STACK_SIZEOF(iio_thread_stacks[bit]),
+			iio_thrd_entry, iio_thrd, NULL, NULL,
+			CONFIG_LIBIIO_THREAD_PRIORITY, 0, K_NO_WAIT);
+
+	if (IS_ENABLED(CONFIG_THREAD_NAME) && name)
+		(void)k_thread_name_set(&iio_thrd->thread, name);
+
+	return iio_thrd;
+}
+
+int iio_thrd_join_and_destroy(struct iio_thrd *thrd)
+{
+	int ret, err;
+
+	__ASSERT(IS_ARRAY_ELEMENT(iio_thread_pool, thrd),
+		 "iio_thrd_join_and_destroy() on a pointer outside the pool");
+
+	k_thread_join(&thrd->thread, K_FOREVER);
+	ret = thrd->ret;
+
+	err = sys_bitarray_free(&iio_thread_bitarray, 1, thrd->slot);
+	__ASSERT(err == 0, "iio_thrd slot %d was not allocated (%d)", (int)thrd->slot, err);
+	ARG_UNUSED(err);
+
+	return ret;
+}

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -8,5 +8,7 @@ build:
   settings:
     dts_root: zephyr
     snippet_root: zephyr
+tests:
+  - zephyr/tests
 samples:
   - zephyr/samples

--- a/zephyr/samples/iiod/sample.yaml
+++ b/zephyr/samples/iiod/sample.yaml
@@ -70,6 +70,23 @@ tests:
       pytest_args:
         - --iiod-transport=uart
 
+  sample.iiod.uart.multithread.pytest:
+    extra_args:
+      - SNIPPET=iiod-console
+      - CONFIG_LIBIIO_IIOD_ADC_EMUL=y
+      - CONFIG_LIBIIO_IIOD_SENSOR_EMUL=y
+      - CONFIG_LIBIIO_MULTITHREADING=y
+    platform_allow:
+      - native_sim
+    integration_platforms:
+      - native_sim
+    harness: pytest
+    timeout: 120
+    harness_config:
+      pytest_dut_scope: session
+      pytest_args:
+        - --iiod-transport=uart
+
   sample.iiod.usb:
     extra_args:
       - SNIPPET=iiod-usb

--- a/zephyr/tests/iiod_concurrent/CMakeLists.txt
+++ b/zephyr/tests/iiod_concurrent/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(libiio_iiod_concurrent)
+
+target_sources(app PRIVATE src/main.c)

--- a/zephyr/tests/iiod_concurrent/app.overlay
+++ b/zephyr/tests/iiod_concurrent/app.overlay
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/ {
+	iio-context {
+		iio-adcs {
+			adc-emul {
+				compatible = "iio,io-channels";
+				io-channels = <&adc_emul 0>, <&adc_emul 1>;
+				io-channel-names = "voltage0", "voltage1";
+				io-name = "adc-emul";
+			};
+		};
+	};
+
+	generator {
+		compatible = "iio,adc-emul-generator";
+		io-channels = <&adc_emul 0>, <&adc_emul 1>;
+	};
+
+	adc_emul: adc {
+		compatible = "zephyr,adc-emul";
+		nchannels = <2>;
+		ref-internal-mv = <3300>;
+		ref-external1-mv = <5000>;
+		#io-channel-cells = <1>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		channel@0 {
+			reg = <0>;
+			zephyr,gain = "ADC_GAIN_1";
+			zephyr,reference = "ADC_REF_INTERNAL";
+			zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+			zephyr,resolution = <10>;
+		};
+
+		channel@1 {
+			reg = <1>;
+			zephyr,gain = "ADC_GAIN_1";
+			zephyr,reference = "ADC_REF_INTERNAL";
+			zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+			zephyr,resolution = <10>;
+		};
+	};
+};

--- a/zephyr/tests/iiod_concurrent/prj.conf
+++ b/zephyr/tests/iiod_concurrent/prj.conf
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+CONFIG_POSIX_API=y
+CONFIG_LIBIIO=y
+CONFIG_LIBIIO_MULTITHREADING=y
+
+# Emulated ADC, so the test has channels to read without any hardware.
+CONFIG_ADC=y
+CONFIG_ADC_EMUL=y
+CONFIG_EMUL=y
+
+# Four clients, so the test can also drive one past the limit. Each connection
+# costs 2 threads.
+# Own port: the iiod sample uses the default 30431 on the same loopback and
+# twister runs scenarios in parallel, so sharing it fails to bind.
+CONFIG_LIBIIO_IIOD_NETWORK_PORT=30441
+
+CONFIG_LIBIIO_IIOD_NETWORK_CLIENT_MAX=4
+CONFIG_LIBIIO_THREAD_POOL_SIZE=10
+
+# Headroom for four connections plus the 3 global tinyiiod mutexes.
+CONFIG_LIBIIO_MUTEX_POOL_SIZE=48
+CONFIG_LIBIIO_COND_POOL_SIZE=32

--- a/zephyr/tests/iiod_concurrent/pytest/conftest.py
+++ b/zephyr/tests/iiod_concurrent/pytest/conftest.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+import socket
+import time
+
+import iio
+import pytest
+from twister_harness import DeviceAdapter
+
+# Must match CONFIG_LIBIIO_IIOD_NETWORK_PORT in prj.conf.
+IIOD_PORT = 30441
+IIOD_URI = f'ip:127.0.0.1:{IIOD_PORT}'
+
+# Must match CONFIG_LIBIIO_IIOD_NETWORK_CLIENT_MAX in prj.conf.
+CLIENT_MAX = 4
+
+
+@pytest.fixture(scope='session')
+def iiod_ready(dut: DeviceAdapter):
+    """Block until the DUT's iiod server accepts connections.
+
+    Poll the port rather than match a log line: startup completes in ~20 ms and
+    the server then blocks in accept(), so a later scan never sees the messages.
+    """
+    deadline = time.monotonic() + 30.0
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(('127.0.0.1', IIOD_PORT), timeout=1.0):
+                pass
+            break
+        except OSError:
+            time.sleep(0.1)
+    else:
+        raise TimeoutError('IIOD network server did not start within 30 seconds')
+
+    yield
+    dut.base_timeout = 2.0
+
+
+@pytest.fixture
+def contexts(iiod_ready):
+    """Open CLIENT_MAX simultaneous contexts and close them afterwards."""
+    opened = []
+    try:
+        for _ in range(CLIENT_MAX):
+            opened.append(iio.Context(IIOD_URI))
+        yield opened
+    finally:
+        for ctx in opened:
+            del ctx
+        opened.clear()
+        # The server frees its client slot before the thread exits and never
+        # joins it, so let it settle before the next test reconnects.
+        time.sleep(0.5)

--- a/zephyr/tests/iiod_concurrent/pytest/test_concurrent.py
+++ b/zephyr/tests/iiod_concurrent/pytest/test_concurrent.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Concurrent iiod client tests.
+
+Client threads in the DUT share one iio_context and the file-scope buffer and
+event-stream lists in iiod/responder.c, whose iio_mutex guards only do
+something under CONFIG_LIBIIO_MULTITHREADING.
+
+pylibiio is a ctypes binding, so the GIL is released per native call and a
+ThreadPoolExecutor genuinely overlaps the requests.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+
+import iio
+import pytest
+
+from conftest import CLIENT_MAX, IIOD_URI
+
+READS_PER_CLIENT = 50
+
+
+def _adc_raw_attr(ctx):
+    """Return a readable 'raw' attribute from the emulated ADC."""
+    for dev in ctx.devices:
+        if 'adc' not in (dev.name or ''):
+            continue
+        for chn in dev.channels:
+            if 'raw' in chn.attrs:
+                return chn.attrs['raw']
+    raise AssertionError('no ADC raw attribute found in context')
+
+
+def _topology(ctx):
+    return sorted(
+        (dev.name, tuple(sorted(c.id for c in dev.channels))) for dev in ctx.devices
+    )
+
+
+def test_concurrent_clients_read_attrs(contexts):
+    """All clients read attributes simultaneously without error."""
+    assert len(contexts) == CLIENT_MAX
+
+    def hammer(ctx):
+        attr = _adc_raw_attr(ctx)
+        values = []
+        for _ in range(READS_PER_CLIENT):
+            values.append(attr.value)
+        return values
+
+    with ThreadPoolExecutor(max_workers=len(contexts)) as pool:
+        results = list(pool.map(hammer, contexts))
+
+    assert len(results) == CLIENT_MAX
+    for i, values in enumerate(results):
+        assert len(values) == READS_PER_CLIENT, f'client {i} short read'
+        assert all(v is not None and v != '' for v in values), f'client {i} got an empty value'
+        # The emulated generator increments per read; all values are integers.
+        for v in values:
+            int(v)
+
+
+def test_concurrent_clients_same_topology(contexts):
+    """Every client enumerates the same devices and channels."""
+    topologies = [_topology(ctx) for ctx in contexts]
+
+    assert topologies[0], 'context enumerated no devices'
+    for i, topo in enumerate(topologies[1:], start=1):
+        assert topo == topologies[0], f'client {i} saw a different topology'
+
+
+def test_client_limit_refused_cleanly(contexts):
+    """One connection past the limit fails without wedging the server.
+
+    The server accepts, finds no free slot and closes, so libiio reports an
+    OSError (in practice EPIPE) rather than hanging.
+    """
+    with pytest.raises(OSError):
+        iio.Context(IIOD_URI)
+
+    # The already-open clients must still work.
+    for i, ctx in enumerate(contexts):
+        assert _adc_raw_attr(ctx).value is not None, f'client {i} broke after the refusal'

--- a/zephyr/tests/iiod_concurrent/src/main.c
+++ b/zephyr/tests/iiod_concurrent/src/main.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/* The network transport's own thread runs the server; the test drives it from the host. */
+int main(void)
+{
+	return 0;
+}

--- a/zephyr/tests/iiod_concurrent/testcase.yaml
+++ b/zephyr/tests/iiod_concurrent/testcase.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+tests:
+  libiio.iiod.concurrent:
+    tags:
+      - libiio
+      - iiod
+    extra_args:
+      - SNIPPET=iiod-network
+    # Needs the host network stack to open several sockets to the DUT.
+    platform_allow:
+      - native_sim
+    integration_platforms:
+      - native_sim
+    harness: pytest
+    timeout: 180
+    harness_config:
+      pytest_dut_scope: session

--- a/zephyr/tests/lock/CMakeLists.txt
+++ b/zephyr/tests/lock/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(libiio_lock)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/zephyr/tests/lock/prj.conf
+++ b/zephyr/tests/lock/prj.conf
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+CONFIG_ZTEST=y
+CONFIG_ASSERT=y
+
+CONFIG_POSIX_API=y
+# libiio needs GNU-style static constructors, or the ARM link fails.
+CONFIG_STATIC_INIT_GNU=y
+CONFIG_LIBIIO=y
+CONFIG_LIBIIO_MULTITHREADING=y
+
+# Small pools keep the exhaustion tests cheap.
+CONFIG_LIBIIO_THREAD_POOL_SIZE=4
+CONFIG_LIBIIO_MUTEX_POOL_SIZE=6
+CONFIG_LIBIIO_COND_POOL_SIZE=4

--- a/zephyr/tests/lock/src/lock.c
+++ b/zephyr/tests/lock/src/lock.c
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Tests for the Zephyr implementation of the libiio lock and thread API.
+ */
+
+#include <iio/iio.h>
+#include <iio/iio-lock.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#include <errno.h>
+
+#ifndef CONFIG_LIBIIO_MULTITHREADING
+#error "This suite tests the threaded lock backend; enable CONFIG_LIBIIO_MULTITHREADING"
+#endif
+
+#define ITERATIONS 2000
+
+struct counter_ctx {
+	struct iio_mutex *lock;
+	volatile unsigned int count;
+};
+
+static int counter_thread(void *d)
+{
+	struct counter_ctx *ctx = d;
+	unsigned int i;
+
+	for (i = 0; i < ITERATIONS; i++) {
+		iio_mutex_lock(ctx->lock);
+		ctx->count = ctx->count + 1;
+		iio_mutex_unlock(ctx->lock);
+	}
+
+	return 0;
+}
+
+ZTEST(libiio_lock, test_mutex_excludes)
+{
+	struct counter_ctx ctx = { .count = 0 };
+	struct iio_thrd *a, *b;
+
+	ctx.lock = iio_mutex_create();
+	zassert_ok(iio_err(ctx.lock), "iio_mutex_create() failed");
+
+	a = iio_thrd_create(counter_thread, &ctx, "counter-a");
+	zassert_ok(iio_err(a), "iio_thrd_create() failed");
+	b = iio_thrd_create(counter_thread, &ctx, "counter-b");
+	zassert_ok(iio_err(b), "iio_thrd_create() failed");
+
+	zassert_ok(iio_thrd_join_and_destroy(a));
+	zassert_ok(iio_thrd_join_and_destroy(b));
+
+	/* The no-op backend loses updates here. */
+	zassert_equal(ctx.count, 2 * ITERATIONS, "lost updates: %u != %u", ctx.count,
+		      2 * ITERATIONS);
+
+	iio_mutex_destroy(ctx.lock);
+}
+
+ZTEST(libiio_lock, test_mutex_pool_exhaustion_and_reuse)
+{
+	struct iio_mutex *held[CONFIG_LIBIIO_MUTEX_POOL_SIZE];
+	struct iio_mutex *extra;
+	unsigned int n = 0, i;
+
+	/* Count rather than assume the pool starts empty. */
+	while (n < ARRAY_SIZE(held)) {
+		struct iio_mutex *m = iio_mutex_create();
+
+		if (iio_err(m))
+			break;
+		held[n++] = m;
+	}
+
+	zassert_true(n > 0, "could not allocate a single mutex");
+
+	extra = iio_mutex_create();
+	zassert_equal(iio_err(extra), -ENOMEM, "expected -ENOMEM once exhausted, got %d",
+		      iio_err(extra));
+
+	for (i = 0; i < n; i++)
+		iio_mutex_destroy(held[i]);
+
+	/* Slots must be reusable, not leaked. */
+	extra = iio_mutex_create();
+	zassert_ok(iio_err(extra), "slot was not released back to the pool");
+	iio_mutex_destroy(extra);
+}
+
+struct cond_ctx {
+	struct iio_mutex *lock;
+	struct iio_cond *cond;
+};
+
+static int signal_thread(void *d)
+{
+	struct cond_ctx *ctx = d;
+
+	/* The waiter holds the mutex until it waits, so this cannot be lost. */
+	iio_mutex_lock(ctx->lock);
+	iio_cond_signal(ctx->cond);
+	iio_mutex_unlock(ctx->lock);
+
+	return 0;
+}
+
+ZTEST(libiio_lock, test_cond_timeout_zero_does_not_block)
+{
+	struct cond_ctx ctx;
+	int64_t start;
+	int ret;
+
+	ctx.lock = iio_mutex_create();
+	zassert_ok(iio_err(ctx.lock));
+	ctx.cond = iio_cond_create();
+	zassert_ok(iio_err(ctx.cond));
+
+	iio_mutex_lock(ctx.lock);
+	start = k_uptime_get();
+	ret = iio_cond_wait(ctx.cond, ctx.lock, 0);
+	zassert_equal(ret, -ETIMEDOUT, "expected -ETIMEDOUT, got %d", ret);
+	zassert_true(k_uptime_get() - start < 10, "a zero timeout must not block");
+	iio_mutex_unlock(ctx.lock);
+
+	iio_cond_destroy(ctx.cond);
+	iio_mutex_destroy(ctx.lock);
+}
+
+ZTEST(libiio_lock, test_cond_timeout_expires)
+{
+	struct cond_ctx ctx;
+	int64_t elapsed;
+	int ret;
+
+	ctx.lock = iio_mutex_create();
+	zassert_ok(iio_err(ctx.lock));
+	ctx.cond = iio_cond_create();
+	zassert_ok(iio_err(ctx.cond));
+
+	iio_mutex_lock(ctx.lock);
+	elapsed = k_uptime_get();
+	ret = iio_cond_wait(ctx.cond, ctx.lock, 100);
+	elapsed = k_uptime_get() - elapsed;
+	iio_mutex_unlock(ctx.lock);
+
+	zassert_equal(ret, -ETIMEDOUT, "expected -ETIMEDOUT, got %d", ret);
+	/* The no-op backend returns -ETIMEDOUT without waiting. */
+	zassert_true(elapsed >= 100, "returned after only %lld ms", elapsed);
+
+	iio_cond_destroy(ctx.cond);
+	iio_mutex_destroy(ctx.lock);
+}
+
+ZTEST(libiio_lock, test_cond_signal_wakes_waiter)
+{
+	struct cond_ctx ctx;
+	struct iio_thrd *thrd;
+	int ret;
+
+	ctx.lock = iio_mutex_create();
+	zassert_ok(iio_err(ctx.lock));
+	ctx.cond = iio_cond_create();
+	zassert_ok(iio_err(ctx.cond));
+
+	iio_mutex_lock(ctx.lock);
+
+	thrd = iio_thrd_create(signal_thread, &ctx, "signaller");
+	zassert_ok(iio_err(thrd));
+
+	ret = iio_cond_wait(ctx.cond, ctx.lock, 5000);
+	iio_mutex_unlock(ctx.lock);
+
+	zassert_ok(ret, "wait was not woken by the signal, got %d", ret);
+	zassert_ok(iio_thrd_join_and_destroy(thrd));
+
+	iio_cond_destroy(ctx.cond);
+	iio_mutex_destroy(ctx.lock);
+}
+
+ZTEST(libiio_lock, test_cond_pool_exhaustion_and_reuse)
+{
+	struct iio_cond *held[CONFIG_LIBIIO_COND_POOL_SIZE];
+	struct iio_cond *extra;
+	unsigned int n = 0, i;
+
+	while (n < ARRAY_SIZE(held)) {
+		struct iio_cond *c = iio_cond_create();
+
+		if (iio_err(c))
+			break;
+		held[n++] = c;
+	}
+
+	zassert_true(n > 0, "could not allocate a single condvar");
+
+	extra = iio_cond_create();
+	zassert_equal(iio_err(extra), -ENOMEM, "expected -ENOMEM once exhausted, got %d",
+		      iio_err(extra));
+
+	for (i = 0; i < n; i++)
+		iio_cond_destroy(held[i]);
+
+	extra = iio_cond_create();
+	zassert_ok(iio_err(extra), "slot was not released back to the pool");
+	iio_cond_destroy(extra);
+}
+
+static int return_value_thread(void *d)
+{
+	return (int)(intptr_t)d;
+}
+
+ZTEST(libiio_lock, test_thrd_returns_value)
+{
+	struct iio_thrd *thrd;
+
+	thrd = iio_thrd_create(return_value_thread, (void *)(intptr_t)42, "answer");
+	zassert_ok(iio_err(thrd));
+	zassert_equal(iio_thrd_join_and_destroy(thrd), 42);
+}
+
+static K_SEM_DEFINE(park_sem, 0, K_SEM_MAX_LIMIT);
+
+static int parked_thread(void *d)
+{
+	ARG_UNUSED(d);
+
+	k_sem_take(&park_sem, K_FOREVER);
+
+	return 0;
+}
+
+ZTEST(libiio_lock, test_thrd_pool_exhaustion_and_reuse)
+{
+	struct iio_thrd *held[CONFIG_LIBIIO_THREAD_POOL_SIZE];
+	struct iio_thrd *extra;
+	unsigned int n = 0, i;
+
+	k_sem_reset(&park_sem);
+
+	while (n < ARRAY_SIZE(held)) {
+		struct iio_thrd *t = iio_thrd_create(parked_thread, NULL, "parked");
+
+		if (iio_err(t))
+			break;
+		held[n++] = t;
+	}
+
+	zassert_true(n > 0, "could not create a single thread");
+
+	extra = iio_thrd_create(parked_thread, NULL, "overflow");
+	zassert_equal(iio_err(extra), -ENOMEM, "expected -ENOMEM once exhausted, got %d",
+		      iio_err(extra));
+
+	/* Release the parked threads, then reclaim the slots. */
+	for (i = 0; i < n; i++)
+		k_sem_give(&park_sem);
+
+	for (i = 0; i < n; i++)
+		zassert_ok(iio_thrd_join_and_destroy(held[i]));
+
+	extra = iio_thrd_create(return_value_thread, (void *)(intptr_t)7, "reused");
+	zassert_ok(iio_err(extra), "slot was not released back to the pool");
+	zassert_equal(iio_thrd_join_and_destroy(extra), 7);
+}
+
+ZTEST_SUITE(libiio_lock, NULL, NULL, NULL, NULL, NULL);

--- a/zephyr/tests/lock/src/task.c
+++ b/zephyr/tests/lock/src/task.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Tests for the iio_task layer. Under NO_THREADS the task body runs inline on
+ * the enqueuing thread and iio_task_start() drains the queue synchronously.
+ */
+
+#include <iio/iio.h>
+#include <iio/iio-lock.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#include <errno.h>
+
+#define BLOCK_MS 200
+
+struct task_ctx {
+	k_tid_t ran_on;
+	struct k_sem started;
+	struct k_sem release;
+};
+
+static int record_thread_fn(void *first, void *elm)
+{
+	struct task_ctx *ctx = first;
+
+	ARG_UNUSED(elm);
+	ctx->ran_on = k_current_get();
+
+	return 1234;
+}
+
+ZTEST(libiio_task, test_task_runs_on_worker_thread)
+{
+	struct task_ctx ctx = { .ran_on = NULL };
+	struct iio_task_token *token;
+	struct iio_task *task;
+
+	task = iio_task_create(record_thread_fn, &ctx, "record-task");
+	zassert_ok(iio_err(task), "iio_task_create() failed");
+
+	iio_task_start(task);
+
+	token = iio_task_enqueue(task, NULL);
+	zassert_ok(iio_err(token), "iio_task_enqueue() failed");
+
+	zassert_equal(iio_task_sync(token, -1), 1234, "task return value not propagated");
+
+	/* Must not have run inline on this thread, as NO_THREADS would. */
+	zassert_not_null(ctx.ran_on, "task body never ran");
+	zassert_not_equal(ctx.ran_on, k_current_get(),
+			  "task body ran inline on the enqueuing thread");
+
+	zassert_ok(iio_task_destroy(task));
+}
+
+static int blocking_fn(void *first, void *elm)
+{
+	struct task_ctx *ctx = first;
+
+	ARG_UNUSED(elm);
+	k_sem_give(&ctx->started);
+	k_sem_take(&ctx->release, K_FOREVER);
+
+	return 99;
+}
+
+static int delayed_release_thread(void *d)
+{
+	struct task_ctx *ctx = d;
+
+	k_msleep(BLOCK_MS);
+	k_sem_give(&ctx->release);
+
+	return 0;
+}
+
+ZTEST(libiio_task, test_task_sync_timeout_cancels_pending)
+{
+	struct task_ctx ctx = { .ran_on = NULL };
+	struct iio_task_token *token;
+	struct iio_task *task;
+	int64_t elapsed;
+	int ret;
+
+	task = iio_task_create(record_thread_fn, &ctx, "pending-task");
+	zassert_ok(iio_err(task));
+
+	/* Leave the task stopped so the token stays queued and can be cancelled. */
+	token = iio_task_enqueue(task, NULL);
+	zassert_ok(iio_err(token));
+
+	elapsed = k_uptime_get();
+	ret = iio_task_sync(token, 100);
+	elapsed = k_uptime_get() - elapsed;
+
+	zassert_equal(ret, -ETIMEDOUT, "expected -ETIMEDOUT, got %d", ret);
+	zassert_true(elapsed >= 100, "returned after only %lld ms", elapsed);
+	zassert_is_null(ctx.ran_on, "task body ran even though it was cancelled");
+
+	zassert_ok(iio_task_destroy(task));
+}
+
+ZTEST(libiio_task, test_task_sync_waits_for_inflight_body)
+{
+	struct task_ctx ctx;
+	struct iio_task_token *token;
+	struct iio_task *task;
+	struct iio_thrd *releaser;
+	int64_t elapsed;
+	int ret;
+
+	k_sem_init(&ctx.started, 0, 1);
+	k_sem_init(&ctx.release, 0, 1);
+
+	task = iio_task_create(blocking_fn, &ctx, "blocking-task");
+	zassert_ok(iio_err(task));
+	iio_task_start(task);
+
+	token = iio_task_enqueue(task, NULL);
+	zassert_ok(iio_err(token));
+
+	/* Make sure the body is genuinely in flight before syncing. */
+	zassert_ok(k_sem_take(&ctx.started, K_MSEC(1000)), "task body never started");
+
+	releaser = iio_thrd_create(delayed_release_thread, &ctx, "releaser");
+	zassert_ok(iio_err(releaser));
+
+	/*
+	 * task.c drops the cancel once a token leaves the queue, so sync loops
+	 * until the body completes. A short timeout is not an escape hatch.
+	 */
+	elapsed = k_uptime_get();
+	ret = iio_task_sync(token, 10);
+	elapsed = k_uptime_get() - elapsed;
+
+	zassert_equal(ret, 99, "expected the body's return value, got %d", ret);
+	zassert_true(elapsed >= BLOCK_MS, "sync did not wait for the body (%lld ms)", elapsed);
+
+	zassert_ok(iio_thrd_join_and_destroy(releaser));
+	zassert_ok(iio_task_destroy(task));
+}
+
+static atomic_t autoclear_ran;
+
+static int autoclear_fn(void *first, void *elm)
+{
+	ARG_UNUSED(first);
+	ARG_UNUSED(elm);
+	atomic_set(&autoclear_ran, 1);
+
+	return 0;
+}
+
+ZTEST(libiio_task, test_task_enqueue_autoclear)
+{
+	struct iio_task *task;
+	unsigned int i;
+
+	atomic_set(&autoclear_ran, 0);
+
+	task = iio_task_create(autoclear_fn, NULL, "autoclear-task");
+	zassert_ok(iio_err(task));
+	iio_task_start(task);
+
+	zassert_ok(iio_task_enqueue_autoclear(task, NULL));
+
+	for (i = 0; i < 100 && !atomic_get(&autoclear_ran); i++)
+		k_msleep(10);
+
+	zassert_true(atomic_get(&autoclear_ran), "autoclear task body never ran");
+	zassert_ok(iio_task_destroy(task));
+}
+
+ZTEST(libiio_task, test_task_stop_waits_for_inflight_body)
+{
+	struct task_ctx ctx;
+	struct iio_task_token *token;
+	struct iio_task *task;
+	struct iio_thrd *releaser;
+	int64_t elapsed;
+
+	k_sem_init(&ctx.started, 0, 1);
+	k_sem_init(&ctx.release, 0, 1);
+
+	task = iio_task_create(blocking_fn, &ctx, "stop-task");
+	zassert_ok(iio_err(task));
+	iio_task_start(task);
+
+	token = iio_task_enqueue(task, NULL);
+	zassert_ok(iio_err(token));
+	zassert_ok(k_sem_take(&ctx.started, K_MSEC(1000)), "task body never started");
+
+	/*
+	 * Nothing but iio_task_stop() may block inside the measured window, so
+	 * the body is released from another thread and the clock starts before
+	 * that thread exists. Sleeping here instead would satisfy the assertion
+	 * on its own, whatever stop() did.
+	 */
+	elapsed = k_uptime_get();
+	releaser = iio_thrd_create(delayed_release_thread, &ctx, "releaser");
+	zassert_ok(iio_err(releaser));
+
+	/* stop() waits for the worker's idle handshake, so it cannot return early. */
+	iio_task_stop(task);
+	elapsed = k_uptime_get() - elapsed;
+
+	zassert_true(elapsed >= BLOCK_MS, "iio_task_stop() returned too early (%lld ms)", elapsed);
+
+	/* The body ran to completion, so sync just reaps the token's pool slots. */
+	zassert_equal(iio_task_sync(token, -1), 99, "task return value not propagated");
+
+	zassert_ok(iio_thrd_join_and_destroy(releaser));
+	zassert_ok(iio_task_destroy(task));
+}
+
+ZTEST_SUITE(libiio_task, NULL, NULL, NULL, NULL, NULL);

--- a/zephyr/tests/lock/testcase.yaml
+++ b/zephyr/tests/lock/testcase.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 Analog Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+tests:
+  libiio.lock:
+    tags:
+      - libiio
+      - lock
+    platform_allow:
+      - native_sim
+      - apard32690/max32690/m4
+    integration_platforms:
+      - native_sim


### PR DESCRIPTION
## PR Description

Zephyr builds compiled `lock-dummy.c`, so every `iio_mutex_lock()` was an empty function, `iio_cond_wait()` returned `-ETIMEDOUT` immediately and `iio_thrd_create()` returned `-ENOSYS`. The network and USB transports already run one iiod interpreter per client over a shared context, mutating the file-scope buffer and event-stream lists in `iiod/responder.c` with their locks compiled out.

Add a `k_mutex`/`k_condvar`/`k_thread` backend behind a new `CONFIG_LIBIIO_MULTITHREADING`, default `n` so existing builds are unchanged. The option switches the lock backend and `NO_THREADS` together: the `NO_THREADS` paths in `task.c` run task bodies inline and release a mutex they do not hold, which is only harmless while the mutexes are no-ops.

Nothing here allocates. Mutex, condvar and thread objects come from static pools with sys_bitarray slot tracking, following the idiom Zephyr's POSIX layer uses for `pthread_mutex_t` and `pthread_cond_t`: `k_mutex_init()` and `k_condvar_init()` run on allocation rather than once at boot, so a slot released while its k_mutex is still held cannot hand the next caller a mutex that still records the old owner. Exhaustion returns `-ENOMEM` and logs which pool ran out. The pool sizes are Kconfig, defaulting higher for the network server, which serves several clients at once.

The 4096 stack default comes from measurement: static analysis puts the deepest path near 1.8 KB on Cortex-M4, and peaks on apard32690 serving an attribute read are 616 bytes for the reader thread and 320 for the writer. The headroom is for the buffer paths still to land.

### Testing

Tested with the network transport on native_sim and the USB transport on apard32690.

Below is a SystemView trace of an `iio_info` transaction (partial) over the USB transport on apard32690. Note the `reader-thd` (purple) and `writer-task` (blue), and `iiod_usb_0` (green) threads.
<img width="1655" height="1141" alt="image" src="https://github.com/user-attachments/assets/b8432532-9d5b-40ba-bd3c-2ace79cdd159" />


## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [x] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
