### PR TITLE
Zephyr Thread Improvements

### DIFF
--- a/block.c
+++ b/block.c
@@ -143,6 +143,8 @@ int iio_block_enqueue(struct iio_block *block, size_t bytes_used, bool cyclic)
 	struct iio_buffer_stream *buf_stream = block->buf_stream;
 	const struct iio_device *dev = buf_stream->buf->dev;
 	const struct iio_backend_ops *ops = dev->ctx->ops;
+	struct iio_task_token *token;
+	int err;
 
 	if (bytes_used > block->size)
 		return -EINVAL;
@@ -160,9 +162,15 @@ int iio_block_enqueue(struct iio_block *block, size_t bytes_used, bool cyclic)
 
 	block->bytes_used = bytes_used;
 	buf_stream->cyclic = cyclic;
-	block->token = iio_task_enqueue(buf_stream->worker, block);
 
-	return iio_err(block->token);
+	token = iio_task_enqueue(buf_stream->worker, block);
+	err = iio_err(token);
+	if (err)
+		return err;
+
+	block->token = token;
+
+	return 0;
 }
 
 int iio_block_dequeue(struct iio_block *block, bool nonblock)

--- a/iiod-responder.c
+++ b/iiod-responder.c
@@ -712,9 +712,8 @@ void iiod_responder_destroy(struct iiod_responder *priv)
 
 void iiod_responder_wait_done(struct iiod_responder *priv)
 {
-	if (!NO_THREADS) {
-		if (priv->read_thrd)
-			iio_thrd_join_and_destroy(priv->read_thrd);
+	if (priv->read_thrd) {
+		iio_thrd_join_and_destroy(priv->read_thrd);
 		priv->read_thrd = NULL;
 	} else if (!priv->thrd_stop) {
 		iiod_responder_reader_worker(priv);

--- a/iiod-responder.c
+++ b/iiod-responder.c
@@ -365,6 +365,8 @@ static int iiod_enqueue_command(struct iiod_io *writer, uint8_t op, uint8_t dev,
 		const struct iiod_buf *buf, size_t nb)
 {
 	struct iiod_responder *priv = writer->responder;
+	struct iio_task_token *token;
+	int err;
 
 	if (nb > NB_BUFS_MAX)
 		return -EINVAL;
@@ -389,10 +391,13 @@ static int iiod_enqueue_command(struct iiod_io *writer, uint8_t op, uint8_t dev,
 		return priv->thrd_err_code;
 	}
 
-	writer->write_token = iio_task_enqueue(priv->write_task, writer);
+	token = iio_task_enqueue(priv->write_task, writer);
+	err = iio_err(token);
+	if (!err)
+		writer->write_token = token;
 	iio_mutex_unlock(priv->lock);
 
-	return iio_err(writer->write_token);
+	return err;
 }
 
 bool iiod_io_command_is_done(struct iiod_io *io)

--- a/iiod-responder.c
+++ b/iiod-responder.c
@@ -643,7 +643,8 @@ void iiod_io_set_timeout(struct iiod_io *io, int timeout_ms)
 	io->timeout_ms = timeout_ms;
 }
 
-struct iiod_responder *iiod_responder_create(const struct iiod_responder_ops *ops, void *d)
+static struct iiod_responder *iiod_responder_do_create(
+		const struct iiod_responder_ops *ops, void *d, bool sync_reader)
 {
 	struct iiod_responder *priv;
 	int err;
@@ -671,7 +672,7 @@ struct iiod_responder *iiod_responder_create(const struct iiod_responder_ops *op
 	if (err)
 		goto err_free_io;
 
-	if (!NO_THREADS) {
+	if (!NO_THREADS && !sync_reader) {
 		priv->read_thrd = iio_thrd_create(iiod_responder_reader_thrd, priv, "reader-thd");
 		err = iio_err(priv->read_thrd);
 		if (err)
@@ -691,6 +692,16 @@ err_free_lock:
 err_free_priv:
 	free(priv);
 	return iio_ptr(err);
+}
+
+struct iiod_responder *iiod_responder_create(const struct iiod_responder_ops *ops, void *d)
+{
+	return iiod_responder_do_create(ops, d, false);
+}
+
+struct iiod_responder *iiod_responder_create_sync(const struct iiod_responder_ops *ops, void *d)
+{
+	return iiod_responder_do_create(ops, d, true);
 }
 
 void iiod_responder_stop(struct iiod_responder *priv)

--- a/iiod-responder.h
+++ b/iiod-responder.h
@@ -90,6 +90,11 @@ struct iiod_responder_ops {
 
 /* Create / Destroy IIOD Responder. */
 struct iiod_responder *iiod_responder_create(const struct iiod_responder_ops *ops, void *d);
+
+/* Create an IIOD Responder whose read loop runs on the thread that calls
+ * iiod_responder_wait_done(), instead of on a reader thread of its own. */
+struct iiod_responder *iiod_responder_create_sync(const struct iiod_responder_ops *ops, void *d);
+
 void iiod_responder_destroy(struct iiod_responder *responder);
 
 /* Set the timeout for I/O operations (default is -1 == infinite) */

--- a/iiod/responder.c
+++ b/iiod/responder.c
@@ -1352,7 +1352,7 @@ int binary_parse(struct parser_pdata *pdata)
 	struct iiod_responder *responder;
 	int ret;
 
-	responder = iiod_responder_create(&iiod_responder_ops, pdata);
+	responder = iiod_responder_create_sync(&iiod_responder_ops, pdata);
 	ret = iio_err(responder);
 	if (ret)
 		return ret;

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -40,21 +40,21 @@ if LIBIIO_MULTITHREADING
 
 config LIBIIO_THREAD_POOL_SIZE
 	int "Maximum number of libiio internal threads"
-	default 12 if LIBIIO_IIOD_NETWORK
-	default 6
+	default 6 if LIBIIO_IIOD_NETWORK
+	default 3
 	help
 	  Slots in the static libiio thread pool. Each costs
 	  LIBIIO_THREAD_STACK_SIZE bytes whether used or not.
 
-	  Demand is 2 per connection (responder reader and writer), plus 2 per
-	  iiod buffer and 1 per buffer or event stream.
+	  Demand is 1 per concurrent interpreter - the responder's writer task,
+	  since its read loop runs on the transport's own thread - plus 2 per
+	  iiod buffer, plus 1 per buffer stream and per event stream.
 
 config LIBIIO_THREAD_STACK_SIZE
 	int "Stack size for libiio internal threads"
 	default 4096
 	help
-	  Stack size for each pool slot. The deepest user is the responder
-	  reader thread running the iiod command dispatch.
+	  Stack size for each pool slot.
 
 config LIBIIO_THREAD_PRIORITY
 	int "Priority for libiio internal threads"

--- a/zephyr/iiod/Kconfig
+++ b/zephyr/iiod/Kconfig
@@ -35,7 +35,7 @@ config LIBIIO_IIOD_NETWORK_CLIENT_THREAD_PRIORITY
 
 config LIBIIO_IIOD_NETWORK_CLIENT_THREAD_STACK_SIZE
 	int "Client thread stack size"
-	default 8192
+	default 4096
 	help
 	  Stack size of the thread running the network client.
 

--- a/zephyr/tests/iiod_concurrent/prj.conf
+++ b/zephyr/tests/iiod_concurrent/prj.conf
@@ -10,14 +10,23 @@ CONFIG_ADC=y
 CONFIG_ADC_EMUL=y
 CONFIG_EMUL=y
 
-# Four clients, so the test can also drive one past the limit. Each connection
-# costs 2 threads.
+# Four clients, so the test can also drive one past the limit.
 # Own port: the iiod sample uses the default 30431 on the same loopback and
 # twister runs scenarios in parallel, so sharing it fails to bind.
 CONFIG_LIBIIO_IIOD_NETWORK_PORT=30441
 
 CONFIG_LIBIIO_IIOD_NETWORK_CLIENT_MAX=4
-CONFIG_LIBIIO_THREAD_POOL_SIZE=10
+
+# Exactly one pool thread per connection, with no headroom, so the pool size is
+# an assertion about the thread count and not just a limit: a responder that
+# went back to spawning its own reader would exhaust the pool and the third
+# client would fail to connect.
+CONFIG_LIBIIO_THREAD_POOL_SIZE=4
+
+# Errors only, so that when the assertion above does trip, the DUT log says
+# which pool ran out instead of leaving the client with a bare broken pipe.
+CONFIG_LOG=y
+CONFIG_LIBIIO_LOG_LEVEL_ERR=y
 
 # Headroom for four connections plus the 3 global tinyiiod mutexes.
 CONFIG_LIBIIO_MUTEX_POOL_SIZE=48

--- a/zephyr/tests/lock/src/responder.c
+++ b/zephyr/tests/lock/src/responder.c
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026 Analog Devices, Inc.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Tests for how the iiod responder reports a pool-exhaustion failure. Zephyr is
+ * the only platform where this is reachable: iio_cond_create() draws from a
+ * fixed pool here, where the pthread backend allocates.
+ */
+
+#include <iio/iio.h>
+#include <iio/iio-lock.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/ztest.h>
+
+#include <errno.h>
+
+#include "iiod-responder.h"
+
+/* Parks the responder's reader thread so the responder stays live for the test:
+ * a read that returns <= 0 sets thrd_stop, and iiod_enqueue_command() would then
+ * refuse before it ever reaches the enqueue this test is about.
+ */
+static K_SEM_DEFINE(reader_parked, 0, 1);
+
+static ssize_t loopback_read(void *d, const struct iiod_buf *buf, size_t nb)
+{
+	ARG_UNUSED(d);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(nb);
+
+	k_sem_take(&reader_parked, K_FOREVER);
+
+	return 0;
+}
+
+static ssize_t loopback_write(void *d, const struct iiod_buf *buf, size_t nb)
+{
+	size_t i, total = 0;
+
+	ARG_UNUSED(d);
+
+	for (i = 0; i < nb; i++)
+		total += buf[i].size;
+
+	return (ssize_t)total;
+}
+
+static ssize_t loopback_discard(void *d, size_t bytes)
+{
+	ARG_UNUSED(d);
+
+	return (ssize_t)bytes;
+}
+
+static int loopback_cmd(const struct iiod_command *cmd, struct iiod_command_data *data, void *d)
+{
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(data);
+	ARG_UNUSED(d);
+
+	return -EINVAL;
+}
+
+static const struct iiod_responder_ops loopback_ops = {
+	.cmd = loopback_cmd,
+	.read = loopback_read,
+	.write = loopback_write,
+	.discard = loopback_discard,
+};
+
+/* Take every remaining iio_cond slot, so the next iio_cond_create() fails. */
+static unsigned int drain_cond_pool(struct iio_cond **held, unsigned int max)
+{
+	unsigned int n = 0;
+
+	while (n < max) {
+		struct iio_cond *cond = iio_cond_create();
+
+		if (iio_err(cond))
+			break;
+
+		held[n++] = cond;
+	}
+
+	return n;
+}
+
+static void release_cond_pool(struct iio_cond **held, unsigned int n)
+{
+	while (n--)
+		iio_cond_destroy(held[n]);
+}
+
+/*
+ * A response whose write token cannot be created must be refused, not
+ * remembered. iio_task_enqueue() reports the failure as an error pointer, and
+ * every later reader of iiod_io::write_token tests it for NULL before
+ * dereferencing it - so storing the error pointer turns a refused command into
+ * a fault on the next round trip, and leaves the io permanently -EIO because the
+ * "already enqueued" guard sees a non-NULL token.
+ */
+ZTEST(libiio_responder, test_enqueue_failure_is_reported_not_stored)
+{
+	struct iio_cond *held[CONFIG_LIBIIO_COND_POOL_SIZE];
+	struct iiod_responder *responder;
+	struct iiod_io *io;
+	unsigned int n;
+	int ret;
+
+	k_sem_reset(&reader_parked);
+
+	responder = iiod_responder_create(&loopback_ops, NULL);
+	zassert_ok(iio_err(responder), "iiod_responder_create() failed (%d)",
+		   iio_err(responder));
+
+	io = iiod_responder_get_default_io(responder);
+	zassert_not_null(io, "responder has no default io");
+
+	n = drain_cond_pool(held, ARRAY_SIZE(held));
+	zassert_true(n > 0, "cond pool already exhausted; the send would fail for the wrong reason");
+
+	ret = iiod_io_send_response_async(io, 0, NULL, 0);
+	zassert_equal(ret, -ENOMEM, "expected -ENOMEM with the cond pool drained, got %d", ret);
+
+	/* Nothing was enqueued, so there is nothing to wait for. This faults if
+	 * the error pointer was stored: iio_task_sync() dereferences it.
+	 */
+	zassert_ok(iiod_io_wait_for_command_done(io),
+		   "wait_for_command_done() reported work that was never enqueued");
+
+	/* Same dereference through the cancel path. */
+	iiod_io_cancel(io);
+
+	release_cond_pool(held, n);
+
+	/* The refused send must not have wedged the io. A stored token makes this
+	 * -EIO forever, which no client can distinguish from a transport error.
+	 */
+	ret = iiod_io_send_response_async(io, 0, NULL, 0);
+	zassert_ok(ret, "send after a refused send failed (%d); the io kept a token", ret);
+
+	zassert_ok(iiod_io_wait_for_command_done(io));
+
+	k_sem_give(&reader_parked);
+	iiod_responder_stop(responder);
+	iiod_responder_wait_done(responder);
+	iiod_responder_destroy(responder);
+}
+
+ZTEST_SUITE(libiio_responder, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
## PR Description

This branch fixes a crash in the IIOD responder's command-enqueue error path and then reduces the thread and stack resources the Zephyr IIOD responder needs per connection.

The fix (`treewide: don't store a failed iio_task_enqueue() result` + its regression test) addresses a bug where a failed enqueue left a poisoned pointer in a field that callers treat as a plain liveness check, leading to a stale-pointer dereference and permanent wedging of the connection; this is reachable on Zephyr whenever `CONFIG_LIBIIO_COND_POOL_SIZE` is exhausted and was confirmed causing a bus fault on apard32690 over USB and a segfault on native_sim.

The remaining commits eliminate an unnecessary per-connection reader thread on the server side (the IIOD daemon and Zephyr transports only ever block waiting for the connection to end, so they don't need an async reader), resize the Zephyr thread pool defaults and test expectations to match the new one-thread-per-connection model, and shrink the network client thread's stack to a size measured via GCC call-graph analysis and cross-checked at runtime on hardware.

Net effect on Zephyr: each IIOD connection now costs one thread pool slot instead of two, and the network configuration's RAM footprint on apard32690 drops from 96% to 77% of the target's 128 KB.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
