### PR TITLE
ci: fix format.sh auto-running on source in FormatCheck

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -61,4 +61,6 @@ format_all() {
     done
 }
 
-format_all
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    format_all
+fi


### PR DESCRIPTION
The Azure `FormatCheck` job sources `format.sh` to reuse its helper functions, but `format_all()` was being called unconditionally at the bottom of the script. 
Sourcing therefore auto-formatted every file in the PR checkout in place before the dry-run check ran, so real formatting issues never made the check fail.

### Changes
- Guard the `format_all` call in `format.sh` to only run when the
  script is executed directly, not when sourced

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
