### PR TITLE
ci: fix Cloudsmith upload naming for stable republishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,17 @@ jobs:
             fi
             for file in "${dir}"*; do
               [[ -f "${file}" ]] || continue
+              filename=$(basename "${file}")
+              # Strip git hash (.g<hex>) so the name is stable across commits
+              stable=$(echo "${filename}" | sed 's/\.g[0-9a-f]\+//')
+              ext="${stable##*.}"
+              stable="${stable%.${ext}}"
+              # macOS .pkg files don't include arch in the name; add tag
+              if [[ "${filename}" != *"${tag}"* ]]; then
+                stable="${stable}-${tag}"
+              fi
               cloudsmith push raw --republish \
+                --name "${stable}.${ext}" \
                 --tags "${tag}" \
                 --version "${VERSION}" \
                 adi/external "${file}"


### PR DESCRIPTION
 ## Summary
  - Use `--name` to assign each uploaded package a stable, unique name by stripping the git commit hash (`.g<hex>`) that changes on every build. This allows `--republish` to correctly match and overwrite packages from previous builds of the same version, instead of accumulating duplicates.
  - Append the artifact tag to macOS `.pkg` names that don't include the architecture. This was causing arm64/x64 uploads to overwrite each other since they had identical filenames.

  ## Test plan
  - [x] Pushed to staging branch with Cloudsmith upload enabled (`libiio-v0~test`) - https://cloudsmith.io/~adi/repos/external/packages/?q=version%3Alibiio-v0~test&sort=date&page=1 
  - [x] Verified all packages have correct names (no double extensions, no hash)
  - [x] Verified macOS `.pkg` packages appear with distinct names per arch
  - [ ] On next `libiio-v0` push, verify old packages are overwritten (not duplicated)